### PR TITLE
Compatibility with Python 3

### DIFF
--- a/scripts/corr2
+++ b/scripts/corr2
@@ -12,7 +12,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-
+from __future__ import print_function
 import sys
 import treecorr
 
@@ -57,12 +57,12 @@ def parse_args():
 
     if args.config_file == None:
         if args.version:
-            print version_str
+            print(version_str)
         else:
             parser.print_help()
         sys.exit()
     elif args.version:
-        print version_str
+        print(version_str)
 
     return args
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
 import sys
 import os
 import glob
+
 try:
     from setuptools import setup, Extension
     from setuptools.command.build_ext import build_ext
 except ImportError:
-    print 'Unable to import setuptools.  Using distutils instead.'
+    print('Unable to import setuptools.  Using distutils instead.')
     from distutils.core import setup, Extension
     from distutils.command.build_ext import build_ext
 try:
@@ -14,7 +16,7 @@ except:
     from distutils.sysconfig import get_config_vars
 
 py_version = "%d.%d"%sys.version_info[0:2]
-print 'Python version = ',py_version
+print('Python version = ',py_version)
 
 scripts = ['corr2']
 scripts = [ os.path.join('scripts',f) for f in scripts ]
@@ -50,11 +52,11 @@ def get_compiler(cc):
     import subprocess
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     lines = p.stdout.readlines()
-    if 'clang' in lines[0]:
+    if "clang" in lines[0].decode(encoding='UTF-8'):
         # Supposedly, clang will support openmp in version 3.5.  Let's go with that for now...
         # If the version is reports >= 3.5, let's call it gcc, rather than clang to get
         # the -fopenmp flag.
-        line = lines[1]
+        line = lines[1].decode(encoding='UTF-8')
         import re
         match = re.search(r'[0-9]+(\.[0-9]+)+', line)
         if match:
@@ -65,9 +67,9 @@ def get_compiler(cc):
             if vnum >= '3.5':
                 return 'gcc'
         return 'clang'
-    elif 'gcc' in lines[0]:
+    elif 'gcc' in lines[0].decode(encoding='UTF-8'):
         return 'gcc'
-    elif 'GCC' in lines[0]:
+    elif 'GCC' in lines[0].decode(encoding='UTF-8'):
         return 'gcc'
     elif 'clang' in cc:
         return 'clang'
@@ -189,9 +191,9 @@ class my_builder( build_ext ):
         cc = self.compiler.executables['compiler_cxx'][0]
         comp_type = get_compiler(cc)
         if cc == comp_type:
-            print 'Using compiler %s'%(cc)
+            print('Using compiler %s'%(cc))
         else:
-            print 'Using compiler %s, which is %s'%(cc,comp_type)
+            print('Using compiler %s, which is %s'%(cc,comp_type))
         for e in self.extensions:
             e.extra_compile_args = copt[ comp_type ]
             e.extra_link_args = lopt[ comp_type ]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -11,7 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-
+from __future__ import print_function
 import numpy
 import treecorr
 import os
@@ -281,10 +281,10 @@ def test_contiguous():
                                   g1=source_data['g1'].astype(float), 
                                   g2=source_data['g2'].astype(float))
 
-    print "dtypes of original arrays: ", [source_data[key].dtype for key in ['ra','dec','g1','g2']]
-    print "dtypes of cat2 arrays: ", [getattr(cat2,key).dtype for key in ['ra','dec','g1','g2']]
-    print "is original g2 array contiguous?", source_data['g2'].flags['C_CONTIGUOUS']
-    print "is cat2.g2 array contiguous?", cat2.g2.flags['C_CONTIGUOUS']
+    print("dtypes of original arrays: ", [source_data[key].dtype for key in ['ra','dec','g1','g2']])
+    print("dtypes of cat2 arrays: ", [getattr(cat2,key).dtype for key in ['ra','dec','g1','g2']])
+    print("is original g2 array contiguous?", source_data['g2'].flags['C_CONTIGUOUS'])
+    print("is cat2.g2 array contiguous?", cat2.g2.flags['C_CONTIGUOUS'])
     assert not source_data['g2'].flags['C_CONTIGUOUS']
     assert cat2.g2.flags['C_CONTIGUOUS']
 

--- a/tests/test_celestial.py
+++ b/tests/test_celestial.py
@@ -11,7 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-
+from __future__ import print_function
 import numpy
 import treecorr
 
@@ -98,12 +98,12 @@ def test_distance():
 
     # Note that the standard formula gets thsse wrong.  d comes back as 0.
     d = arccos(sin(0.342) * sin(0.342) + cos(0.342) * cos(0.342) * cos(1.7e-9))
-    print 'd(c6) = ',1.7e-9 * cos(0.342), c1.distanceTo(c6), d
+    print('d(c6) = ',1.7e-9 * cos(0.342), c1.distanceTo(c6), d)
     d = arccos(sin(0.342) * sin(0.342+1.9e-9) + cos(0.342) * cos(0.342+1.9e-9) * cos(0.))
-    print 'd(c7) = ',1.9e-9, c1.distanceTo(c7), d
+    print('d(c7) = ',1.9e-9, c1.distanceTo(c7), d)
     d = arccos(sin(0.342) * sin(0.342) + cos(0.342) * cos(0.342) * cos(1.2e-9))
     true_d = sqrt( (2.3e-9 * cos(0.342))**2 + 1.2e-9**2)
-    print 'd(c7) = ',true_d, c1.distanceTo(c8), d
+    print('d(c7) = ',true_d, c1.distanceTo(c8), d)
     numpy.testing.assert_almost_equal(c1.distanceTo(c6)/(1.7e-9 * cos(0.342)), 1.0)
     numpy.testing.assert_almost_equal(c1.distanceTo(c7)/1.9e-9, 1.0)
     numpy.testing.assert_almost_equal(c1.distanceTo(c8)/true_d, 1.0)
@@ -204,7 +204,7 @@ def test_projection():
     # The shoelace formula gives the area of a triangle given coordinates:
     # A = 1/2 abs( (x2-x1)*(y3-y1) - (x3-x1)*(y2-y1) )
     area = 0.5 * abs( (pB[0]-pA[0])*(pC[1]-pA[1]) - (pC[0]-pA[0])*(pB[1]-pA[1]) )
-    print 'lambert area = ',area,E
+    print('lambert area = ',area,E)
     numpy.testing.assert_almost_equal(area / E, 1, decimal=5)
 
     # Check that project_rad does the same thing
@@ -226,14 +226,14 @@ def test_projection():
     cosB = ((pC[0]-pB[0])*(pA[0]-pB[0]) + (pC[1]-pB[1])*(pA[1]-pB[1])) / (c*a)
     cosC = ((pA[0]-pC[0])*(pB[0]-pC[0]) + (pA[1]-pC[1])*(pB[1]-pC[1])) / (a*b)
 
-    print 'lambert cosA = ',cosA,cos(A)
-    print 'lambert cosB = ',cosB,cos(B)
-    print 'lambert cosC = ',cosC,cos(C)
+    print('lambert cosA = ',cosA,cos(A))
+    print('lambert cosB = ',cosB,cos(B))
+    print('lambert cosC = ',cosC,cos(C))
  
     # The deproject jacobian should tell us how the area changes
     dudx, dudy, dvdx, dvdy = center.deproject_jac(*pA, projection='lambert')
     jac_area = abs(dudx*dvdy - dudy*dvdx)
-    print 'lambert jac_area = ',jac_area,E/area
+    print('lambert jac_area = ',jac_area,E/area)
     numpy.testing.assert_almost_equal(jac_area, E/area, decimal=5)
 
 
@@ -254,9 +254,9 @@ def test_projection():
     cosB = ((pC[0]-pB[0])*(pA[0]-pB[0]) + (pC[1]-pB[1])*(pA[1]-pB[1])) / (c*a)
     cosC = ((pA[0]-pC[0])*(pB[0]-pC[0]) + (pA[1]-pC[1])*(pB[1]-pC[1])) / (a*b)
 
-    print 'stereographic cosA = ',cosA,cos(A)
-    print 'stereographic cosB = ',cosB,cos(B)
-    print 'stereographic cosC = ',cosC,cos(C)
+    print('stereographic cosA = ',cosA,cos(A))
+    print('stereographic cosB = ',cosB,cos(B))
+    print('stereographic cosC = ',cosC,cos(C))
     numpy.testing.assert_almost_equal(cosA,cos(A), decimal=5)
     numpy.testing.assert_almost_equal(cosB,cos(B), decimal=5)
     numpy.testing.assert_almost_equal(cosC,cos(C), decimal=5)
@@ -274,12 +274,12 @@ def test_projection():
 
     # The area is not preserved
     area = 0.5 * abs( (pB[0]-pA[0])*(pC[1]-pA[1]) - (pC[0]-pA[0])*(pB[1]-pA[1]) )
-    print 'stereographic area = ',area,E
+    print('stereographic area = ',area,E)
  
     # The deproject jacobian should tell us how the area changes
     dudx, dudy, dvdx, dvdy = center.deproject_jac(*pA, projection='stereographic')
     jac_area = abs(dudx*dvdy - dudy*dvdx)
-    print 'stereographic jac_area = ',jac_area,E/area
+    print('stereographic jac_area = ',jac_area,E/area)
     numpy.testing.assert_almost_equal(jac_area, E/area, decimal=5)
 
 
@@ -311,18 +311,18 @@ def test_projection():
     cosB = ((pC[0]-pB[0])*(pA[0]-pB[0]) + (pC[1]-pB[1])*(pA[1]-pB[1])) / (c*a)
     cosC = ((pA[0]-pC[0])*(pB[0]-pC[0]) + (pA[1]-pC[1])*(pB[1]-pC[1])) / (a*b)
 
-    print 'gnomonic cosA = ',cosA,cos(A)
-    print 'gnomonic cosB = ',cosB,cos(B)
-    print 'gnomonic cosC = ',cosC,cos(C)
+    print('gnomonic cosA = ',cosA,cos(A))
+    print('gnomonic cosB = ',cosB,cos(B))
+    print('gnomonic cosC = ',cosC,cos(C))
  
     # The area is not preserved
     area = 0.5 * abs( (pB[0]-pA[0])*(pC[1]-pA[1]) - (pC[0]-pA[0])*(pB[1]-pA[1]) )
-    print 'gnomonic area = ',area,E
+    print('gnomonic area = ',area,E)
 
     # The deproject jacobian should tell us how the area changes
     dudx, dudy, dvdx, dvdy = center.deproject_jac(*pA, projection='gnomonic')
     jac_area = abs(dudx*dvdy - dudy*dvdx)
-    print 'gnomonic jac_area = ',jac_area,E/area
+    print('gnomonic jac_area = ',jac_area,E/area)
     numpy.testing.assert_almost_equal(jac_area, E/area, decimal=5)
 
 
@@ -337,9 +337,9 @@ def test_projection():
     dA = sqrt( pA[0]**2 + pA[1]**2 )
     dB = sqrt( pB[0]**2 + pB[1]**2 )
     dC = sqrt( pC[0]**2 + pC[1]**2 )
-    print 'postel dA = ',dA,center.distanceTo(cA)
-    print 'postel dB = ',dB,center.distanceTo(cB)
-    print 'postel dC = ',dC,center.distanceTo(cC)
+    print('postel dA = ',dA,center.distanceTo(cA))
+    print('postel dB = ',dB,center.distanceTo(cB))
+    print('postel dC = ',dC,center.distanceTo(cC))
     numpy.testing.assert_almost_equal( dA, center.distanceTo(cA) )
     numpy.testing.assert_almost_equal( dB, center.distanceTo(cB) )
     numpy.testing.assert_almost_equal( dC, center.distanceTo(cC) )
@@ -363,18 +363,18 @@ def test_projection():
     cosB = ((pC[0]-pB[0])*(pA[0]-pB[0]) + (pC[1]-pB[1])*(pA[1]-pB[1])) / (c*a)
     cosC = ((pA[0]-pC[0])*(pB[0]-pC[0]) + (pA[1]-pC[1])*(pB[1]-pC[1])) / (a*b)
 
-    print 'postel cosA = ',cosA,cos(A)
-    print 'postel cosB = ',cosB,cos(B)
-    print 'postel cosC = ',cosC,cos(C)
+    print('postel cosA = ',cosA,cos(A))
+    print('postel cosB = ',cosB,cos(B))
+    print('postel cosC = ',cosC,cos(C))
  
     # The area is not preserved
     area = 0.5 * abs( (pB[0]-pA[0])*(pC[1]-pA[1]) - (pC[0]-pA[0])*(pB[1]-pA[1]) )
-    print 'postel area = ',area,E
+    print('postel area = ',area,E)
 
     # The deproject jacobian should tell us how the area changes
     dudx, dudy, dvdx, dvdy = center.deproject_jac(*pA, projection='postel')
     jac_area = abs(dudx*dvdy - dudy*dvdx)
-    print 'postel jac_area = ',jac_area,E/area
+    print('postel jac_area = ',jac_area,E/area)
     numpy.testing.assert_almost_equal(jac_area, E/area, decimal=5)
 
 
@@ -395,15 +395,15 @@ def test_precess():
     # http://www.bbastrodesigns.com/coordErrors.html
     dra_1950 = -(2. + 39.07/60.)/60. * treecorr.hours
     ddec_1950 = -(16. + 16.3/60.)/60. * treecorr.degrees
-    print 'delta from website: ',dra_1950,ddec_1950
-    print 'delta from precess: ',(c1.ra-orig.ra),(c1.dec-orig.dec)
+    print('delta from website: ',dra_1950,ddec_1950)
+    print('delta from precess: ',(c1.ra-orig.ra),(c1.dec-orig.dec))
     numpy.testing.assert_almost_equal(dra_1950, c1.ra-orig.ra, decimal=5)
     numpy.testing.assert_almost_equal(ddec_1950, c1.dec-orig.dec, decimal=5)
 
     dra_1900 = -(5. + 17.74/60.)/60. * treecorr.hours
     ddec_1900 = -(32. + 35.4/60.)/60. * treecorr.degrees
-    print 'delta from website: ',dra_1900,ddec_1900
-    print 'delta from precess: ',(c2.ra-orig.ra),(c2.dec-orig.dec)
+    print('delta from website: ',dra_1900,ddec_1900)
+    print('delta from precess: ',(c2.ra-orig.ra),(c2.dec-orig.dec))
     numpy.testing.assert_almost_equal(dra_1900, c2.ra-orig.ra, decimal=5)
     numpy.testing.assert_almost_equal(ddec_1900, c2.dec-orig.dec, decimal=5)
 
@@ -412,7 +412,7 @@ def test_galactic():
     # the galactic center is located at 17h:45.6m, -28.94d
     center = treecorr.CelestialCoord( (17.+45.6/60.) * treecorr.hours,
                                       -28.94 * treecorr.degrees )
-    print 'center.galactic = ',center.galactic()
+    print('center.galactic = ',center.galactic())
     el,b = center.galactic()
     numpy.testing.assert_almost_equal(el, 0., decimal=3)
     numpy.testing.assert_almost_equal(b, 0., decimal=3)
@@ -420,21 +420,21 @@ def test_galactic():
     # The north pole is at 12h:51.4m, 27.13d
     north = treecorr.CelestialCoord( (12.+51.4/60.) * treecorr.hours,
                                      27.13 * treecorr.degrees )
-    print 'north.galactic = ',north.galactic()
+    print('north.galactic = ',north.galactic())
     el,b = north.galactic()
     numpy.testing.assert_almost_equal(b, pi/2., decimal=3)
 
     # The south pole is at 0h:51.4m, -27.13d
     south = treecorr.CelestialCoord( (0.+51.4/60.) * treecorr.hours,
                                      -27.13 * treecorr.degrees )
-    print 'south.galactic = ',south.galactic()
+    print('south.galactic = ',south.galactic())
     el,b = south.galactic()
     numpy.testing.assert_almost_equal(b, -pi/2., decimal=3)
 
     # The anti-center is at 5h:42.6m, 28.92d
     anticenter = treecorr.CelestialCoord( (5.+45.6/60.) * treecorr.hours,
                                           28.94 * treecorr.degrees )
-    print 'anticenter.galactic = ',anticenter.galactic()
+    print('anticenter.galactic = ',anticenter.galactic())
     el,b = anticenter.galactic()
     numpy.testing.assert_almost_equal(el, pi, decimal=3)
     numpy.testing.assert_almost_equal(b, 0., decimal=3)

--- a/tests/test_gg.py
+++ b/tests/test_gg.py
@@ -11,7 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-
+from __future__ import print_function
 import numpy
 import treecorr
 import os
@@ -54,22 +54,22 @@ def test_gg():
     true_xip = temp * (r**4 - 16.*r**2*r0**2 + 32.*r0**4)/r0**4
     true_xim = temp * r**4/r0**4
 
-    print 'gg.xip = ',gg.xip
-    print 'true_xip = ',true_xip
-    print 'ratio = ',gg.xip / true_xip
-    print 'diff = ',gg.xip - true_xip
-    print 'max diff = ',max(abs(gg.xip - true_xip))
+    print('gg.xip = ',gg.xip)
+    print('true_xip = ',true_xip)
+    print('ratio = ',gg.xip / true_xip)
+    print('diff = ',gg.xip - true_xip)
+    print('max diff = ',max(abs(gg.xip - true_xip)))
     assert max(abs(gg.xip - true_xip)) < 3.e-7
-    print 'xip_im = ',gg.xip_im
+    print('xip_im = ',gg.xip_im)
     assert max(abs(gg.xip_im)) < 2.e-7
 
-    print 'gg.xim = ',gg.xim
-    print 'true_xim = ',true_xim
-    print 'ratio = ',gg.xim / true_xim
-    print 'diff = ',gg.xim - true_xim
-    print 'max diff = ',max(abs(gg.xim - true_xim))
+    print('gg.xim = ',gg.xim)
+    print('true_xim = ',true_xim)
+    print('ratio = ',gg.xim / true_xim)
+    print('diff = ',gg.xim - true_xim)
+    print('max diff = ',max(abs(gg.xim - true_xim)))
     assert max(abs(gg.xim - true_xim)) < 3.e-7
-    print 'xim_im = ',gg.xim_im
+    print('xim_im = ',gg.xim_im)
     assert max(abs(gg.xim_im)) < 1.e-7
 
     # Check MapSq calculation:
@@ -82,20 +82,20 @@ def test_gg():
     true_mapsq = 6.*numpy.pi * gamma0**2 * r0**8 * r**4 / (L**2 * (r**2+r0**2)**5)
 
     mapsq, mapsq_im, mxsq, mxsq_im, varmapsq = gg.calculateMapSq('Crittenden')
-    print 'mapsq = ',mapsq
-    print 'true_mapsq = ',true_mapsq
-    print 'ratio = ',mapsq/true_mapsq
-    print 'diff = ',mapsq-true_mapsq
-    print 'max diff = ',max(abs(mapsq - true_mapsq))
-    print 'max diff[16:] = ',max(abs(mapsq[16:] - true_mapsq[16:]))
+    print('mapsq = ',mapsq)
+    print('true_mapsq = ',true_mapsq)
+    print('ratio = ',mapsq/true_mapsq)
+    print('diff = ',mapsq-true_mapsq)
+    print('max diff = ',max(abs(mapsq - true_mapsq)))
+    print('max diff[16:] = ',max(abs(mapsq[16:] - true_mapsq[16:])))
     # It's pretty ratty near the start where the integral is poorly evaluated, but the 
     # agreement is pretty good if we skip the first 16 elements.
     # Well, it gets bad again at the end, but those values are small enough that they still
     # pass this test.
     assert max(abs(mapsq[16:]-true_mapsq[16:])) < 3.e-8
-    print 'mxsq = ',mxsq
-    print 'max = ',max(abs(mxsq))
-    print 'max[16:] = ',max(abs(mxsq[16:]))
+    print('mxsq = ',mxsq)
+    print('max = ',max(abs(mxsq)))
+    print('max[16:] = ',max(abs(mxsq[16:])))
     assert max(abs(mxsq[16:])) < 3.e-8
 
     # Check that we get the same result using the corr2 executable:
@@ -105,36 +105,36 @@ def test_gg():
         p = subprocess.Popen( ["corr2","gg.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','gg.out'))
-        print 'gg.xip = ',gg.xip
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/gg.xip
-        print 'diff = ',corr2_output[:,2]-gg.xip
+        print('gg.xip = ',gg.xip)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/gg.xip)
+        print('diff = ',corr2_output[:,2]-gg.xip)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/gg.xip, 1., decimal=3)
 
-        print 'gg.xim = ',gg.xim
-        print 'from corr2 output = ',corr2_output[:,3]
-        print 'ratio = ',corr2_output[:,3]/gg.xim
-        print 'diff = ',corr2_output[:,3]-gg.xim
+        print('gg.xim = ',gg.xim)
+        print('from corr2 output = ',corr2_output[:,3])
+        print('ratio = ',corr2_output[:,3]/gg.xim)
+        print('diff = ',corr2_output[:,3]-gg.xim)
         numpy.testing.assert_almost_equal(corr2_output[:,3]/gg.xim, 1., decimal=3)
 
-        print 'xip_im from corr2 output = ',corr2_output[:,4]
-        print 'max err = ',max(abs(corr2_output[:,4]))
+        print('xip_im from corr2 output = ',corr2_output[:,4])
+        print('max err = ',max(abs(corr2_output[:,4])))
         assert max(abs(corr2_output[:,4])) < 2.e-7
-        print 'xim_im from corr2 output = ',corr2_output[:,5]
-        print 'max err = ',max(abs(corr2_output[:,5]))
+        print('xim_im from corr2 output = ',corr2_output[:,5])
+        print('max err = ',max(abs(corr2_output[:,5])))
         assert max(abs(corr2_output[:,5])) < 1.e-7
 
         corr2_output2 = numpy.loadtxt(os.path.join('output','gg_m2.out'))
-        print 'mapsq = ',mapsq
-        print 'from corr2 output = ',corr2_output2[:,1]
-        print 'ratio = ',corr2_output2[:,1]/mapsq
-        print 'diff = ',corr2_output2[:,1]-mapsq
+        print('mapsq = ',mapsq)
+        print('from corr2 output = ',corr2_output2[:,1])
+        print('ratio = ',corr2_output2[:,1]/mapsq)
+        print('diff = ',corr2_output2[:,1]-mapsq)
         numpy.testing.assert_almost_equal(corr2_output2[:,1]/mapsq, 1., decimal=3)
 
-        print 'mxsq = ',mxsq
-        print 'from corr2 output = ',corr2_output2[:,2]
-        print 'ratio = ',corr2_output2[:,2]/mxsq
-        print 'diff = ',corr2_output2[:,2]-mxsq
+        print('mxsq = ',mxsq)
+        print('from corr2 output = ',corr2_output2[:,2])
+        print('ratio = ',corr2_output2[:,2]/mxsq)
+        print('diff = ',corr2_output2[:,2]-mxsq)
         numpy.testing.assert_almost_equal(corr2_output2[:,2]/mxsq, 1., decimal=3)
 
     # Also check the Schneider version.  The math isn't quite as nice here, but it is tractable
@@ -149,23 +149,23 @@ def test_gg():
         true_mapsq *= i0(x) * r**2 * (r**4 + 96.*r0**4) - 16.*i1(x) * r0**2 * (r**4 + 24.*r0**4)
 
         mapsq, mapsq_im, mxsq, mxsq_im, varmapsq = gg.calculateMapSq('Schneider')
-        print 'Schneider mapsq = ',mapsq
-        print 'true_mapsq = ',true_mapsq
-        print 'ratio = ',mapsq/true_mapsq
-        print 'diff = ',mapsq-true_mapsq
-        print 'max diff = ',max(abs(mapsq - true_mapsq))
-        print 'max diff[20:] = ',max(abs(mapsq[20:] - true_mapsq[20:]))
+        print('Schneider mapsq = ',mapsq)
+        print('true_mapsq = ',true_mapsq)
+        print('ratio = ',mapsq/true_mapsq)
+        print('diff = ',mapsq-true_mapsq)
+        print('max diff = ',max(abs(mapsq - true_mapsq)))
+        print('max diff[20:] = ',max(abs(mapsq[20:] - true_mapsq[20:])))
         # This one stay ratty longer, so we need to skip the first 20 and also loosen the
         # test a bit.
         assert max(abs(mapsq[20:]-true_mapsq[20:])) < 7.e-8
-        print 'mxsq = ',mxsq
-        print 'max = ',max(abs(mxsq))
-        print 'max[20:] = ',max(abs(mxsq[20:]))
+        print('mxsq = ',mxsq)
+        print('max = ',max(abs(mxsq)))
+        print('max[20:] = ',max(abs(mxsq[20:])))
         assert max(abs(mxsq[20:])) < 7.e-8
 
     except ImportError:
         # Don't require scipy if the user doesn't have it.
-        print 'Skipping tests of Schneider aperture mass, since scipy.special not available.'
+        print('Skipping tests of Schneider aperture mass, since scipy.special not available.')
 
 
 def test_spherical():
@@ -250,23 +250,23 @@ def test_spherical():
                                     verbose=2)
         gg.process(cat)
 
-        print 'ra0, dec0 = ',ra0,dec0
-        print 'gg.xip = ',gg.xip
-        print 'true_xip = ',true_xip
-        print 'ratio = ',gg.xip / true_xip
-        print 'diff = ',gg.xip - true_xip
-        print 'max diff = ',max(abs(gg.xip - true_xip))
+        print('ra0, dec0 = ',ra0,dec0)
+        print('gg.xip = ',gg.xip)
+        print('true_xip = ',true_xip)
+        print('ratio = ',gg.xip / true_xip)
+        print('diff = ',gg.xip - true_xip)
+        print('max diff = ',max(abs(gg.xip - true_xip)))
         # The 3rd and 4th centers are somewhat less accurate.  Not sure why.
         # The math seems to be right, since the last one that gets all the way to the pole
         # works, so I'm not sure what is going on.  It's just a few bins that get a bit less
         # accurate.  Possibly worth investigating further at some point...
         assert max(abs(gg.xip - true_xip)) < 3.e-7
 
-        print 'gg.xim = ',gg.xim
-        print 'true_xim = ',true_xim
-        print 'ratio = ',gg.xim / true_xim
-        print 'diff = ',gg.xim - true_xim
-        print 'max diff = ',max(abs(gg.xim - true_xim))
+        print('gg.xim = ',gg.xim)
+        print('true_xim = ',true_xim)
+        print('ratio = ',gg.xim / true_xim)
+        print('diff = ',gg.xim - true_xim)
+        print('max diff = ',max(abs(gg.xim - true_xim)))
         assert max(abs(gg.xim - true_xim)) < 2.e-7
 
     # One more center that can be done very easily.  If the center is the north pole, then all
@@ -281,21 +281,21 @@ def test_spherical():
                            dec_units='rad')
     gg.process(cat)
 
-    print 'gg.xip = ',gg.xip
-    print 'gg.xip_im = ',gg.xip_im
-    print 'true_xip = ',true_xip
-    print 'ratio = ',gg.xip / true_xip
-    print 'diff = ',gg.xip - true_xip
-    print 'max diff = ',max(abs(gg.xip - true_xip))
+    print('gg.xip = ',gg.xip)
+    print('gg.xip_im = ',gg.xip_im)
+    print('true_xip = ',true_xip)
+    print('ratio = ',gg.xip / true_xip)
+    print('diff = ',gg.xip - true_xip)
+    print('max diff = ',max(abs(gg.xip - true_xip)))
     assert max(abs(gg.xip - true_xip)) < 3.e-7
     assert max(abs(gg.xip_im)) < 3.e-7
 
-    print 'gg.xim = ',gg.xim
-    print 'gg.xim_im = ',gg.xim_im
-    print 'true_xim = ',true_xim
-    print 'ratio = ',gg.xim / true_xim
-    print 'diff = ',gg.xim - true_xim
-    print 'max diff = ',max(abs(gg.xim - true_xim))
+    print('gg.xim = ',gg.xim)
+    print('gg.xim_im = ',gg.xim_im)
+    print('true_xim = ',true_xim)
+    print('ratio = ',gg.xim / true_xim)
+    print('diff = ',gg.xim - true_xim)
+    print('max diff = ',max(abs(gg.xim - true_xim)))
     assert max(abs(gg.xim - true_xim)) < 2.e-7
     assert max(abs(gg.xim_im)) < 2.e-7
 
@@ -306,22 +306,22 @@ def test_spherical():
         p = subprocess.Popen( ["corr2","gg_spherical.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','gg_spherical.out'))
-        print 'gg.xip = ',gg.xip
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/gg.xip
-        print 'diff = ',corr2_output[:,2]-gg.xip
+        print('gg.xip = ',gg.xip)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/gg.xip)
+        print('diff = ',corr2_output[:,2]-gg.xip)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/gg.xip, 1., decimal=3)
 
-        print 'gg.xim = ',gg.xim
-        print 'from corr2 output = ',corr2_output[:,3]
-        print 'ratio = ',corr2_output[:,3]/gg.xim
-        print 'diff = ',corr2_output[:,3]-gg.xim
+        print('gg.xim = ',gg.xim)
+        print('from corr2 output = ',corr2_output[:,3])
+        print('ratio = ',corr2_output[:,3]/gg.xim)
+        print('diff = ',corr2_output[:,3]-gg.xim)
         numpy.testing.assert_almost_equal(corr2_output[:,3]/gg.xim, 1., decimal=3)
 
-        print 'xip_im from corr2 output = ',corr2_output[:,4]
+        print('xip_im from corr2 output = ',corr2_output[:,4])
         assert max(abs(corr2_output[:,4])) < 3.e-7
 
-        print 'xim_im from corr2 output = ',corr2_output[:,5]
+        print('xim_im from corr2 output = ',corr2_output[:,5])
         assert max(abs(corr2_output[:,5])) < 2.e-7
 
 
@@ -347,19 +347,19 @@ def test_aardvark():
     #print 'direct.xip = ',direct_xip
 
     xip_err = gg.xip - direct_xip
-    print 'xip_err = ',xip_err
-    print 'max = ',max(abs(xip_err))
+    print('xip_err = ',xip_err)
+    print('max = ',max(abs(xip_err)))
     assert max(abs(xip_err)) < 2.e-7
-    print 'xip_im = ',gg.xip_im
-    print 'max = ',max(abs(gg.xip_im))
+    print('xip_im = ',gg.xip_im)
+    print('max = ',max(abs(gg.xip_im)))
     assert max(abs(gg.xip_im)) < 3.e-7
 
     xim_err = gg.xim - direct_xim
-    print 'xim_err = ',xim_err
-    print 'max = ',max(abs(xim_err))
+    print('xim_err = ',xim_err)
+    print('max = ',max(abs(xim_err)))
     assert max(abs(xim_err)) < 1.e-7
-    print 'xim_im = ',gg.xim_im
-    print 'max = ',max(abs(gg.xim_im))
+    print('xim_im = ',gg.xim_im)
+    print('max = ',max(abs(gg.xim_im)))
     assert max(abs(gg.xim_im)) < 1.e-7
 
     # However, after some back and forth about the calculation, we concluded that Eric hadn't
@@ -378,13 +378,13 @@ def test_aardvark():
     #print 'bs0.xip = ',bs0_xip
 
     xip_err = gg.xip - bs0_xip
-    print 'xip_err = ',xip_err
-    print 'max = ',max(abs(xip_err))
+    print('xip_err = ',xip_err)
+    print('max = ',max(abs(xip_err)))
     assert max(abs(xip_err)) < 1.e-7
 
     xim_err = gg.xim - bs0_xim
-    print 'xim_err = ',xim_err
-    print 'max = ',max(abs(xim_err))
+    print('xim_err = ',xim_err)
+    print('max = ',max(abs(xim_err)))
     assert max(abs(xim_err)) < 5.e-8
 
     # Check that we get the same result using the corr2 executable:
@@ -394,23 +394,23 @@ def test_aardvark():
     p = subprocess.Popen( ["corr2","Aardvark.params"] )
     p.communicate()
     corr2_output = numpy.loadtxt(os.path.join('output','Aardvark.out'))
-    print 'gg.xip = ',gg.xip
-    print 'from corr2 output = ',corr2_output[:,2]
-    print 'ratio = ',corr2_output[:,2]/gg.xip
-    print 'diff = ',corr2_output[:,2]-gg.xip
+    print('gg.xip = ',gg.xip)
+    print('from corr2 output = ',corr2_output[:,2])
+    print('ratio = ',corr2_output[:,2]/gg.xip)
+    print('diff = ',corr2_output[:,2]-gg.xip)
     numpy.testing.assert_almost_equal(corr2_output[:,2]/gg.xip, 1., decimal=3)
 
-    print 'gg.xim = ',gg.xim
-    print 'from corr2 output = ',corr2_output[:,3]
-    print 'ratio = ',corr2_output[:,3]/gg.xim
-    print 'diff = ',corr2_output[:,3]-gg.xim
+    print('gg.xim = ',gg.xim)
+    print('from corr2 output = ',corr2_output[:,3])
+    print('ratio = ',corr2_output[:,3]/gg.xim)
+    print('diff = ',corr2_output[:,3]-gg.xim)
     numpy.testing.assert_almost_equal(corr2_output[:,3]/gg.xim, 1., decimal=3)
 
-    print 'xip_im from corr2 output = ',corr2_output[:,4]
-    print 'max err = ',max(abs(corr2_output[:,4]))
+    print('xip_im from corr2 output = ',corr2_output[:,4])
+    print('max err = ',max(abs(corr2_output[:,4])))
     assert max(abs(corr2_output[:,4])) < 3.e-7
-    print 'xim_im from corr2 output = ',corr2_output[:,5]
-    print 'max err = ',max(abs(corr2_output[:,5]))
+    print('xim_im from corr2 output = ',corr2_output[:,5])
+    print('max err = ',max(abs(corr2_output[:,5])))
     assert max(abs(corr2_output[:,5])) < 1.e-7
 
     # As bin_slop decreases, the agreement should get even better.
@@ -424,13 +424,13 @@ def test_aardvark():
         #print 'bs0.xip = ',bs0_xip
 
         xip_err = gg.xip - bs0_xip
-        print 'xip_err = ',xip_err
-        print 'max = ',max(abs(xip_err))
+        print('xip_err = ',xip_err)
+        print('max = ',max(abs(xip_err)))
         assert max(abs(xip_err)) < 1.e-8
 
         xim_err = gg.xim - bs0_xim
-        print 'xim_err = ',xim_err
-        print 'max = ',max(abs(xim_err))
+        print('xim_err = ',xim_err)
+        print('max = ',max(abs(xim_err)))
         assert max(abs(xim_err)) < 1.e-8
 
  

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -11,6 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
+from __future__ import print_function
 
 def get_aardvark():
     """We host the Aardvark.fit file separately so it people don't need to download it with
@@ -20,8 +21,8 @@ def get_aardvark():
     file_name = os.path.join('data','Aardvark.fit')
     url = 'https://github.com/rmjarvis/TreeCorr/wiki/Aardvark.fit'
     if not os.path.isfile(file_name):
-        import urllib
-        print 'downloading %s from %s...'%(file_name,url)
-        urllib.urlretrieve(url,file_name)
-        print 'done.'
+        import urllib.request
+        print('downloading %s from %s...'%(file_name,url))
+        urllib.request.urlretrieve(url,file_name)
+        print('done.')
     

--- a/tests/test_kk.py
+++ b/tests/test_kk.py
@@ -11,7 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-
+from __future__ import print_function
 import numpy
 import treecorr
 import os
@@ -30,14 +30,14 @@ def test_constant():
     cat = treecorr.Catalog(x=x, y=y, k=kappa, x_units='arcmin', y_units='arcmin')
     kk = treecorr.KKCorrelation(bin_size=0.1, min_sep=0.1, max_sep=10., sep_units='arcmin')
     kk.process(cat)
-    print 'kk.xi = ',kk.xi
+    print('kk.xi = ',kk.xi)
     numpy.testing.assert_almost_equal(kk.xi, A**2, decimal=10)
 
     # Now add some noise to the values. It should still work, but at slightly lower accuracy.
     kappa += 0.001 * (numpy.random.random_sample(ngal)-0.5)
     cat = treecorr.Catalog(x=x, y=y, k=kappa, x_units='arcmin', y_units='arcmin')
     kk.process(cat)
-    print 'kk.xi = ',kk.xi
+    print('kk.xi = ',kk.xi)
     numpy.testing.assert_almost_equal(kk.xi, A**2, decimal=6)
 
 
@@ -70,11 +70,11 @@ def test_kk():
     kk.process(cat)
     r = numpy.exp(kk.meanlogr)
     true_xi = numpy.pi * A**2 * (s/L)**2 * numpy.exp(-0.25*r**2/s**2)
-    print 'kk.xi = ',kk.xi
-    print 'true_xi = ',true_xi
-    print 'ratio = ',kk.xi / true_xi
-    print 'diff = ',kk.xi - true_xi
-    print 'max diff = ',max(abs(kk.xi - true_xi))
+    print('kk.xi = ',kk.xi)
+    print('true_xi = ',true_xi)
+    print('ratio = ',kk.xi / true_xi)
+    print('diff = ',kk.xi - true_xi)
+    print('max diff = ',max(abs(kk.xi - true_xi)))
     assert max(abs(kk.xi - true_xi)) < 5.e-7
 
     # Check that we get the same result using the corr2 executable:
@@ -84,10 +84,10 @@ def test_kk():
         p = subprocess.Popen( ["corr2","kk.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','kk.out'))
-        print 'kk.xi = ',kk.xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/kk.xi
-        print 'diff = ',corr2_output[:,2]-kk.xi
+        print('kk.xi = ',kk.xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/kk.xi)
+        print('diff = ',corr2_output[:,2]-kk.xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/kk.xi, 1., decimal=3)
 
 

--- a/tests/test_ng.py
+++ b/tests/test_ng.py
@@ -12,6 +12,7 @@
 #    and/or other materials provided with the distribution.
 
 
+from __future__ import print_function
 import numpy
 import treecorr
 import os
@@ -44,12 +45,12 @@ def test_single():
     r = numpy.exp(ng.meanlogr)
     true_gt = gamma0 * numpy.exp(-0.5*r**2/r0**2)
 
-    print 'ng.xi = ',ng.xi
-    print 'ng.xi_im = ',ng.xi_im
-    print 'true_gammat = ',true_gt
-    print 'ratio = ',ng.xi / true_gt
-    print 'diff = ',ng.xi - true_gt
-    print 'max diff = ',max(abs(ng.xi - true_gt))
+    print('ng.xi = ',ng.xi)
+    print('ng.xi_im = ',ng.xi_im)
+    print('true_gammat = ',true_gt)
+    print('ratio = ',ng.xi / true_gt)
+    print('diff = ',ng.xi - true_gt)
+    print('max diff = ',max(abs(ng.xi - true_gt)))
     assert max(abs(ng.xi - true_gt)) < 4.e-4
     assert max(abs(ng.xi_im)) < 3.e-5
 
@@ -61,13 +62,13 @@ def test_single():
         p = subprocess.Popen( ["corr2","ng_single.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','ng_single.out'))
-        print 'ng.xi = ',ng.xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/ng.xi
-        print 'diff = ',corr2_output[:,2]-ng.xi
+        print('ng.xi = ',ng.xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/ng.xi)
+        print('diff = ',corr2_output[:,2]-ng.xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/ng.xi, 1., decimal=3)
 
-        print 'xi_im from corr2 output = ',corr2_output[:,3]
+        print('xi_im from corr2 output = ',corr2_output[:,3])
         assert max(abs(corr2_output[:,3])) < 3.e-5
 
 
@@ -97,12 +98,12 @@ def test_pairwise():
     r = numpy.exp(ng.meanlogr)
     true_gt = gamma0 * numpy.exp(-0.5*r**2/r0**2)
 
-    print 'ng.xi = ',ng.xi
-    print 'ng.xi_im = ',ng.xi_im
-    print 'true_gammat = ',true_gt
-    print 'ratio = ',ng.xi / true_gt
-    print 'diff = ',ng.xi - true_gt
-    print 'max diff = ',max(abs(ng.xi - true_gt))
+    print('ng.xi = ',ng.xi)
+    print('ng.xi_im = ',ng.xi_im)
+    print('true_gammat = ',true_gt)
+    print('ratio = ',ng.xi / true_gt)
+    print('diff = ',ng.xi - true_gt)
+    print('max diff = ',max(abs(ng.xi - true_gt)))
     # I don't really understand why this comes out slightly less accurate.
     # I would have thought it would be slightly more accurate because it doesn't use the
     # approximations intrinsic to the tree calculation.
@@ -117,13 +118,13 @@ def test_pairwise():
         p = subprocess.Popen( ["corr2","ng_pairwise.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','ng_pairwise.out'))
-        print 'ng.xi = ',ng.xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/ng.xi
-        print 'diff = ',corr2_output[:,2]-ng.xi
+        print('ng.xi = ',ng.xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/ng.xi)
+        print('diff = ',corr2_output[:,2]-ng.xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/ng.xi, 1., decimal=3)
 
-        print 'xi_im from corr2 output = ',corr2_output[:,3]
+        print('xi_im from corr2 output = ',corr2_output[:,3])
         assert max(abs(corr2_output[:,3])) < 3.e-5
 
 
@@ -203,12 +204,12 @@ def test_spherical():
                                       ra_units='rad', dec_units='rad')
         ng.process(lens_cat, source_cat)
 
-        print 'ra0, dec0 = ',ra0,dec0
-        print 'ng.xi = ',ng.xi
-        print 'true_gammat = ',true_gt
-        print 'ratio = ',ng.xi / true_gt
-        print 'diff = ',ng.xi - true_gt
-        print 'max diff = ',max(abs(ng.xi - true_gt))
+        print('ra0, dec0 = ',ra0,dec0)
+        print('ng.xi = ',ng.xi)
+        print('true_gammat = ',true_gt)
+        print('ratio = ',ng.xi / true_gt)
+        print('diff = ',ng.xi - true_gt)
+        print('max diff = ',max(abs(ng.xi - true_gt)))
         # The 3rd and 4th centers are somewhat less accurate.  Not sure why.
         # The math seems to be right, since the last one that gets all the way to the pole
         # works, so I'm not sure what is going on.  It's just a few bins that get a bit less
@@ -227,12 +228,12 @@ def test_spherical():
                                   ra_units='rad', dec_units='rad')
     ng.process(lens_cat, source_cat)
 
-    print 'ng.xi = ',ng.xi
-    print 'ng.xi_im = ',ng.xi_im
-    print 'true_gammat = ',true_gt
-    print 'ratio = ',ng.xi / true_gt
-    print 'diff = ',ng.xi - true_gt
-    print 'max diff = ',max(abs(ng.xi - true_gt))
+    print('ng.xi = ',ng.xi)
+    print('ng.xi_im = ',ng.xi_im)
+    print('true_gammat = ',true_gt)
+    print('ratio = ',ng.xi / true_gt)
+    print('diff = ',ng.xi - true_gt)
+    print('max diff = ',max(abs(ng.xi - true_gt)))
     assert max(abs(ng.xi - true_gt)) < 1.e-3
     assert max(abs(ng.xi_im)) < 3.e-5
 
@@ -244,13 +245,13 @@ def test_spherical():
         p = subprocess.Popen( ["corr2","ng_spherical.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','ng_spherical.out'))
-        print 'ng.xi = ',ng.xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/ng.xi
-        print 'diff = ',corr2_output[:,2]-ng.xi
+        print('ng.xi = ',ng.xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/ng.xi)
+        print('diff = ',corr2_output[:,2]-ng.xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/ng.xi, 1., decimal=3)
 
-        print 'xi_im from corr2 output = ',corr2_output[:,3]
+        print('xi_im from corr2 output = ',corr2_output[:,3])
         assert max(abs(corr2_output[:,3])) < 3.e-5
 
 
@@ -287,12 +288,12 @@ def test_ng():
     r = numpy.exp(ng.meanlogr)
     true_gt = gamma0 * numpy.exp(-0.5*r**2/r0**2)
 
-    print 'ng.xi = ',ng.xi
-    print 'ng.xi_im = ',ng.xi_im
-    print 'true_gammat = ',true_gt
-    print 'ratio = ',ng.xi / true_gt
-    print 'diff = ',ng.xi - true_gt
-    print 'max diff = ',max(abs(ng.xi - true_gt))
+    print('ng.xi = ',ng.xi)
+    print('ng.xi_im = ',ng.xi_im)
+    print('true_gammat = ',true_gt)
+    print('ratio = ',ng.xi / true_gt)
+    print('diff = ',ng.xi - true_gt)
+    print('max diff = ',max(abs(ng.xi - true_gt)))
     assert max(abs(ng.xi - true_gt)) < 4.e-3
     assert max(abs(ng.xi_im)) < 4.e-3
 
@@ -303,14 +304,14 @@ def test_ng():
     rg = treecorr.NGCorrelation(bin_size=0.1, min_sep=1., max_sep=25., sep_units='arcmin',
                                 verbose=2)
     rg.process(rand_cat, source_cat)
-    print 'rg.xi = ',rg.xi
+    print('rg.xi = ',rg.xi)
     xi, xi_im, varxi = ng.calculateXi(rg)
-    print 'compensated xi = ',xi
-    print 'compensated xi_im = ',xi_im
-    print 'true_gammat = ',true_gt
-    print 'ratio = ',xi / true_gt
-    print 'diff = ',xi - true_gt
-    print 'max diff = ',max(abs(xi - true_gt))
+    print('compensated xi = ',xi)
+    print('compensated xi_im = ',xi_im)
+    print('true_gammat = ',true_gt)
+    print('ratio = ',xi / true_gt)
+    print('diff = ',xi - true_gt)
+    print('max diff = ',max(abs(xi - true_gt)))
     # It turns out this doesn't come out much better.  I think the imprecision is mostly just due
     # to the smallish number of lenses, not to edge effects
     assert max(abs(xi - true_gt)) < 4.e-3
@@ -325,14 +326,14 @@ def test_ng():
         p = subprocess.Popen( ["corr2","ng.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','ng.out'))
-        print 'ng.xi = ',ng.xi
-        print 'xi = ',xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/xi
-        print 'diff = ',corr2_output[:,2]-xi
+        print('ng.xi = ',ng.xi)
+        print('xi = ',xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/xi)
+        print('diff = ',corr2_output[:,2]-xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=3)
 
-        print 'xi_im from corr2 output = ',corr2_output[:,3]
+        print('xi_im from corr2 output = ',corr2_output[:,3])
         assert max(abs(corr2_output[:,3])) < 4.e-3
 
 

--- a/tests/test_nk.py
+++ b/tests/test_nk.py
@@ -11,6 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
+from __future__ import print_function
 import numpy
 import treecorr
 import os
@@ -40,11 +41,11 @@ def test_single():
     r = numpy.exp(nk.meanlogr)
     true_k = kappa0 * numpy.exp(-0.5*r**2/r0**2) * (1.-0.5*r**2/r0**2)
 
-    print 'nk.xi = ',nk.xi
-    print 'true_kappa = ',true_k
-    print 'ratio = ',nk.xi / true_k
-    print 'diff = ',nk.xi - true_k
-    print 'max diff = ',max(abs(nk.xi - true_k))
+    print('nk.xi = ',nk.xi)
+    print('true_kappa = ',true_k)
+    print('ratio = ',nk.xi / true_k)
+    print('diff = ',nk.xi - true_k)
+    print('max diff = ',max(abs(nk.xi - true_k)))
     assert max(abs(nk.xi - true_k)) < 4.e-4
 
     # Check that we get the same result using the corr2 executable:
@@ -55,10 +56,10 @@ def test_single():
         p = subprocess.Popen( ["corr2","nk_single.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','nk_single.out'))
-        print 'nk.xi = ',nk.xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/nk.xi
-        print 'diff = ',corr2_output[:,2]-nk.xi
+        print('nk.xi = ',nk.xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/nk.xi)
+        print('diff = ',corr2_output[:,2]-nk.xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/nk.xi, 1., decimal=3)
 
 
@@ -91,11 +92,11 @@ def test_nk():
     r = numpy.exp(nk.meanlogr)
     true_k = kappa0 * numpy.exp(-0.5*r**2/r0**2) * (1.-0.5*r**2/r0**2)
 
-    print 'nk.xi = ',nk.xi
-    print 'true_kappa = ',true_k
-    print 'ratio = ',nk.xi / true_k
-    print 'diff = ',nk.xi - true_k
-    print 'max diff = ',max(abs(nk.xi - true_k))
+    print('nk.xi = ',nk.xi)
+    print('true_kappa = ',true_k)
+    print('ratio = ',nk.xi / true_k)
+    print('diff = ',nk.xi - true_k)
+    print('max diff = ',max(abs(nk.xi - true_k)))
     assert max(abs(nk.xi - true_k)) < 5.e-3
 
     nrand = nlens * 13
@@ -105,13 +106,13 @@ def test_nk():
     rk = treecorr.NKCorrelation(bin_size=0.1, min_sep=1., max_sep=25., sep_units='arcmin',
                                 verbose=2)
     rk.process(rand_cat, source_cat)
-    print 'rk.xi = ',rk.xi
+    print('rk.xi = ',rk.xi)
     xi, varxi = nk.calculateXi(rk)
-    print 'compensated xi = ',xi
-    print 'true_kappa = ',true_k
-    print 'ratio = ',xi / true_k
-    print 'diff = ',xi - true_k
-    print 'max diff = ',max(abs(xi - true_k))
+    print('compensated xi = ',xi)
+    print('true_kappa = ',true_k)
+    print('ratio = ',xi / true_k)
+    print('diff = ',xi - true_k)
+    print('max diff = ',max(abs(xi - true_k)))
     # It turns out this doesn't come out much better.  I think the imprecision is mostly just due
     # to the smallish number of lenses, not to edge effects
     assert max(abs(xi - true_k)) < 5.e-3
@@ -125,11 +126,11 @@ def test_nk():
         p = subprocess.Popen( ["corr2","nk.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','nk.out'))
-        print 'nk.xi = ',nk.xi
-        print 'xi = ',xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/xi
-        print 'diff = ',corr2_output[:,2]-xi
+        print('nk.xi = ',nk.xi)
+        print('xi = ',xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/xi)
+        print('diff = ',corr2_output[:,2]-xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=3)
 
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -11,7 +11,7 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-
+from __future__ import print_function
 import numpy
 import treecorr
 import os
@@ -35,7 +35,7 @@ def test_direct_count():
     nbins = 50
     dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
     dd.process(cat1, cat2)
-    print 'dd.npairs = ',dd.npairs
+    print('dd.npairs = ',dd.npairs)
 
     log_min_sep = numpy.log(min_sep)
     log_max_sep = numpy.log(max_sep)
@@ -50,8 +50,8 @@ def test_direct_count():
             if k >= nbins: continue
             true_npairs[k] += 1
 
-    print 'true_npairs = ',true_npairs
-    print 'diff = ',dd.npairs - true_npairs
+    print('true_npairs = ',true_npairs)
+    print('diff = ',dd.npairs - true_npairs)
     numpy.testing.assert_array_equal(dd.npairs, true_npairs)
 
 def test_direct_3d():
@@ -81,7 +81,7 @@ def test_direct_3d():
     nbins = 50
     dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
     dd.process(cat1, cat2)
-    print 'dd.npairs = ',dd.npairs
+    print('dd.npairs = ',dd.npairs)
 
     log_min_sep = numpy.log(min_sep)
     log_max_sep = numpy.log(max_sep)
@@ -96,8 +96,8 @@ def test_direct_3d():
             if k >= nbins: continue
             true_npairs[k] += 1
 
-    print 'true_npairs = ',true_npairs
-    print 'diff = ',dd.npairs - true_npairs
+    print('true_npairs = ',true_npairs)
+    print('diff = ',dd.npairs - true_npairs)
     numpy.testing.assert_array_equal(dd.npairs, true_npairs)
 
 def test_nn():
@@ -126,7 +126,7 @@ def test_nn():
     dd = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., sep_units='arcmin',
                                 verbose=2)
     dd.process(cat)
-    print 'dd.npairs = ',dd.npairs
+    print('dd.npairs = ',dd.npairs)
 
     nrand = 5 * ngal
     rx = (numpy.random.random_sample(nrand)-0.5) * L
@@ -135,30 +135,30 @@ def test_nn():
     rr = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., sep_units='arcmin',
                                 verbose=2)
     rr.process(rand)
-    print 'rr.npairs = ',rr.npairs
+    print('rr.npairs = ',rr.npairs)
 
     dr = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., sep_units='arcmin',
                                 verbose=2)
     dr.process(cat,rand)
-    print 'dr.npairs = ',dr.npairs
+    print('dr.npairs = ',dr.npairs)
 
     r = numpy.exp(dd.meanlogr)
     true_xi = 0.25/numpy.pi * (L/s)**2 * numpy.exp(-0.25*r**2/s**2) - 1.
 
     xi, varxi = dd.calculateXi(rr,dr)
-    print 'xi = ',xi
-    print 'true_xi = ',true_xi
-    print 'ratio = ',xi / true_xi
-    print 'diff = ',xi - true_xi
-    print 'max rel diff = ',max(abs((xi - true_xi)/true_xi))
+    print('xi = ',xi)
+    print('true_xi = ',true_xi)
+    print('ratio = ',xi / true_xi)
+    print('diff = ',xi - true_xi)
+    print('max rel diff = ',max(abs((xi - true_xi)/true_xi)))
     # This isn't super accurate.  But the agreement improves as L increase, so I think it is 
     # merely a matter of the finite field and the integrals going to infinity.  (Sort of, since
     # we still have L in there.)
     assert max(abs(xi - true_xi)/true_xi) < 0.1
 
     simple_xi, varxi = dd.calculateXi(rr)
-    print 'simple xi = ',simple_xi
-    print 'max rel diff = ',max(abs((simple_xi - true_xi)/true_xi))
+    print('simple xi = ',simple_xi)
+    print('max rel diff = ',max(abs((simple_xi - true_xi)/true_xi)))
     # The simple calculation (i.e. dd/rr-1, rather than (dd-2dr+rr)/rr as above) is only 
     # slightly less accurate in this case.  Probably because the mask is simple (a box), so
     # the difference is relatively minor.  The error is slightly higher in this case, but testing
@@ -173,10 +173,10 @@ def test_nn():
         p = subprocess.Popen( ["corr2","nn.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','nn.out'))
-        print 'xi = ',xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/xi
-        print 'diff = ',corr2_output[:,2]-xi
+        print('xi = ',xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/xi)
+        print('diff = ',corr2_output[:,2]-xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=3)
 
 
@@ -213,7 +213,7 @@ def test_3d():
     cat = treecorr.Catalog(ra=ra, dec=dec, r=r, ra_units='deg', dec_units='deg')
     dd = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., verbose=2)
     dd.process(cat)
-    print 'dd.npairs = ',dd.npairs
+    print('dd.npairs = ',dd.npairs)
 
     nrand = 5 * ngal
     rx = (numpy.random.random_sample(nrand)-0.5) * L + xcen
@@ -225,26 +225,26 @@ def test_3d():
     rand = treecorr.Catalog(ra=rra, dec=rdec, r=rr, ra_units='deg', dec_units='deg')
     rr = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., verbose=2)
     rr.process(rand)
-    print 'rr.npairs = ',rr.npairs
+    print('rr.npairs = ',rr.npairs)
 
     dr = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., verbose=2)
     dr.process(cat,rand)
-    print 'dr.npairs = ',dr.npairs
+    print('dr.npairs = ',dr.npairs)
 
     r = numpy.exp(dd.meanlogr)
     true_xi = 1./(8.*numpy.pi**1.5) * (L/s)**3 * numpy.exp(-0.25*r**2/s**2) - 1.
 
     xi, varxi = dd.calculateXi(rr,dr)
-    print 'xi = ',xi
-    print 'true_xi = ',true_xi
-    print 'ratio = ',xi / true_xi
-    print 'diff = ',xi - true_xi
-    print 'max rel diff = ',max(abs((xi - true_xi)/true_xi))
+    print('xi = ',xi)
+    print('true_xi = ',true_xi)
+    print('ratio = ',xi / true_xi)
+    print('diff = ',xi - true_xi)
+    print('max rel diff = ',max(abs((xi - true_xi)/true_xi)))
     assert max(abs(xi - true_xi)/true_xi) < 0.1
 
     simple_xi, varxi = dd.calculateXi(rr)
-    print 'simple xi = ',simple_xi
-    print 'max rel diff = ',max(abs((simple_xi - true_xi)/true_xi))
+    print('simple xi = ',simple_xi)
+    print('max rel diff = ',max(abs((simple_xi - true_xi)/true_xi)))
     assert max(abs(simple_xi - true_xi)/true_xi) < 0.1
 
     # Check that we get the same result using the corr2 executable:
@@ -255,10 +255,10 @@ def test_3d():
         p = subprocess.Popen( ["corr2","nn_3d.params"] )
         p.communicate()
         corr2_output = numpy.loadtxt(os.path.join('output','nn_3d.out'))
-        print 'xi = ',xi
-        print 'from corr2 output = ',corr2_output[:,2]
-        print 'ratio = ',corr2_output[:,2]/xi
-        print 'diff = ',corr2_output[:,2]-xi
+        print('xi = ',xi)
+        print('from corr2 output = ',corr2_output[:,2])
+        print('ratio = ',corr2_output[:,2]/xi)
+        print('diff = ',corr2_output[:,2]-xi)
         numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=3)
 
 
@@ -285,14 +285,14 @@ def test_list():
 
     dd = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., verbose=2)
     dd.process(data_cats)
-    print 'dd.npairs = ',dd.npairs
+    print('dd.npairs = ',dd.npairs)
 
     rr = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., verbose=2)
     rr.process(rand_cats)
-    print 'rr.npairs = ',rr.npairs
+    print('rr.npairs = ',rr.npairs)
 
     xi, varxi = dd.calculateXi(rr)
-    print 'xi = ',xi
+    print('xi = ',xi)
 
     # Now do the same thing with one big catalog for each.
     ddx = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., verbose=2)
@@ -303,11 +303,11 @@ def test_list():
     rrx.process(rand_catx)
     xix, varxix = ddx.calculateXi(rrx)
 
-    print 'ddx.npairs = ',ddx.npairs
-    print 'rrx.npairs = ',rrx.npairs
-    print 'xix = ',xix
-    print 'ratio = ',xi/xix
-    print 'diff = ',xi-xix
+    print('ddx.npairs = ',ddx.npairs)
+    print('rrx.npairs = ',rrx.npairs)
+    print('xix = ',xix)
+    print('ratio = ',xi/xix)
+    print('diff = ',xi-xix)
     numpy.testing.assert_almost_equal(xix/xi, 1., decimal=2)
 
     # Check that we get the same result using the corr2 executable:
@@ -351,30 +351,30 @@ def test_list():
     p = subprocess.Popen( ["corr2","nn_list1.params"] )
     p.communicate()
     corr2_output = numpy.loadtxt(os.path.join('output','nn_list1.out'))
-    print 'xi = ',xi
-    print 'from corr2 output = ',corr2_output[:,2]
-    print 'ratio = ',corr2_output[:,2]/xi
-    print 'diff = ',corr2_output[:,2]-xi
+    print('xi = ',xi)
+    print('from corr2 output = ',corr2_output[:,2])
+    print('ratio = ',corr2_output[:,2]/xi)
+    print('diff = ',corr2_output[:,2]-xi)
     numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=3)
 
     import subprocess
     p = subprocess.Popen( ["corr2","nn_list2.params"] )
     p.communicate()
     corr2_output = numpy.loadtxt(os.path.join('output','nn_list2.out'))
-    print 'xi = ',xi
-    print 'from corr2 output = ',corr2_output[:,2]
-    print 'ratio = ',corr2_output[:,2]/xi
-    print 'diff = ',corr2_output[:,2]-xi
+    print('xi = ',xi)
+    print('from corr2 output = ',corr2_output[:,2])
+    print('ratio = ',corr2_output[:,2]/xi)
+    print('diff = ',corr2_output[:,2]-xi)
     numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=2)
 
     import subprocess
     p = subprocess.Popen( ["corr2","nn_list3.params"] )
     p.communicate()
     corr2_output = numpy.loadtxt(os.path.join('output','nn_list3.out'))
-    print 'xi = ',xi
-    print 'from corr2 output = ',corr2_output[:,2]
-    print 'ratio = ',corr2_output[:,2]/xi
-    print 'diff = ',corr2_output[:,2]-xi
+    print('xi = ',xi)
+    print('from corr2 output = ',corr2_output[:,2])
+    print('ratio = ',corr2_output[:,2]/xi)
+    print('diff = ',corr2_output[:,2]-xi)
     numpy.testing.assert_almost_equal(corr2_output[:,2]/xi, 1., decimal=2)
 
 

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -11,7 +11,9 @@
 #    this list of conditions, and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
+from __future__ import print_function
 import treecorr
+
 
 def parse_variable(config, v):
     """Parse a configuration variable from a string that should look like 'key = value'
@@ -220,22 +222,22 @@ def print_params(params):
     for key in params:
         value_type, may_be_list, default_value, valid_values = params[key][:4]
         description = params[key][4:]
-        print ("{0:<"+str(max_len)+"} {1}").format(key,description[0])
+        print(("{0:<"+str(max_len)+"} {1}").format(key,description[0]))
         for d in description[1:]:
-            print "                {0}".format(d)
+            print("                {0}".format(d))
 
         # str(value_type) looks like "<type 'float'>"
         # value_type.__name__ looks like 'float'
         if may_be_list:
-            print "                Type must be {0} or a list of {0}.".format(value_type.__name__)
+            print("                Type must be {0} or a list of {0}.".format(value_type.__name__))
         else:
-            print "                Type must be {0}.".format(value_type.__name__)
+            print("                Type must be {0}.".format(value_type.__name__))
 
         if valid_values is not None:
-            print "                Valid values are {0!s}".format(valid_values)
+            print("                Valid values are {0!s}".format(valid_values))
         if default_value is not None:
-            print "                Default value is {0!s}".format(default_value)
-        print
+            print("                Default value is {0!s}".format(default_value))
+        print()
 
 
 def convert(value, value_type, key):


### PR DESCRIPTION
By default, installing the TreeCorr package fails with Python 3:

```
$ sudo pip install TreeCorr

Collecting TreeCorr
  Downloading TreeCorr-3.1.1.tar.gz (90kB)
    100% |████████████████████████████████| 94kB 3.3MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/tmp/pip-build-l957_r8f/TreeCorr/setup.py", line 8
        print 'Unable to import setuptools.  Using distutils instead.'
                                                                     ^
    SyntaxError: Missing parentheses in call to 'print'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/tmp/pip-build-l957_r8f/TreeCorr
```

I've made some minor changes to make the code work both in Python 2.7 and in Python 3. I haven't tested it with older versions of Python.