### PR TITLE
Add ability to count and get indices of objects near a given coordinate.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,12 @@ New features
   current Rperp metric, and it will remain available as such after 4.0. (#73)
 - Added better messaging when OpenMP is not found to work with the available
   clang compiler. (#75)
+- Added new methods Field.count_near and Field.get_near, which return the
+  number of or the indices of points in the field that are near a given
+  other coordinate.  (#44)
+- Added new method BinnedCorr2.sample_pairs, which returns a random sampling
+  of pairs within a given range of separations.  E.g. a sample of pairs that
+  fell into a given bin of the correlation function. (#67)
 
 
 Bug fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,13 @@ API changes
   had been relying on multiple fields being cached, this could lead to a
   performance regression for you.  However, you can update the number of
   fields cached with catalog.resize_cache(n). (#53)
+- Using bin_slop=0 no longer does the brute force calculation.  Rather, it
+  stops traversing the tree when all pairs for a given pair of cells would
+  fall into the same bin.  This distinction is normally not important, and
+  the new behavior is merely a performance increase.  However, there is a
+  numerical difference for shear correlations, as the shear projection is not
+  exactly equivalent.  To obtain the brute force calculation, use the new
+  `brute=True` option.
 
 
 Performance Improvements
@@ -77,6 +84,8 @@ New features
 - Added new method BinnedCorr2.sample_pairs, which returns a random sampling
   of pairs within a given range of separations.  E.g. a sample of pairs that
   fell into a given bin of the correlation function. (#67)
+- Added `brute` option for Correlation instances.  This is equivalent to the
+  old behavior of `bin_slop=0`.
 
 
 Bug fixes

--- a/docs/bintype.rst
+++ b/docs/bintype.rst
@@ -129,15 +129,14 @@ down, so the resulting counts come out pretty close to correct.  Furthermore, th
 number of pairs within the specified range is always correct, since each pair is placed
 in some bin.
 
-Finally, there is a distinction between ``bin_slop=0`` and ``bin_slop \ll 1``.
-Internally, the former will *always* traverse the tree all the way to the leaves.  So
+Finally, there is a distinction between ``bin_slop=0`` and ``brute=True``.
+Internally, the latter will *always* traverse the tree all the way to the leaves.  So
 every pair will be calculated individually.  This is the brute force calculation.
-If ``bin_slop`` is very, very small, but not equal to 0, then it will allow for the
-traversal to stop early if all possible pairs in a given pair of cells fall into the same bin.
-This can be quite a large speedup in some cases.  And especially for NN correlations, there
-is no disadvantage to doing so.
+However, ``bin_slop=0`` will allow for the traversal to stop early if all possible pairs in a
+given pair of cells fall into the same bin.  This can be quite a large speedup in some cases.
+And especially for NN correlations, there is no disadvantage to doing so.
 
 For shear correlations, there can be a slight difference between using ``bin_slop=0`` and
-``bin_slop=1.e-20`` (or some other similarly negligible value) because the shear projections
-won't be precisely equal in the two cases.  If the difference is seen to matter for you,
-this is probably a sign that you should decrease your bin size.
+``brute=True`` because the shear projections won't be precisely equal in the two cases.
+If the difference is seen to matter for you, this is probably a sign that you should decrease
+your bin size.

--- a/include/BinType.h
+++ b/include/BinType.h
@@ -94,9 +94,6 @@ struct BinTypeHelper<Log>
         double s1ps2sq = s1ps2 * s1ps2;
         if (s1ps2sq <= bsq*rsq) return true;
 
-        // b = 0 means recurse all the way to the leaves.
-        if (b == 0) return false;
-
         // If s1+s2 > 0.5 * (binsize + b) * r, then the total leakage (on both sides perhaps)
         // will be more than b.  I.e. too much slop.
         if (s1ps2sq > 0.25 * SQR(binsize + b) * rsq) return false;
@@ -191,9 +188,6 @@ struct BinTypeHelper<Linear>
         // s1 + s2 <= b
         // Note: this automatically includes the s1ps2 == 0 case, so don't do it separately.
         if (s1ps2 <= b) return true;
-
-        // b = 0 means recurse all the way to the leaves.
-        if (b == 0) return false;
 
         // If s1+s2 > 0.5 * (binsize + b), then the total leakage (on both sides perhaps)
         // will be more than b.  I.e. too much slop.
@@ -296,9 +290,6 @@ struct BinTypeHelper<TwoD>
         // Standard stop splitting criterion.
         // s1 + s2 <= b
         if (s1ps2 <= b) return true;
-
-        // b = 0 means recurse all the way to the leaves.
-        if (b == 0) return false;
 
         // If s1+s2 > 0.5 * (binsize + b), then the total leakage (on both sides perhaps)
         // will be more than b.  I.e. too much slop.

--- a/include/BinnedCorr2.h
+++ b/include/BinnedCorr2.h
@@ -64,6 +64,19 @@ public:
     void operator=(const BinnedCorr2<D1,D2,B>& rhs);
     void operator+=(const BinnedCorr2<D1,D2,B>& rhs);
 
+    // Sample a random subset of pairs in a given range
+    template <int C, int M>
+    long samplePairs(const Field<D1, C>& field1, const Field<D2, C>& field2,
+                     double min_sep, double max_sep, long* i1, long* i2, double* sep, int n);
+    template <int C, int M>
+    void samplePairs(const Cell<D1, C>& c1, const Cell<D2, C>& c2,
+                     double min_sep, double min_sepsq, double max_sep, double max_sepsq,
+                     long* i1, long* i2, double* sep, int n, long& k);
+    template <int C, int M>
+    void sampleFrom(const Cell<D1, C>& c1, const Cell<D2, C>& c2, double rsq, double r,
+                    long* i1, long* i2, double* sep, int n, long& k);
+
+
 protected:
 
     double _minsep;

--- a/include/BinnedCorr2_C.h
+++ b/include/BinnedCorr2_C.h
@@ -12,75 +12,25 @@
  *    and/or other materials provided with the distribution.
  */
 
-extern void* BuildNNCorr(int bin_type,
-                         double minsep, double maxsep, int nbins, double binsize, double b,
-                         double minrpar, double maxrpar,
-                         double* meanr, double* meanlogr, double* weight, double* npairs);
-extern void* BuildNKCorr(int bin_type,
-                         double minsep, double maxsep, int nbins, double binsize, double b,
-                         double minrpar, double maxrpar,
-                         double* xi,
-                         double* meanr, double* meanlogr, double* weight, double* npairs);
-extern void* BuildNGCorr(int bin_type,
-                         double minsep, double maxsep, int nbins, double binsize, double b,
-                         double minrpar, double maxrpar,
-                         double* xi, double* xi_im,
-                         double* meanr, double* meanlogr, double* weight, double* npairs);
-extern void* BuildKKCorr(int bin_type,
-                         double minsep, double maxsep, int nbins, double binsize, double b,
-                         double minrpar, double maxrpar,
-                         double* xi,
-                         double* meanr, double* meanlogr, double* weight, double* npairs);
-extern void* BuildKGCorr(int bin_type,
-                         double minsep, double maxsep, int nbins, double binsize, double b,
-                         double minrpar, double maxrpar,
-                         double* xi, double* xi_im,
-                         double* meanr, double* meanlogr, double* weight, double* npairs);
-extern void* BuildGGCorr(int bin_type,
-                         double minsep, double maxsep, int nbins, double binsize, double b,
-                         double minrpar, double maxrpar,
-                         double* xip, double* xip_im, double* xim, double* xim_im,
-                         double* meanr, double* meanlogr, double* weight, double* npairs);
+extern void* BuildCorr2(int d1, int d2, int bin_type,
+                       double minsep, double maxsep, int nbins, double binsize, double b,
+                       double minrpar, double maxrpar,
+                       double* xip, double* xip_im, double* xim, double* xim_im,
+                       double* meanr, double* meanlogr, double* weight, double* npairs);
 
-extern void DestroyNNCorr(void* corr, int bin_type);
-extern void DestroyNKCorr(void* corr, int bin_type);
-extern void DestroyNGCorr(void* corr, int bin_type);
-extern void DestroyKKCorr(void* corr, int bin_type);
-extern void DestroyKGCorr(void* corr, int bin_type);
-extern void DestroyGGCorr(void* corr, int bin_type);
+extern void DestroyCorr2(void* corr, int d1, int d2, int bin_type);
 
-extern void ProcessAutoNN(void* corr, void* field, int dots, int coord, int bin_type, int metric);
-extern void ProcessAutoKK(void* corr, void* field, int dots, int coord, int bin_type, int metric);
-extern void ProcessAutoGG(void* corr, void* field, int dots, int coord, int bin_type, int metric);
+extern void ProcessAuto2(void* corr, void* field, int dots,
+                        int d, int coord, int bin_type, int metric);
 
-extern void ProcessCrossNN(void* corr, void* field1, void* field2, int dots, int coord,
-                           int bin_type, int metric);
-extern void ProcessCrossNK(void* corr, void* field1, void* field2, int dots, int coord,
-                           int bin_type, int metric);
-extern void ProcessCrossNG(void* corr, void* field1, void* field2, int dots, int coord,
-                           int bin_type, int metric);
-extern void ProcessCrossKK(void* corr, void* field1, void* field2, int dots, int coord,
-                           int bin_type, int metric);
-extern void ProcessCrossKG(void* corr, void* field1, void* field2, int dots, int coord,
-                           int bin_type, int metric);
-extern void ProcessCrossGG(void* corr, void* field1, void* field2, int dots, int coord,
-                           int bin_type, int metric);
+extern void ProcessCross2(void* corr, void* field1, void* field2, int dots,
+                         int d1, int d2, int coord, int bin_type, int metric);
 
-extern void ProcessPairNN(void* corr, void* field1, void* field2, int dots, int coord,
-                          int bin_type, int metric);
-extern void ProcessPairNK(void* corr, void* field1, void* field2, int dots, int coord,
-                          int bin_type, int metric);
-extern void ProcessPairNG(void* corr, void* field1, void* field2, int dots, int coord,
-                          int bin_type, int metric);
-extern void ProcessPairKK(void* corr, void* field1, void* field2, int dots, int coord,
-                          int bin_type, int metric);
-extern void ProcessPairKG(void* corr, void* field1, void* field2, int dots, int coord,
-                          int bin_type, int metric);
-extern void ProcessPairGG(void* corr, void* field1, void* field2, int dots, int coord,
-                          int bin_type, int metric);
+extern void ProcessPair(void* corr, void* field1, void* field2, int dots,
+                        int d1, int d2, int coord, int bin_type, int metric);
 
 extern int SetOMPThreads(int num_threads);
 
 extern long SamplePairs(void* corr, void* field1, void* field2, double min_sep, double max_sep,
-                        int d1, int d2, int coords, int metric, int bin_type,
+                        int d1, int d2, int coords, int bin_type, int metric,
                         long* i1, long* i2, double* sep, int n);

--- a/include/BinnedCorr2_C.h
+++ b/include/BinnedCorr2_C.h
@@ -81,3 +81,6 @@ extern void ProcessPairGG(void* corr, void* field1, void* field2, int dots, int 
 
 extern int SetOMPThreads(int num_threads);
 
+extern long SamplePairs(void* corr, void* field1, void* field2, double min_sep, double max_sep,
+                        int d1, int d2, int coords, int metric, int bin_type,
+                        long* i1, long* i2, double* sep, int n);

--- a/include/BinnedCorr3_C.h
+++ b/include/BinnedCorr3_C.h
@@ -12,45 +12,21 @@
  *    and/or other materials provided with the distribution.
  */
 
-extern void* BuildNNNCorr(int bin_type,
-                          double minsep, double maxsep, int nbins, double binsize, double b,
-                          double minu, double maxu, int nubins, double ubinsize, double bu,
-                          double minv, double maxv, int nvbins, double vbinsize, double bv,
-                          double minrpar, double maxrpar,
-                          double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
-                          double* meand3, double* meanlogd3, double* meanu, double* meanv,
-                          double* weight, double* ntri);
-extern void* BuildKKKCorr(int bin_type,
-                          double minsep, double maxsep, int nbins, double binsize, double b,
-                          double minu, double maxu, int nubins, double ubinsize, double bu,
-                          double minv, double maxv, int nvbins, double vbinsize, double bv,
-                          double minrpar, double maxrpar,
-                          double* zeta,
-                          double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
-                          double* meand3, double* meanlogd3, double* meanu, double* meanv,
-                          double* weight, double* ntri);
-extern void* BuildGGGCorr(int bin_type,
-                          double minsep, double maxsep, int nbins, double binsize, double b,
-                          double minu, double maxu, int nubins, double ubinsize, double bu,
-                          double minv, double maxv, int nvbins, double vbinsize, double bv,
-                          double minrpar, double maxrpar,
-                          double* gam0, double* gam0_im, double* gam1, double* gam1_im,
-                          double* gam2, double* gam2_im, double* gam3, double* gam3_im,
-                          double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
-                          double* meand3, double* meanlogd3, double* meanu, double* meanv,
-                          double* weight, double* ntri);
+extern void* BuildCorr3(int d1, int d2, int d3, int bin_type,
+                        double minsep, double maxsep, int nbins, double binsize, double b,
+                        double minu, double maxu, int nubins, double ubinsize, double bu,
+                        double minv, double maxv, int nvbins, double vbinsize, double bv,
+                        double minrpar, double maxrpar,
+                        double* gam0, double* gam0_im, double* gam1, double* gam1_im,
+                        double* gam2, double* gam2_im, double* gam3, double* gam3_im,
+                        double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
+                        double* meand3, double* meanlogd3, double* meanu, double* meanv,
+                        double* weight, double* ntri);
 
-extern void DestroyNNNCorr(void* corr, int bin_type);
-extern void DestroyKKKCorr(void* corr, int bin_type);
-extern void DestroyGGGCorr(void* corr, int bin_type);
+extern void DestroyCorr3(void* corr, int d1, int d2, int d3, int bin_type);
 
-extern void ProcessAutoNNN(void* corr, void* field, int dots, int coord, int bin_type, int metric);
-extern void ProcessAutoKKK(void* corr, void* field, int dots, int coord, int bin_type, int metric);
-extern void ProcessAutoGGG(void* corr, void* field, int dots, int coord, int bin_type, int metric);
+extern void ProcessAuto3(void* corr, void* field, int dots,
+                         int d, int coord, int bin_type, int metric);
 
-extern void ProcessCrossNNN(void* corr, void* field1, void* field2, void* field3, int dots,
-                            int coord, int bin_type, int metric);
-extern void ProcessCrossKKK(void* corr, void* field1, void* field2, void* field3, int dots,
-                            int coord, int bin_type, int metric);
-extern void ProcessCrossGGG(void* corr, void* field1, void* field2, void* field3, int dots,
-                            int coord, int bin_type, int metric);
+extern void ProcessCross3(void* corr, void* field1, void* field2, void* field3, int dots,
+                          int d1, int d2, int d3, int coord, int bin_type, int metric);

--- a/include/Cell.h
+++ b/include/Cell.h
@@ -236,8 +236,10 @@ public:
     const Cell<D,C>* getRight() const { return _left ? _right : 0; }
     const LeafInfo* getInfo() const { return _left ? 0 : &_info; }
 
+    // These are mostly used for debugging purposes.
     long countLeaves() const;
     std::vector<const Cell<D,C>*> getAllLeaves() const;
+    bool includesIndex(long index) const;
 
     void Write(std::ostream& os) const;
     void WriteTree(std::ostream& os, int indent=0) const;

--- a/include/Cell.h
+++ b/include/Cell.h
@@ -200,14 +200,14 @@ public:
         _size(0.), _sizesq(0.), _data(data), _left(0), _info(info) {}
 
     Cell(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
-         double minsizesq, SplitMethod sm, size_t start, size_t end);
+         double minsizesq, SplitMethod sm, bool brute, size_t start, size_t end);
 
     Cell(CellData<D,C>* ave, double sizesq,
          std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
-         double minsizesq, SplitMethod sm, size_t start, size_t end);
+         double minsizesq, SplitMethod sm, bool brute, size_t start, size_t end);
 
     void finishInit(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
-                    double minsizesq, SplitMethod sm, size_t start, size_t end);
+                    double minsizesq, SplitMethod sm, bool brute, size_t start, size_t end);
 
     ~Cell()
     {

--- a/include/Cell.h
+++ b/include/Cell.h
@@ -50,30 +50,29 @@ class CellData<NData,C>
 public:
     CellData() {}
 
-    CellData(const Position<C>& pos, double w, double wpos) :
-        _pos(pos), _w(w), _wpos(wpos), _n(w != 0.) {}
+    CellData(const Position<C>& pos, double w) :
+        _pos(pos), _w(w), _n(w != 0.) {}
 
     template <int C2>
-    CellData(const Position<C2>& pos, double w, double wpos) :
-        _pos(pos), _w(w), _wpos(wpos), _n(w != 0.) {}
+    CellData(const Position<C2>& pos, double w) :
+        _pos(pos), _w(w), _n(w != 0.) {}
 
-    CellData(const std::vector<CellData<NData,C>*>& vdata,
+    CellData(const std::vector<std::pair<CellData<NData,C>*,double> >& vdata,
              size_t start, size_t end);
 
     // This doesn't do anything, but is provided for consistency with the other
     // kinds of CellData.
-    void finishAverages(const std::vector<CellData<NData,C>*>&, size_t , size_t ) {}
+    void finishAverages(const std::vector<std::pair<CellData<NData,C>*,double> >&,
+                        size_t , size_t ) {}
 
     const Position<C>& getPos() const { return _pos; }
     double getW() const { return _w; }
-    double getWPos() const { return _wpos; }
     long getN() const { return _n; }
 
 private:
 
     Position<C> _pos;
     float _w;
-    float _wpos;
     long _n;
 };
 
@@ -87,25 +86,26 @@ class CellData<KData,C>
 public:
     CellData() {}
 
-    CellData(const Position<C>& pos, double k, double w, double wpos) :
-        _pos(pos), _wk(w*k), _w(w), _wpos(wpos), _n(w != 0.)
+    CellData(const Position<C>& pos, double k, double w) :
+        _pos(pos), _wk(w*k), _w(w), _n(w != 0.)
     {}
 
     template <int C2>
-    CellData(const Position<C2>& pos, double k, double w, double wpos) :
-        _pos(pos), _wk(w*k), _w(w), _wpos(wpos), _n(w != 0.)
+    CellData(const Position<C2>& pos, double k, double w) :
+        _pos(pos), _wk(w*k), _w(w), _n(w != 0.)
     {}
 
-    CellData(const std::vector<CellData<KData,C>*>& vdata, size_t start, size_t end);
+    CellData(const std::vector<std::pair<CellData<KData,C>*,double> >& vdata,
+             size_t start, size_t end);
 
     // The above constructor just computes the mean pos, since sometimes that's all we
     // need.  So this function will finish the rest of the construction when desired.
-    void finishAverages(const std::vector<CellData<KData,C>*>& vdata, size_t start, size_t end);
+    void finishAverages(const std::vector<std::pair<CellData<KData,C>*,double> >&,
+                        size_t start, size_t end);
 
     const Position<C>& getPos() const { return _pos; }
     double getWK() const { return _wk; }
     double getW() const { return _w; }
-    double getWPos() const { return _wpos; }
     long getN() const { return _n; }
 
 private:
@@ -113,7 +113,6 @@ private:
     Position<C> _pos;
     float _wk;
     float _w;
-    float _wpos;
     long _n;
 };
 
@@ -127,25 +126,26 @@ class CellData<GData,C>
 public:
     CellData() {}
 
-    CellData(const Position<C>& pos, const std::complex<double>& g, double w, double wpos) :
-        _pos(pos), _wg(w*g), _w(w), _wpos(wpos), _n(w != 0.)
+    CellData(const Position<C>& pos, const std::complex<double>& g, double w) :
+        _pos(pos), _wg(w*g), _w(w), _n(w != 0.)
     {}
 
     template <int C2>
-    CellData(const Position<C2>& pos, const std::complex<double>& g, double w, double wpos) :
-        _pos(pos), _wg(w*g), _w(w), _wpos(wpos), _n(w != 0.)
+    CellData(const Position<C2>& pos, const std::complex<double>& g, double w) :
+        _pos(pos), _wg(w*g), _w(w), _n(w != 0.)
     {}
 
-    CellData(const std::vector<CellData<GData,C>*>& vdata, size_t start, size_t end);
+    CellData(const std::vector<std::pair<CellData<GData,C>*,double> >& vdata,
+             size_t start, size_t end);
 
     // The above constructor just computes the mean pos, since sometimes that's all we
     // need.  So this function will finish the rest of the construction when desired.
-    void finishAverages(const std::vector<CellData<GData,C>*>& vdata, size_t start, size_t end);
+    void finishAverages(const std::vector<std::pair<CellData<GData,C>*,double> >&,
+                        size_t start, size_t end);
 
     const Position<C>& getPos() const { return _pos; }
     std::complex<double> getWG() const { return _wg; }
     double getW() const { return _w; }
-    double getWPos() const { return _wpos; }
     long getN() const { return _n; }
 
 private:
@@ -153,7 +153,6 @@ private:
     Position<C> _pos;
     std::complex<float> _wg;
     float _w;
-    float _wpos;
     long _n;
 };
 
@@ -177,10 +176,11 @@ public:
 
     Cell(CellData<D,C>* data) : _size(0.), _sizesq(0.), _data(data), _left(0), _right(0) {}
 
-    Cell(std::vector<CellData<D,C>*>& vdata,
+    Cell(std::vector<std::pair<CellData<D,C>*,double> >& vdata,
          double minsizesq, SplitMethod sm, size_t start, size_t end);
 
-    Cell(CellData<D,C>* ave, double sizesq, std::vector<CellData<D,C>*>& vdata,
+    Cell(CellData<D,C>* ave, double sizesq,
+         std::vector<std::pair<CellData<D,C>*,double> >& vdata,
          double minsizesq, SplitMethod sm, size_t start, size_t end);
 
     ~Cell()
@@ -197,7 +197,6 @@ public:
     const CellData<D,C>& getData() const { return *_data; }
     const Position<C>& getPos() const { return _data->getPos(); }
     double getW() const { return _data->getW(); }
-    double getWPos() const { return _data->getWPos(); }
     long getN() const { return _data->getN(); }
 
     double getSize() const { return _size; }
@@ -226,12 +225,12 @@ protected:
 
 template <int D, int C>
 double CalculateSizeSq(
-    const Position<C>& cen, const std::vector<CellData<D,C>*>& vdata,
+    const Position<C>& cen, const std::vector<std::pair<CellData<D,C>*,double> >& vdata,
     size_t start, size_t end);
 
 template <int D, int C>
 size_t SplitData(
-    std::vector<CellData<D,C>*>& vdata, SplitMethod sm,
+    std::vector<std::pair<CellData<D,C>*,double> >& vdata, SplitMethod sm,
     size_t start, size_t end, const Position<C>& meanpos);
 
 template <int D, int C>

--- a/include/Cell.h
+++ b/include/Cell.h
@@ -234,7 +234,8 @@ public:
 
     const Cell<D,C>* getLeft() const { return _left; }
     const Cell<D,C>* getRight() const { return _left ? _right : 0; }
-    const LeafInfo* getInfo() const { return _left ? 0 : &_info; }
+    const LeafInfo& getInfo() const { Assert(!_left && getN()==1); return _info; }
+    const ListLeafInfo& getListInfo() const { Assert(!_left && getN()!=1); return _listinfo; }
 
     // These are mostly used for debugging purposes.
     long countLeaves() const;

--- a/include/Field.h
+++ b/include/Field.h
@@ -48,6 +48,7 @@ public:
     long getNObj() const { return _nobj; }
     long getNTopLevel() const { return long(_cells.size()); }
     const std::vector<Cell<D,C>*>& getCells() const { return _cells; }
+    long countNear(double x, double y, double z, double sep) const;
 
 private:
 

--- a/include/Field.h
+++ b/include/Field.h
@@ -49,6 +49,7 @@ public:
     long getNTopLevel() const { return long(_cells.size()); }
     const std::vector<Cell<D,C>*>& getCells() const { return _cells; }
     long countNear(double x, double y, double z, double sep) const;
+    void getNear(double x, double y, double z, double sep, long* indices, int n) const;
 
 private:
 

--- a/include/Field.h
+++ b/include/Field.h
@@ -42,7 +42,7 @@ public:
     Field(double* x, double* y, double* z, double* g1, double* g2, double* k,
           double* w, double* wpos, long nobj,
           double minsize, double maxsize,
-          int sm_int, int maxtop);
+          int sm_int, bool brute, int maxtop);
     ~Field();
 
     long getNObj() const { return _nobj; }

--- a/include/Field_C.h
+++ b/include/Field_C.h
@@ -34,6 +34,8 @@ extern void DestroyNField(void* field, int coords);
 extern long FieldGetNTopLevel(void* field, int d, int coords);
 extern long FieldCountNear(void* field, double x, double y, double z, double sep,
                            int d, int coords);
+extern void FieldGetNear(void* field, double x, double y, double z, double sep,
+                         int d, int coords, long* indices, int n);
 
 extern void* BuildGSimpleField(double* x, double* y, double* z, double* g1, double* g2,
                                double* w, double* wpos, long nobj, int coords);

--- a/include/Field_C.h
+++ b/include/Field_C.h
@@ -31,13 +31,9 @@ extern void DestroyGField(void* field, int coords);
 extern void DestroyKField(void* field, int coords);
 extern void DestroyNField(void* field, int coords);
 
-extern long NFieldGetNTopLevel(void* field, int coords);
-extern long KFieldGetNTopLevel(void* field, int coords);
-extern long GFieldGetNTopLevel(void* field, int coords);
-
-extern long NFieldCountNear(void* field, double x, double y, double z, double sep, int coords);
-extern long KFieldCountNear(void* field, double x, double y, double z, double sep, int coords);
-extern long GFieldCountNear(void* field, double x, double y, double z, double sep, int coords);
+extern long FieldGetNTopLevel(void* field, int d, int coords);
+extern long FieldCountNear(void* field, double x, double y, double z, double sep,
+                           int d, int coords);
 
 extern void* BuildGSimpleField(double* x, double* y, double* z, double* g1, double* g2,
                                double* w, double* wpos, long nobj, int coords);

--- a/include/Field_C.h
+++ b/include/Field_C.h
@@ -35,6 +35,10 @@ extern long NFieldGetNTopLevel(void* field, int coords);
 extern long KFieldGetNTopLevel(void* field, int coords);
 extern long GFieldGetNTopLevel(void* field, int coords);
 
+extern long NFieldCountNear(void* field, double x, double y, double z, double sep, int coords);
+extern long KFieldCountNear(void* field, double x, double y, double z, double sep, int coords);
+extern long GFieldCountNear(void* field, double x, double y, double z, double sep, int coords);
+
 extern void* BuildGSimpleField(double* x, double* y, double* z, double* g1, double* g2,
                                double* w, double* wpos, long nobj, int coords);
 

--- a/include/Field_C.h
+++ b/include/Field_C.h
@@ -15,17 +15,17 @@
 extern void* BuildGField(double* x, double* y, double* z, double* g1, double* g2,
                          double* w, double* wpos, long nobj,
                          double minsize, double maxsize,
-                         int sm_int, int maxtop, int coords);
+                         int sm_int, int brute, int maxtop, int coords);
 
 extern void* BuildKField(double* x, double* y, double* z, double* k,
                          double* w, double* wpos, long nobj,
                          double minsize, double maxsize,
-                         int sm_int, int maxtop, int coords);
+                         int sm_int, int brute, int maxtop, int coords);
 
 extern void* BuildNField(double* x, double* y, double* z,
                          double* w, double* wpos, long nobj,
                          double minsize, double maxsize,
-                         int sm_int, int maxtop, int coords);
+                         int sm_int, int brute, int maxtop, int coords);
 
 extern void DestroyGField(void* field, int coords);
 extern void DestroyKField(void* field, int coords);

--- a/include/Field_C.h
+++ b/include/Field_C.h
@@ -12,97 +12,38 @@
  *    and/or other materials provided with the distribution.
  */
 
-extern void* BuildGFieldFlat(double* x, double* y, double* g1, double* g2,
-                             double* w, double* wpos, long nobj,
-                             double minsize, double maxsize,
-                             int sm_int, int maxtop);
-extern void* BuildGField3D(double* x, double* y, double* z, double* g1, double* g2,
-                           double* w, double* wpos, long nobj,
-                           double minsize, double maxsize,
-                           int sm_int, int maxtop);
-extern void* BuildGFieldSphere(double* x, double* y, double* z, double* g1, double* g2,
-                               double* w, double* wpos, long nobj,
-                               double minsize, double maxsize,
-                               int sm_int, int maxtop);
+extern void* BuildGField(double* x, double* y, double* z, double* g1, double* g2,
+                         double* w, double* wpos, long nobj,
+                         double minsize, double maxsize,
+                         int sm_int, int maxtop, int coords);
 
-extern void* BuildKFieldFlat(double* x, double* y, double* k,
-                             double* w, double* wpos, long nobj,
-                             double minsize, double maxsize,
-                             int sm_int, int maxtop);
-extern void* BuildKField3D(double* x, double* y, double* z, double* k,
-                           double* w, double* wpos, long nobj,
-                           double minsize, double maxsize,
-                           int sm_int, int maxtop);
-extern void* BuildKFieldSphere(double* x, double* y, double* z, double* k,
-                               double* w, double* wpos, long nobj,
-                               double minsize, double maxsize,
-                               int sm_int, int maxtop);
+extern void* BuildKField(double* x, double* y, double* z, double* k,
+                         double* w, double* wpos, long nobj,
+                         double minsize, double maxsize,
+                         int sm_int, int maxtop, int coords);
 
-extern void* BuildNFieldFlat(double* x, double* y,
-                             double* w, double* wpos, long nobj,
-                             double minsize, double maxsize,
-                             int sm_int, int maxtop);
-extern void* BuildNField3D(double* x, double* y, double* z,
-                           double* w, double* wpos, long nobj,
-                           double minsize, double maxsize,
-                           int sm_int, int maxtop);
-extern void* BuildNFieldSphere(double* x, double* y, double* z,
-                               double* w, double* wpos, long nobj,
-                               double minsize, double maxsize,
-                               int sm_int, int maxtop);
+extern void* BuildNField(double* x, double* y, double* z,
+                         double* w, double* wpos, long nobj,
+                         double minsize, double maxsize,
+                         int sm_int, int maxtop, int coords);
 
-extern void DestroyGFieldFlat(void* field);
-extern void DestroyGField3D(void* field);
-extern void DestroyGFieldSphere(void* field);
+extern void DestroyGField(void* field, int coords);
+extern void DestroyKField(void* field, int coords);
+extern void DestroyNField(void* field, int coords);
 
-extern void DestroyKFieldFlat(void* field);
-extern void DestroyKField3D(void* field);
-extern void DestroyKFieldSphere(void* field);
+extern long NFieldGetNTopLevel(void* field, int coords);
+extern long KFieldGetNTopLevel(void* field, int coords);
+extern long GFieldGetNTopLevel(void* field, int coords);
 
-extern void DestroyNFieldFlat(void* field);
-extern void DestroyNField3D(void* field);
-extern void DestroyNFieldSphere(void* field);
+extern void* BuildGSimpleField(double* x, double* y, double* z, double* g1, double* g2,
+                               double* w, double* wpos, long nobj, int coords);
 
+extern void* BuildKSimpleField(double* x, double* y, double* z, double* k,
+                               double* w, double* wpos, long nobj, int coords);
 
-extern void* BuildGSimpleFieldFlat(double* x, double* y, double* g1, double* g2,
-                                   double* w, double* wpos, long nobj);
-extern void* BuildGSimpleField3D(double* x, double* y, double* z, double* g1, double* g2,
-                                 double* w, double* wpos, long nobj);
-extern void* BuildGSimpleFieldSphere(double* x, double* y, double* z, double* g1, double* g2,
-                                     double* w, double* wpos, long nobj);
+extern void* BuildNSimpleField(double* x, double* y, double* z,
+                               double* w, double* wpos, long nobj, int coords);
 
-extern void* BuildKSimpleFieldFlat(double* x, double* y, double* k,
-                                   double* w, double* wpos, long nobj);
-extern void* BuildKSimpleField3D(double* x, double* y, double* z, double* k,
-                                 double* w, double* wpos, long nobj);
-extern void* BuildKSimpleFieldSphere(double* x, double* y, double* z, double* k,
-                                     double* w, double* wpos, long nobj);
-
-extern void* BuildNSimpleFieldFlat(double* x, double* y,
-                                   double* w, double* wpos, long nobj);
-extern void* BuildNSimpleField3D(double* x, double* y, double* z,
-                                 double* w, double* wpos, long nobj);
-extern void* BuildNSimpleFieldSphere(double* x, double* y, double* z,
-                                     double* w, double* wpos, long nobj);
-
-extern void DestroyGSimpleFieldFlat(void* field);
-extern void DestroyGSimpleField3D(void* field);
-extern void DestroyGSimpleFieldSphere(void* field);
-
-extern void DestroyKSimpleFieldFlat(void* field);
-extern void DestroyKSimpleField3D(void* field);
-extern void DestroyKSimpleFieldSphere(void* field);
-
-extern void DestroyNSimpleFieldFlat(void* field);
-extern void DestroyNSimpleField3D(void* field);
-extern void DestroyNSimpleFieldSphere(void* field);
-
-extern long NFieldFlatGetNTopLevel(void* field);
-extern long NField3DGetNTopLevel(void* field);
-extern long NFieldSphereGetNTopLevel(void* field);
-extern long KFieldFlatGetNTopLevel(void* field);
-extern long KField3DGetNTopLevel(void* field);
-extern long KFieldSphereGetNTopLevel(void* field);
-extern long GFieldFlatGetNTopLevel(void* field);
-extern long GField3DGetNTopLevel(void* field);
-extern long GFieldSphereGetNTopLevel(void* field);
+extern void DestroyGSimpleField(void* field, int coords);
+extern void DestroyKSimpleField(void* field, int coords);
+extern void DestroyNSimpleField(void* field, int coords);

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -78,7 +78,8 @@ struct MetricHelper<Euclidean>
     // then we also need to make sure we are fully in the range for rpar as well.  For
     // Euclidean (and others that don't use rpar), this is always true, but Rper and Rlens
     // have a check here.
-    static bool isRParInsideRange(double rpar, double s1ps2, double minrpar, double maxrpar)
+    static bool isRParInsideRange(const Position<Flat>& p1, const Position<Flat>& p2,
+                                  double s1ps2, double minrpar, double maxrpar, double rpar)
     { return true; }
 
     // The normal tests about whether a given distance is inside the binning range happen
@@ -128,6 +129,10 @@ struct MetricHelper<Euclidean>
     static bool isRParOutsideRange(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                                    double s1ps2, double minrpar, double maxrpar, double& rpar)
     { return false; }
+
+    static bool isRParInsideRange(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
+                                  double s1ps2, double minrpar, double maxrpar, double rpar)
+    { return true; }
 
     static bool tooSmallDist(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                              double rsq, double rpar, double s1ps2, double minsepsq)
@@ -229,7 +234,8 @@ struct MetricHelper<OldRperp>
         else return false;
     }
 
-    static bool isRParInsideRange(double rpar, double s1ps2, double minrpar, double maxrpar)
+    static bool isRParInsideRange(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
+                                  double s1ps2, double minrpar, double maxrpar, double rpar)
     {
         // Quick return if no min/max rpar
         if (minrpar == -std::numeric_limits<double>::max() &&
@@ -355,7 +361,8 @@ struct MetricHelper<Rperp>
         else return false;
     }
 
-    static bool isRParInsideRange(double rpar, double s1ps2, double minrpar, double maxrpar)
+    static bool isRParInsideRange(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
+                                  double s1ps2, double minrpar, double maxrpar, double rpar)
     {
         // Quick return if no min/max rpar
         if (minrpar == -std::numeric_limits<double>::max() &&
@@ -457,7 +464,8 @@ struct MetricHelper<Rlens>
         else return false;
     }
 
-    static bool isRParInsideRange(double rpar, double s1ps2, double minrpar, double maxrpar)
+    static bool isRParInsideRange(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
+                                  double s1ps2, double minrpar, double maxrpar, double rpar)
     {
         // Quick return if no min/max rpar
         if (minrpar == -std::numeric_limits<double>::max() &&
@@ -557,17 +565,22 @@ struct MetricHelper<Arc>
         if (minrpar == -std::numeric_limits<double>::max() &&
             maxrpar == std::numeric_limits<double>::max()) return false;
 
+        // Remember that s1ps2 has been scaled to be the values on the unit circle.
+        // So scale them back up here.
+        s1ps2 *= std::max(p1.norm(), p2.norm());
         rpar = calculateRPar(p1,p2);
         if (rpar + s1ps2 < minrpar) return true;
         else if (rpar - s1ps2 > maxrpar) return true;
         else return false;
     }
 
-    static bool isRParInsideRange(double rpar, double s1ps2, double minrpar, double maxrpar)
+    static bool isRParInsideRange(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
+                                  double s1ps2, double minrpar, double maxrpar, double rpar)
     {
         // Quick return if no min/max rpar
         if (minrpar == -std::numeric_limits<double>::max() &&
             maxrpar == std::numeric_limits<double>::max()) return true;
+        s1ps2 *= std::max(p1.norm(), p2.norm());
         if (rpar - s1ps2 < minrpar) return false;
         else if (rpar + s1ps2 > maxrpar) return false;
         else return true;

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -522,12 +522,18 @@ struct MetricHelper<Arc>
     // For 3d coordinates, use the cross product to get sin(theta)
     static double DistSq(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                          double& s1, double& s2)
-    { return SQR(Dist(p1,p2)); }
+    {
+        double dsq = SQR(Dist(p1,p2));
+        // Also the sizes need to be converted to the effective size on the unit sphere
+        s1 /= p1.norm();
+        s2 /= p2.norm();
+        return dsq;
+    }
 
     static double Dist(const Position<ThreeD>& p1, const Position<ThreeD>& p2)
     {
         // sin(theta) = |p1 x p2| / |p1| |p2|
-        double sintheta = sqrt( p1.cross(p2).normSq() / (p1.normSq() * p2.normSq()) );
+        double sintheta = p1.cross(p2).norm() / (p1.norm() * p2.norm());
         double theta = std::asin(sintheta);
         return theta;
     }

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -33,6 +33,14 @@ struct MetricHelper;
 template <>
 struct MetricHelper<Euclidean>
 {
+    // For each metric, we have enum values with allowed coordinate systems mapped to
+    // the normal enum value for that system, but disallowed coordinates mapped to one
+    // of the allowed ones, so that when we instantiate the templates, we don't get
+    // compiler errors from trying to instantiate functions that don't exist.
+    //
+    // For Euclidean, all coordinate systems are allowed.
+    enum { _Flat=Flat, _ThreeD=ThreeD, _Sphere=Sphere };
+
     ///
     //
     // Flat
@@ -142,6 +150,8 @@ struct MetricHelper<Euclidean>
 template <>
 struct MetricHelper<OldRperp>
 {
+    enum { _Flat=ThreeD, _ThreeD=ThreeD, _Sphere=ThreeD };
+
     static double DistSq(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                          double& s1, double& s2)
     {
@@ -266,6 +276,8 @@ struct MetricHelper<OldRperp>
 template <>
 struct MetricHelper<Rperp>
 {
+    enum { _Flat=ThreeD, _ThreeD=ThreeD, _Sphere=ThreeD };
+
     static double DistSq(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                          double& s1, double& s2)
     {
@@ -397,6 +409,8 @@ struct MetricHelper<Rperp>
 template <>
 struct MetricHelper<Rlens>
 {
+    enum { _Flat=ThreeD, _ThreeD=ThreeD, _Sphere=ThreeD };
+
     // The distance is measured perpendicular to the p2 direction at the distance of p1.
     static double DistSq(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                          double& s1, double& s2)
@@ -475,6 +489,8 @@ struct MetricHelper<Rlens>
 template <>
 struct MetricHelper<Arc>
 {
+    enum { _Flat=ThreeD, _ThreeD=ThreeD, _Sphere=Sphere };
+
     static double DistSq(const Position<Sphere>& p1, const Position<Sphere>& p2,
                          double& s1, double& s2)
     { return SQR(Dist(p1,p2)); }

--- a/include/Position.h
+++ b/include/Position.h
@@ -19,6 +19,7 @@
 
 // The Coord enum is defined here:
 #include "Position_C.h"
+#include "dbg.h"
 
 template <typename T>
 inline T SQR(T x) { return x * x; }
@@ -46,6 +47,11 @@ public:
         _normsq = rhs._normsq; _norm = rhs._norm;
         return *this;
     }
+
+    // A convenience constructor to be parallel with 3d positions so I can do things like
+    // Position<C> pos(x,y,z) when z=0 for Flat.
+    Position(double x, double y, double z) : _x(x), _y(y), _normsq(0.), _norm(0.)
+    { Assert(z==0.); }
 
     double getX() const { return _x; }
     double getY() const { return _y; }
@@ -226,14 +232,14 @@ public:
     Position<Sphere>& operator/=(double a)
     { Position<ThreeD>::operator/=(a); return *this; }
 
-    Position<Sphere> operator+(const Position<Sphere>& p2) const
-    { Position<Sphere> p1 = *this; p1 += p2; return p1; }
-    Position<Sphere> operator-(const Position<Sphere>& p2) const
-    { Position<Sphere> p1 = *this; p1 -= p2; return p1; }
-    Position<Sphere> operator*(double a) const
-    { Position<Sphere> p1 = *this; p1 *= a; return p1; }
-    Position<Sphere> operator/(double a) const
-    { Position<Sphere> p1 = *this; p1 /= a; return p1; }
+    Position<ThreeD> operator+(const Position<Sphere>& p2) const
+    { Position<ThreeD> p1 = *this; p1 += p2; return p1; }
+    Position<ThreeD> operator-(const Position<Sphere>& p2) const
+    { Position<ThreeD> p1 = *this; p1 -= p2; return p1; }
+    Position<ThreeD> operator*(double a) const
+    { Position<ThreeD> p1 = *this; p1 *= a; return p1; }
+    Position<ThreeD> operator/(double a) const
+    { Position<ThreeD> p1 = *this; p1 /= a; return p1; }
 
 }; // Position<Sphere>
 

--- a/src/BinnedCorr2.cpp
+++ b/src/BinnedCorr2.cpp
@@ -306,8 +306,8 @@ void BinnedCorr2<D1,D2,B>::process11(const Cell<D1,C>& c1, const Cell<D2,C>& c2,
     const double s1ps2 = s1+s2;
 
     double rpar = 0; // Gets set to correct value by this function if appropriate
-    if (MetricHelper<M>::isRParOutsideRange(c1.getPos(), c2.getPos(), s1ps2, _minrpar, _maxrpar,
-                                            rpar))
+    if (MetricHelper<M>::isRParOutsideRange(c1.getPos(), c2.getPos(), s1ps2,
+                                            _minrpar, _maxrpar, rpar))
         return;
     xdbg<<"RPar in range\n";
 
@@ -324,7 +324,8 @@ void BinnedCorr2<D1,D2,B>::process11(const Cell<D1,C>& c1, const Cell<D2,C>& c2,
     // Now check if these cells are small enough that it is ok to drop into a single bin.
     int k=-1;
     double r=0,logr=0;  // If singleBin is true, these values are set for use by directProcess11
-    if (MetricHelper<M>::isRParInsideRange(rpar, s1ps2, _minrpar, _maxrpar) &&
+    if (MetricHelper<M>::isRParInsideRange(c1.getPos(), c2.getPos(), s1ps2,
+                                           _minrpar, _maxrpar, rpar) &&
         BinTypeHelper<B>::singleBin(rsq, s1ps2, c1.getPos(), c2.getPos(),
                                     _binsize, _b, _bsq,
                                     _minsep, _maxsep, _logminsep,
@@ -602,8 +603,8 @@ void BinnedCorr2<D1,D2,B>::samplePairs(
     const double s1ps2 = s1+s2;
 
     double rpar = 0; // Gets set to correct value by this function if appropriate
-    if (MetricHelper<M>::isRParOutsideRange(c1.getPos(), c2.getPos(), s1ps2, _minrpar, _maxrpar,
-                                            rpar))
+    if (MetricHelper<M>::isRParOutsideRange(c1.getPos(), c2.getPos(), s1ps2,
+                                            _minrpar, _maxrpar, rpar))
         return;
     xdbg<<"RPar in range\n";
 
@@ -620,7 +621,8 @@ void BinnedCorr2<D1,D2,B>::samplePairs(
     // Now check if these cells are small enough that it is ok to drop into a single bin.
     int kk=-1;
     double r=0,logr=0;  // If singleBin is true, these values are set for use by directProcess11
-    if (MetricHelper<M>::isRParInsideRange(rpar, s1ps2, _minrpar, _maxrpar) &&
+    if (MetricHelper<M>::isRParInsideRange(c1.getPos(), c2.getPos(), s1ps2,
+                                           _minrpar, _maxrpar, rpar) &&
         BinTypeHelper<B>::singleBin(rsq, s1ps2, c1.getPos(), c2.getPos(),
                                     _binsize, _b, _bsq,
                                     _minsep, _maxsep, _logminsep,

--- a/src/BinnedCorr2.cpp
+++ b/src/BinnedCorr2.cpp
@@ -679,7 +679,7 @@ void BinnedCorr2<D1,D2,B>::samplePairs(
 
 void SelectRandomFrom(long m, std::vector<long>& selection)
 {
-    dbg<<"SelectRandomFrom("<<m<<", "<<selection.size()<<")\n";
+    xdbg<<"SelectRandomFrom("<<m<<", "<<selection.size()<<")\n";
     long n = selection.size();
     // There are two algorithms here.
     // Floyd's algorithm is efficient for m >> n.
@@ -770,12 +770,12 @@ void BinnedCorr2<D1,D2,B>::sampleFrom(
     } else {
         XAssert(std::abs(r - sqrt(rsq)) < 1.e-10*r);
     }
-    dbg<<"sampleFrom: "<<c1.getN()<<"  "<<c2.getN()<<"  "<<rsq<<"  "<<r<<std::endl;
-    dbg<<"   n1,n2,k,n,m = "<<n1<<','<<n2<<','<<k<<','<<n<<','<<m<<std::endl;
+    xdbg<<"sampleFrom: "<<c1.getN()<<"  "<<c2.getN()<<"  "<<rsq<<"  "<<r<<std::endl;
+    xdbg<<"   n1,n2,k,n,m = "<<n1<<','<<n2<<','<<k<<','<<n<<','<<m<<std::endl;
 
     if (k + m <= n) {
         // Case 1
-        dbg<<"Case 1: take all pairs\n";
+        xdbg<<"Case 1: take all pairs\n";
         for (size_t p1=0; p1<leaf1.size(); ++p1) {
             int nn1 = leaf1[p1]->getN();
             for (int q1=0; q1<nn1; ++q1) {
@@ -798,7 +798,7 @@ void BinnedCorr2<D1,D2,B>::sampleFrom(
         }
     } else if (m <= n) {
         // Case 2
-        dbg<<"Case 2: Check one at a time.\n";
+        xdbg<<"Case 2: Check one at a time.\n";
         for (size_t p1=0; p1<leaf1.size(); ++p1) {
             int nn1 = leaf1[p1]->getN();
             for (int q1=0; q1<nn1; ++q1) {
@@ -829,7 +829,7 @@ void BinnedCorr2<D1,D2,B>::sampleFrom(
         }
     } else {
         // Case 3
-        dbg<<"Case 3: Select n without replacement\n";
+        xdbg<<"Case 3: Select n without replacement\n";
         std::vector<long> selection(n);
         SelectRandomFrom(k+m, selection);
         // If any items in k<=i<n are from the original set, put them in their original place.
@@ -856,7 +856,7 @@ void BinnedCorr2<D1,D2,B>::sampleFrom(
         for (size_t p1=0; p1<leaf1.size(); ++p1) {
             int nn1 = leaf1[p1]->getN();
             for (int q1=0; q1<nn1; ++q1) {
-                dbg<<"i = "<<i<<", next = "<<next->first<<"  "<<next->second<<std::endl;
+                xdbg<<"i = "<<i<<", next = "<<next->first<<"  "<<next->second<<std::endl;
                 Assert(i <= next->first);
                 if (next->first > i + n2) {
                     // Then skip this loop through the second vector
@@ -870,7 +870,7 @@ void BinnedCorr2<D1,D2,B>::sampleFrom(
                     int nn2 = leaf2[p2]->getN();
                     for (int q2=0; q2<nn2; ++q2,++i) {
                         if (i == next->first) {
-                            dbg<<"Use i = "<<i<<std::endl;
+                            xdbg<<"Use i = "<<i<<std::endl;
                             int index2;
                             if (nn2 == 1) index2 = leaf2[p2]->getInfo().index;
                             else index2 = (*leaf2[p2]->getListInfo().indices)[q2];
@@ -888,7 +888,7 @@ void BinnedCorr2<D1,D2,B>::sampleFrom(
             }
             if (next == places.end()) break;
         }
-        dbg<<"Done: i = "<<i<<", k+m = "<<k+m<<std::endl;
+        xdbg<<"Done: i = "<<i<<", k+m = "<<k+m<<std::endl;
         k += m;
     }
 }

--- a/src/BinnedCorr3.cpp
+++ b/src/BinnedCorr3.cpp
@@ -226,7 +226,7 @@ void BinnedCorr3<D1,D2,D3,B>::process(const Field<D1,C>& field, bool dots)
 
 template <int D1, int D2, int D3, int B> template <int C, int M>
 void BinnedCorr3<D1,D2,D3,B>::process(const Field<D1,C>& field1, const Field<D2,C>& field2,
-                                    const Field<D3,C>& field3, bool dots)
+                                      const Field<D3,C>& field3, bool dots)
 {
     xdbg<<"_coords = "<<_coords<<std::endl;
     xdbg<<"C = "<<C<<std::endl;
@@ -306,10 +306,10 @@ void BinnedCorr3<D1,D2,D3,B>::process(const Field<D1,C>& field1, const Field<D2,
     if (dots) std::cout<<std::endl;
 }
 
-// Does all triangles with 3 points in c123
 template <int D1, int D2, int D3, int B> template <int C, int M>
 void BinnedCorr3<D1,D2,D3,B>::process3(const Cell<D1,C>* c123)
 {
+    // Does all triangles with 3 points in c123
     xdbg<<"Process3: c123 = "<<c123->getData().getPos()<<"  "<<"  "<<c123->getSize()<<"  "<<c123->getData().getN()<<std::endl;
     if (c123->getW() == 0) {
         xdbg<<"    w == 0.  return\n";
@@ -328,11 +328,11 @@ void BinnedCorr3<D1,D2,D3,B>::process3(const Cell<D1,C>* c123)
     process21<true,C,M>(c123->getRight(),c123->getLeft());
 }
 
-// Does all triangles with two points in c12 and 3rd point in c3
-// This version is allowed to swap the positions of points 1,2,3
 template <int D1, int D2, int D3, int B> template <bool sort, int C, int M>
 void BinnedCorr3<D1,D2,D3,B>::process21(const Cell<D1,C>* c12, const Cell<D3,C>* c3)
 {
+    // Does all triangles with two points in c12 and 3rd point in c3
+    // This version is allowed to swap the positions of points 1,2,3
     xdbg<<"Process21: c12 = "<<c12->getData().getPos()<<"  "<<"  "<<c12->getSize()<<"  "<<c12->getData().getN()<<std::endl;
     xdbg<<"           c3  = "<<c3->getData().getPos()<<"  "<<"  "<<c3->getSize()<<"  "<<c3->getData().getN()<<std::endl;
 
@@ -690,12 +690,12 @@ struct SortHelper<D,D,D,true,C,M>
     }
 };
 
-// Does all triangles with 1 point each in c1, c2, c3
 template <int D1, int D2, int D3, int B> template <bool sort, int C, int M>
 void BinnedCorr3<D1,D2,D3,B>::process111(
     const Cell<D1,C>* c1, const Cell<D2,C>* c2, const Cell<D3,C>* c3,
     double d1sq, double d2sq, double d3sq)
 {
+    // Does all triangles with 1 point each in c1, c2, c3
     if (c1->getW() == 0) {
         xdbg<<"    w1 == 0.  return\n";
         return;
@@ -1128,196 +1128,253 @@ extern "C" {
 #include "BinnedCorr3_C.h"
 }
 
-void* BuildNNNCorr(int bin_type,
-                   double minsep, double maxsep, int nbins, double binsize, double b,
-                   double minu, double maxu, int nubins, double ubinsize, double bu,
-                   double minv, double maxv, int nvbins, double vbinsize, double bv,
-                   double minrpar, double maxrpar,
-                   double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
-                   double* meand3, double* meanlogd3, double* meanu, double* meanv,
-                   double* weight, double* ntri)
+
+template <int D1, int D2, int D3>
+void* BuildCorr3c(int bin_type,
+                  double minsep, double maxsep, int nbins, double binsize, double b,
+                  double minu, double maxu, int nubins, double ubinsize, double bu,
+                  double minv, double maxv, int nvbins, double vbinsize, double bv,
+                  double minrpar, double maxrpar,
+                  double* zeta0, double* zeta1, double* zeta2, double* zeta3,
+                  double* zeta4, double* zeta5, double* zeta6, double* zeta7,
+                  double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
+                  double* meand3, double* meanlogd3, double* meanu, double* meanv,
+                  double* weight, double* ntri)
 {
-    dbg<<"Start BuildNNNCorr\n";
-    void* corr = static_cast<void*>(new BinnedCorr3<NData,NData,NData,Log>(
+    Assert(bin_type == Log);
+    return static_cast<void*>(new BinnedCorr3<D1,D2,D3,Log>(
             minsep, maxsep, nbins, binsize, b,
             minu, maxu, nubins, ubinsize, bu,
             minv, maxv, nvbins, vbinsize, bv,
             minrpar, maxrpar,
-            0, 0, 0, 0, 0, 0, 0, 0,
+            zeta0, zeta1, zeta2, zeta3, zeta4, zeta5, zeta6, zeta7,
             meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3, meanu, meanv,
             weight, ntri));
+}
+
+void* BuildCorr3(int d1, int d2, int d3, int bin_type,
+                 double minsep, double maxsep, int nbins, double binsize, double b,
+                 double minu, double maxu, int nubins, double ubinsize, double bu,
+                 double minv, double maxv, int nvbins, double vbinsize, double bv,
+                 double minrpar, double maxrpar,
+                 double* zeta0, double* zeta1, double* zeta2, double* zeta3,
+                 double* zeta4, double* zeta5, double* zeta6, double* zeta7,
+                 double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
+                 double* meand3, double* meanlogd3, double* meanu, double* meanv,
+                 double* weight, double* ntri)
+{
+    dbg<<"Start BuildCorr3 "<<d1<<" "<<d2<<" "<<d3<<" "<<bin_type<<std::endl;
+    void* corr=0;
+    Assert(d2 == d1);
+    Assert(d3 == d1);
+    switch(d1) {
+      case NData:
+           corr = BuildCorr3c<NData,NData,NData>(
+               bin_type, minsep, maxsep, nbins, binsize, b,
+               minu, maxu, nubins, ubinsize, bu,
+               minv, maxv, nvbins, vbinsize, bv,
+               minrpar, maxrpar,
+               zeta0, zeta1, zeta2, zeta3, zeta4, zeta5, zeta6, zeta7,
+               meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3, meanu, meanv,
+               weight, ntri);
+           break;
+      case KData:
+           corr = BuildCorr3c<KData,KData,KData>(
+               bin_type, minsep, maxsep, nbins, binsize, b,
+               minu, maxu, nubins, ubinsize, bu,
+               minv, maxv, nvbins, vbinsize, bv,
+               minrpar, maxrpar,
+               zeta0, zeta1, zeta2, zeta3, zeta4, zeta5, zeta6, zeta7,
+               meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3, meanu, meanv,
+               weight, ntri);
+           break;
+      case GData:
+           corr = BuildCorr3c<GData,GData,GData>(
+               bin_type, minsep, maxsep, nbins, binsize, b,
+               minu, maxu, nubins, ubinsize, bu,
+               minv, maxv, nvbins, vbinsize, bv,
+               minrpar, maxrpar,
+               zeta0, zeta1, zeta2, zeta3, zeta4, zeta5, zeta6, zeta7,
+               meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3, meanu, meanv,
+               weight, ntri);
+           break;
+      default:
+           Assert(false);
+    }
     xdbg<<"corr = "<<corr<<std::endl;
     return corr;
 }
 
-void* BuildKKKCorr(int bin_type,
-                   double minsep, double maxsep, int nbins, double binsize, double b,
-                   double minu, double maxu, int nubins, double ubinsize, double bu,
-                   double minv, double maxv, int nvbins, double vbinsize, double bv,
-                   double minrpar, double maxrpar,
-                   double* zeta,
-                   double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
-                   double* meand3, double* meanlogd3, double* meanu, double* meanv,
-                   double* weight, double* ntri)
+template <int D1, int D2, int D3>
+void DestroyCorr3c(void* corr, int bin_type)
 {
-    dbg<<"Start BuildKKKCorr\n";
-    void* corr = static_cast<void*>(new BinnedCorr3<KData,KData,KData,Log>(
-            minsep, maxsep, nbins, binsize, b,
-            minu, maxu, nubins, ubinsize, bu,
-            minv, maxv, nvbins, vbinsize, bv,
-            minrpar, maxrpar,
-            zeta, 0, 0, 0, 0, 0, 0, 0,
-            meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3, meanu, meanv,
-            weight, ntri));
-    xdbg<<"corr = "<<corr<<std::endl;
-    return corr;
+    Assert(bin_type == Log);  // This is the only one we have yet.
+    delete static_cast<BinnedCorr3<D1,D2,D3,Log>*>(corr);
 }
 
-
-void* BuildGGGCorr(int bin_type,
-                   double minsep, double maxsep, int nbins, double binsize, double b,
-                   double minu, double maxu, int nubins, double ubinsize, double bu,
-                   double minv, double maxv, int nvbins, double vbinsize, double bv,
-                   double minrpar, double maxrpar,
-                   double* gam0r, double* gam0i, double* gam1r, double* gam1i,
-                   double* gam2r, double* gam2i, double* gam3r, double* gam3i,
-                   double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
-                   double* meand3, double* meanlogd3, double* meanu, double* meanv,
-                   double* weight, double* ntri)
+void DestroyCorr3(void* corr, int d1, int d2, int d3, int bin_type)
 {
-    dbg<<"Start BuildGGGCorr\n";
-    void* corr = static_cast<void*>(new BinnedCorr3<GData,GData,GData,Log>(
-            minsep, maxsep, nbins, binsize, b,
-            minu, maxu, nubins, ubinsize, bu,
-            minv, maxv, nvbins, vbinsize, bv,
-            minrpar, maxrpar,
-            gam0r, gam0i, gam1r, gam1i, gam2r, gam2i, gam3r, gam3i,
-            meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3, meanu, meanv,
-            weight, ntri));
+    dbg<<"Start DestroyCorr "<<d1<<" "<<d2<<" "<<d3<<" "<<bin_type<<std::endl;
     xdbg<<"corr = "<<corr<<std::endl;
-    return corr;
+    Assert(d2 == d1); // For now don't bother with the next two layers to resolve these.
+    Assert(d3 == d1);
+    switch(d1) {
+      case NData:
+           DestroyCorr3c<NData, NData, NData>(corr, bin_type);
+           break;
+      case KData:
+           DestroyCorr3c<KData, KData, KData>(corr, bin_type);
+           break;
+      case GData:
+           DestroyCorr3c<GData, GData, GData>(corr, bin_type);
+           break;
+      default:
+           Assert(false);
+    }
 }
 
-
-void DestroyNNNCorr(void* corr, int bin_type)
+template <int M, int D, int B>
+void ProcessAuto3e(BinnedCorr3<D,D,D,B>* corr, void* field, int dots, int coords)
 {
-    dbg<<"Start DestroyNNNCorr\n";
-    xdbg<<"corr = "<<corr<<std::endl;
-    delete static_cast<BinnedCorr3<NData,NData,NData,Log>*>(corr);
+    switch(coords) {
+      case Flat:
+           Assert(MetricHelper<M>::_Flat == int(Flat));
+           corr->template process<MetricHelper<M>::_Flat,M>(
+               *static_cast<Field<D,MetricHelper<M>::_Flat>*>(field), dots);
+           break;
+      case Sphere:
+           Assert(MetricHelper<M>::_Sphere == int(Sphere));
+           corr->template process<MetricHelper<M>::_Sphere,M>(
+               *static_cast<Field<D,MetricHelper<M>::_Sphere>*>(field), dots);
+           break;
+      case ThreeD:
+           Assert(MetricHelper<M>::_ThreeD == int(ThreeD));
+           corr->template process<MetricHelper<M>::_ThreeD,M>(
+               *static_cast<Field<D,MetricHelper<M>::_ThreeD>*>(field), dots);
+           break;
+      default:
+           Assert(false);
+    }
 }
-
-void DestroyKKKCorr(void* corr, int bin_type)
-{
-    dbg<<"Start DestroyKKKCorr\n";
-    xdbg<<"corr = "<<corr<<std::endl;
-    delete static_cast<BinnedCorr3<KData,KData,KData,Log>*>(corr);
-}
-
-void DestroyGGGCorr(void* corr, int bin_type)
-{
-    dbg<<"Start DestroyGGGCorr\n";
-    xdbg<<"corr = "<<corr<<std::endl;
-    delete static_cast<BinnedCorr3<GData,GData,GData,Log>*>(corr);
-}
-
 
 template <int D, int B>
-void ProcessAuto3b(BinnedCorr3<D,D,D,B>& corr, void* field, int dots, int coord, int metric)
+void ProcessAuto3d(BinnedCorr3<D,D,D,B>* corr, void* field, int dots, int coords, int metric)
 {
-    if (coord == Flat) {
-        if (metric == Euclidean)
-            corr.template process<Flat,Euclidean>(*static_cast<Field<D,Flat>*>(field),dots);
-        else
-            Assert(false);
-    } else {
-        if (metric == Euclidean)
-            corr.template process<ThreeD,Euclidean>(*static_cast<Field<D,ThreeD>*>(field),dots);
-        else if (metric == Arc)
-            corr.template process<Sphere,Arc>(*static_cast<Field<D,Sphere>*>(field),dots);
-        else
-            Assert(false);
+    switch(metric) {
+      case Euclidean:
+           ProcessAuto3e<Euclidean>(corr, field, dots, coords);
+           break;
+      case Arc:
+           ProcessAuto3e<Arc>(corr, field, dots, coords);
+           break;
+      default:
+           Assert(false);
     }
 }
 
 template <int D>
-void ProcessAuto3(void* corr, void* field, int dots, int coord, int bin_type, int metric)
+void ProcessAuto3c(void* corr, void* field, int dots, int coords, int bin_type, int metric)
 {
-    ProcessAuto3b(*(static_cast<BinnedCorr3<D,D,D,Log>*>(corr)), field, dots, coord, metric);
+    Assert(bin_type == Log);
+    ProcessAuto3d(static_cast<BinnedCorr3<D,D,D,Log>*>(corr), field, dots, coords, metric);
 }
 
-void ProcessAutoNNN(void* corr, void* field, int dots, int coord, int bin_type, int metric)
+void ProcessAuto3(void* corr, void* field, int dots, int d, int coords, int bin_type, int metric)
 {
-    dbg<<"Start ProcessAutoNNN\n";
-    ProcessAuto3<NData>(corr, field, dots, coord, bin_type, metric);
+    dbg<<"Start ProcessAuto3 "<<d<<" "<<coords<<" "<<bin_type<<" "<<metric<<std::endl;
+
+    switch(d) {
+      case NData:
+           ProcessAuto3c<NData>(corr, field, dots, coords, bin_type, metric);
+           break;
+      case KData:
+           ProcessAuto3c<KData>(corr, field, dots, coords, bin_type, metric);
+           break;
+      case GData:
+           ProcessAuto3c<GData>(corr, field, dots, coords, bin_type, metric);
+           break;
+      default:
+           Assert(false);
+    }
 }
 
-void ProcessAutoKKK(void* corr, void* field, int dots, int coord, int bin_type, int metric)
+template <int M, int D1, int D2, int D3, int B>
+void ProcessCross3e(BinnedCorr3<D1,D2,D3,B>* corr, void* field1, void* field2, void* field3,
+                    int dots, int coords)
 {
-    dbg<<"Start ProcessAutoKKK\n";
-    ProcessAuto3<KData>(corr, field, dots, coord, bin_type, metric);
-}
-
-void ProcessAutoGGG(void* corr, void* field, int dots, int coord, int bin_type, int metric)
-{
-    dbg<<"Start ProcessAutoGGG\n";
-    ProcessAuto3<GData>(corr, field, dots, coord, bin_type, metric);
+    switch(coords) {
+      case Flat:
+           Assert(MetricHelper<M>::_Flat == int(Flat));
+           corr->template process<MetricHelper<M>::_Flat,M>(
+               *static_cast<Field<D1,MetricHelper<M>::_Flat>*>(field1),
+               *static_cast<Field<D2,MetricHelper<M>::_Flat>*>(field2),
+               *static_cast<Field<D3,MetricHelper<M>::_Flat>*>(field3), dots);
+           break;
+      case Sphere:
+           Assert(MetricHelper<M>::_Sphere == int(Sphere));
+           corr->template process<Sphere,M>(
+               *static_cast<Field<D1,MetricHelper<M>::_Sphere>*>(field1),
+               *static_cast<Field<D2,MetricHelper<M>::_Sphere>*>(field2),
+               *static_cast<Field<D3,MetricHelper<M>::_Sphere>*>(field3), dots);
+           break;
+      case ThreeD:
+           Assert(MetricHelper<M>::_ThreeD == int(ThreeD));
+           corr->template process<ThreeD,M>(
+               *static_cast<Field<D1,MetricHelper<M>::_ThreeD>*>(field1),
+               *static_cast<Field<D2,MetricHelper<M>::_ThreeD>*>(field2),
+               *static_cast<Field<D3,MetricHelper<M>::_ThreeD>*>(field3), dots);
+           break;
+      default:
+           Assert(false);
+    }
 }
 
 template <int D1, int D2, int D3, int B>
-void ProcessCross3b(BinnedCorr3<D1,D2,D3,B>& corr, void* field1, void* field2, void* field3,
-                    int dots, int coord, int metric)
+void ProcessCross3d(BinnedCorr3<D1,D2,D3,B>* corr, void* field1, void* field2, void* field3,
+                    int dots, int coords, int metric)
 {
-    if (coord == Flat) {
-        if (metric == Euclidean)
-            corr.template process<Flat,Euclidean>(
-                *static_cast<Field<D1,Flat>*>(field1),
-                *static_cast<Field<D2,Flat>*>(field2),
-                *static_cast<Field<D3,Flat>*>(field3),dots);
-        else
-            Assert(false);
-    } else {
-        if (metric == Euclidean)
-            corr.template process<ThreeD,Euclidean>(
-                *static_cast<Field<D1,ThreeD>*>(field1),
-                *static_cast<Field<D2,ThreeD>*>(field2),
-                *static_cast<Field<D3,ThreeD>*>(field3),dots);
-        else if (metric == Arc)
-            corr.template process<Sphere,Arc>(
-                *static_cast<Field<D1,Sphere>*>(field1),
-                *static_cast<Field<D2,Sphere>*>(field2),
-                *static_cast<Field<D3,Sphere>*>(field3),dots);
-        else
-            Assert(false);
+    switch(metric) {
+      case Euclidean:
+           ProcessCross3e<Euclidean>(corr, field1, field2, field3, dots, coords);
+           break;
+      case Arc:
+           ProcessCross3e<Arc>(corr, field1, field2, field3, dots, coords);
+           break;
+      default:
+           Assert(false);
     }
 }
 
 template <int D1, int D2, int D3>
-void ProcessCross3(void* corr, void* field1, void* field2, void* field3,
-                   int dots, int coord, int bin_type, int metric)
+void ProcessCross3c(void* corr, void* field1, void* field2, void* field3, int dots,
+                    int bin_type, int coords, int metric)
 {
-    ProcessCross3b(*static_cast<BinnedCorr3<D1,D2,D3,Log>*>(corr), field1, field2, field3,
-                   dots, coord, metric);
+    Assert(bin_type == Log);
+    ProcessCross3d(static_cast<BinnedCorr3<D1,D2,D3,Log>*>(corr), field1, field2, field3, dots,
+                   coords, metric);
 }
 
-void ProcessCrossNNN(void* corr, void* field1, void* field2, void* field3, int dots,
-                     int coord, int bin_type, int metric)
+void ProcessCross3(void* corr, void* field1, void* field2, void* field3, int dots,
+                   int d1, int d2, int d3, int coords, int bin_type, int metric)
 {
-    dbg<<"Start ProcessCrossNNN\n";
-    ProcessCross3<NData,NData,NData>(corr, field1, field2, field3, dots, coord, bin_type, metric);
+    dbg<<"Start ProcessCross3 "<<d1<<" "<<d2<<" "<<d3<<" "<<coords<<" "<<bin_type<<" "<<metric<<std::endl;
+
+    Assert(d2 == d1);
+    Assert(d3 == d1);
+    switch(d1) {
+      case NData:
+           ProcessCross3c<NData,NData,NData>(corr, field1, field2, field3, dots,
+                                             bin_type, coords, metric);
+           break;
+      case KData:
+           ProcessCross3c<KData,KData,KData>(corr, field1, field2, field3, dots,
+                                             bin_type, coords, metric);
+           break;
+      case GData:
+           ProcessCross3c<GData,GData,GData>(corr, field1, field2, field3, dots,
+                                             bin_type, coords, metric);
+           break;
+      default:
+           Assert(false);
+    }
 }
-
-void ProcessCrossKKK(void* corr, void* field1, void* field2, void* field3, int dots,
-                     int coord, int bin_type, int metric)
-{
-    dbg<<"Start ProcessCrossKKK\n";
-    ProcessCross3<KData,KData,KData>(corr, field1, field2, field3, dots, coord, bin_type, metric);
-}
-
-void ProcessCrossGGG(void* corr, void* field1, void* field2, void* field3, int dots,
-                     int coord, int bin_type, int metric)
-{
-    dbg<<"Start ProcessCrossGGG\n";
-    ProcessCross3<GData,GData,GData>(corr, field1, field2, field3, dots, coord, bin_type, metric);
-}
-
-

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -238,13 +238,11 @@ size_t select_random(size_t lo, size_t hi)
     if (lo == hi) {
         return lo;
     } else {
-        // Get a random number between 0.1 and 0.9
+        // Get a random number between 0 and 1
         double r = rand();
         r /= RAND_MAX;
-        r *= 0.8;
-        r += 0.1;
         size_t mid = size_t(r * (hi-lo+1)) + lo;
-        if (mid > hi) mid = hi;  // Just in case rand() == RAND_MAX
+        if (mid > hi) mid = hi;  // Just in case
         return mid;
     }
 }
@@ -294,8 +292,8 @@ size_t SplitData(
                // The code for RANDOM is same as MEDIAN except for the next line.
                // Note: The lo and hi values are slightly subtle.  We want to make sure if there
                // are only two values, we actually split.  So if start=1, end=3, the only possible
-               // result should be mid=2.  Otherwise, we want roughly 1/4 and 3/4 of the span.
-               mid = select_random(end-3*(end-start)/4,start+3*(end-start)/4);
+               // result should be mid=2.  Otherwise, we want roughly 2/5 and 3/5 of the span.
+               mid = select_random(end-3*(end-start)/5,start+3*(end-start)/5);
 
                typename std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >::iterator middle =
                    vdata.begin()+mid;

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -342,6 +342,7 @@ Cell<D,C>::Cell(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
         _data = vdata[start].first;
         vdata[start].first = 0; // Make sure calling routine doesn't delete this one!
         _info = vdata[start].second;  // This only copies as a LeafInfo, so throws away wpos.
+        xdbg<<"_info.index = "<<_info.index<<"  "<<vdata[start].second.index<<std::endl;
     } else {
         _data = new CellData<D,C>(vdata,start,end);
         _data->finishAverages(vdata,start,end);
@@ -386,9 +387,16 @@ void Cell<D,C>::finishInit(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >&
         }
     } else {
         _size = _sizesq = 0.;
-        Assert(_data->getN() > 1);
-        _listinfo.indices = new std::vector<long>(end-start);
-        for (int i=start; i<end; ++i) (*_listinfo.indices)[i-start] = vdata[i].second.index;
+        if (_data->getN() == 1) {
+            _info = vdata[start].second;
+            xdbg<<"_info.index = "<<_info.index<<"  "<<vdata[start].second.index<<std::endl;
+        } else {
+            _listinfo.indices = new std::vector<long>(end-start);
+            for (int i=start; i<end; ++i) {
+                xdbg<<"Set indices["<<i-start<<"] = "<<vdata[i].second.index<<std::endl;
+                (*_listinfo.indices)[i-start] = vdata[i].second.index;
+            }
+        }
     }
 }
 
@@ -425,7 +433,6 @@ std::vector<const Cell<D,C>*> Cell<D,C>::getAllLeaves() const
         temp = _right->getAllLeaves();
         ret.insert(ret.end(),temp.begin(),temp.end());
     } else {
-        Assert(!_right);
         ret.push_back(this);
     }
     return ret;

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -402,6 +402,19 @@ long Cell<D,C>::countLeaves() const
 }
 
 template <int D, int C>
+bool Cell<D,C>::includesIndex(long index) const
+{
+    if (_left) {
+        return _left->includesIndex(index) || _right->includesIndex(index);
+    } else if (getN() == 1) {
+        return _info.index == index;
+    } else {
+        const std::vector<long>& indices = *_listinfo.indices;
+        return std::find(indices.begin(), indices.end(), index) != indices.end();
+    }
+}
+
+template <int D, int C>
 std::vector<const Cell<D,C>*> Cell<D,C>::getAllLeaves() const
 {
     std::vector<const Cell<D,C>*> ret;

--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -308,355 +308,180 @@ extern "C" {
 #include "Field_C.h"
 }
 
-void* BuildGFieldFlat(double* x, double* y, double* g1, double* g2,
-                      double* w, double* wpos, long nobj,
-                      double minsize, double maxsize,
-                      int sm_int, int maxtop)
+template <int D>
+void* BuildField(double* x, double* y, double* z, double* g1, double* g2, double* k,
+                 double* w, double* wpos, long nobj,
+                 double minsize, double maxsize,
+                 int sm_int, int maxtop, int coords)
 {
-    dbg<<"Start BuildGFieldFlat\n";
-    // Use w for k in this call to make sure k[i] is valid and won't seg fault.
-    // The actual value of k[i] is ignored.
-    Field<GData,Flat>* field = new Field<GData,Flat>(x, y, 0, g1, g2, w,
-                                                     w, wpos, nobj,
-                                                     minsize, maxsize,
-                                                     sm_int, maxtop);
+    dbg<<"Start BuildField "<<D<<"  "<<coords<<std::endl;
+    void* field=0;
+    switch(coords) {
+      case Flat:
+           // Note: Use w for k, since we access k[i], even though value will be ignored.
+           field = static_cast<void*>(new Field<D,Flat>(x, y, 0, g1, g2, k,
+                                                        w, wpos, nobj,
+                                                        minsize, maxsize,
+                                                        sm_int, maxtop));
+           break;
+      case Sphere:
+           field = static_cast<void*>(new Field<D,Sphere>(x, y, z, g1, g2, k,
+                                                          w, wpos, nobj,
+                                                          minsize, maxsize,
+                                                          sm_int, maxtop));
+           break;
+      case ThreeD:
+           field = static_cast<void*>(new Field<D,ThreeD>(x, y, z, g1, g2, k,
+                                                          w, wpos, nobj,
+                                                          minsize, maxsize,
+                                                          sm_int, maxtop));
+           break;
+    }
     xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildGField3D(double* x, double* y, double* z, double* g1, double* g2,
-                    double* w, double* wpos, long nobj,
-                    double minsize, double maxsize,
-                    int sm_int, int maxtop)
-{
-    dbg<<"Start BuildGField3D\n";
-    Field<GData,ThreeD>* field = new Field<GData,ThreeD>(x, y, z, g1, g2, w,
-                                                         w, wpos, nobj,
-                                                         minsize, maxsize,
-                                                         sm_int, maxtop);
-    dbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildGFieldSphere(double* x, double* y, double* z, double* g1, double* g2,
-                        double* w, double* wpos, long nobj,
-                        double minsize, double maxsize,
-                        int sm_int, int maxtop)
-{
-    dbg<<"Start BuildGField3D\n";
-    Field<GData,Sphere>* field = new Field<GData,Sphere>(x, y, z, g1, g2, w,
-                                                         w, wpos, nobj,
-                                                         minsize, maxsize,
-                                                         sm_int, maxtop);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
+    return field;
 }
 
-void* BuildKFieldFlat(double* x, double* y, double* k,
-                      double* w, double* wpos, long nobj,
-                      double minsize, double maxsize,
-                      int sm_int, int maxtop)
+void* BuildGField(double* x, double* y, double* z, double* g1, double* g2,
+                  double* w, double* wpos, long nobj,
+                  double minsize, double maxsize,
+                  int sm_int, int maxtop, int coords)
 {
-    dbg<<"Start BuildKFieldFlat\n";
-    Field<KData,Flat>* field = new Field<KData,Flat>(x, y, 0, w, w, k,
-                                                     w, wpos, nobj,
-                                                     minsize, maxsize,
-                                                     sm_int, maxtop);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildKField3D(double* x, double* y, double* z, double* k,
-                    double* w, double* wpos, long nobj,
-                    double minsize, double maxsize,
-                    int sm_int, int maxtop)
-{
-    dbg<<"Start BuildKField3D\n";
-    Field<KData,ThreeD>* field = new Field<KData,ThreeD>(x, y, z, w, w, k,
-                                                         w, wpos, nobj,
-                                                         minsize, maxsize,
-                                                         sm_int, maxtop);
-    dbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildKFieldSphere(double* x, double* y, double* z, double* k,
-                        double* w, double* wpos, long nobj,
-                        double minsize, double maxsize,
-                        int sm_int, int maxtop)
-{
-    dbg<<"Start BuildKField3D\n";
-    Field<KData,Sphere>* field = new Field<KData,Sphere>(x, y, z, w, w, k,
-                                                         w, wpos, nobj,
-                                                         minsize, maxsize,
-                                                         sm_int, maxtop);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-
-void* BuildNFieldFlat(double* x, double* y,
-                      double* w, double* wpos, long nobj,
-                      double minsize, double maxsize,
-                      int sm_int, int maxtop)
-{
-    dbg<<"Start BuildNFieldFlat\n";
-    Field<NData,Flat>* field = new Field<NData,Flat>(x, y, 0, w, w, w,
-                                                     w, wpos, nobj,
-                                                     minsize, maxsize,
-                                                     sm_int, maxtop);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildNField3D(double* x, double* y, double* z,
-                    double* w, double* wpos, long nobj,
-                    double minsize, double maxsize,
-                    int sm_int, int maxtop)
-{
-    dbg<<"Start BuildNField3D\n";
-    Field<NData,ThreeD>* field = new Field<NData,ThreeD>(x, y, z, w, w, w,
-                                                         w, wpos, nobj,
-                                                         minsize, maxsize,
-                                                         sm_int, maxtop);
-    dbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildNFieldSphere(double* x, double* y, double* z,
-                        double* w, double* wpos, long nobj,
-                        double minsize, double maxsize,
-                        int sm_int, int maxtop)
-{
-    dbg<<"Start BuildNField3D\n";
-    Field<NData,Sphere>* field = new Field<NData,Sphere>(x, y, z, w, w, w,
-                                                         w, wpos, nobj,
-                                                         minsize, maxsize,
-                                                         sm_int, maxtop);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-
-void DestroyGFieldFlat(void* field)
-{
-    dbg<<"Start DestroyGFieldFlat\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<GData,Flat>*>(field);
-}
-void DestroyGField3D(void* field)
-{
-    dbg<<"Start DestroyGField3D\n";
-    dbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<GData,ThreeD>*>(field);
-}
-void DestroyGFieldSphere(void* field)
-{
-    dbg<<"Start DestroyGField3D\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<GData,Sphere>*>(field);
-}
-
-void DestroyKFieldFlat(void* field)
-{
-    dbg<<"Start DestroyKFieldFlat\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<KData,Flat>*>(field);
-}
-void DestroyKField3D(void* field)
-{
-    dbg<<"Start DestroyKField3D\n";
-    dbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<KData,ThreeD>*>(field);
-}
-void DestroyKFieldSphere(void* field)
-{
-    dbg<<"Start DestroyKField3D\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<KData,Sphere>*>(field);
-}
-
-void DestroyNFieldFlat(void* field)
-{
-    dbg<<"Start DestroyNFieldFlat\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<NData,Flat>*>(field);
-}
-void DestroyNField3D(void* field)
-{
-    dbg<<"Start DestroyNField3D\n";
-    dbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<NData,ThreeD>*>(field);
-}
-void DestroyNFieldSphere(void* field)
-{
-    dbg<<"Start DestroyNField3D\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<Field<NData,Sphere>*>(field);
+    // Note: Use w for k, since we access k[i], even though value will be ignored.
+    return BuildField<GData>(x,y,z, g1,g2,w, w,wpos,nobj, minsize,maxsize, sm_int,maxtop,coords);
 }
 
 
-void* BuildGSimpleFieldFlat(double* x, double* y, double* g1, double* g2,
-                            double* w, double* wpos, long nobj)
+void* BuildKField(double* x, double* y, double* z, double* k,
+                  double* w, double* wpos, long nobj,
+                  double minsize, double maxsize,
+                  int sm_int, int maxtop, int coords)
 {
-    dbg<<"Start BuildGSimpleFieldFlat\n";
-    // Use w for k in this call to make sure k[i] is valid and won't seg fault.
-    // The actual value of k[i] is ignored.
-    SimpleField<GData,Flat>* field = new SimpleField<GData,Flat>(x, y, 0, g1, g2, w,
-                                                                 w, wpos, nobj);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildGSimpleField3D(double* x, double* y, double* z, double* g1, double* g2,
-                          double* w, double* wpos, long nobj)
-{
-    dbg<<"Start BuildGSimpleField3D\n";
-    SimpleField<GData,ThreeD>* field = new SimpleField<GData,ThreeD>(
-        x, y, z, g1, g2, w,
-        w, wpos, nobj);
-    dbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildGSimpleFieldSphere(double* x, double* y, double* z, double* g1, double* g2,
-                              double* w, double* wpos, long nobj)
-{
-    dbg<<"Start BuildGSimpleField3D\n";
-    SimpleField<GData,Sphere>* field = new SimpleField<GData,Sphere>(
-        x, y, z, g1, g2, w,
-        w, wpos, nobj);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
+    // Note: Use w for g1,g2, since we access g1[i],g2[i] even though values are ignored.
+    return BuildField<KData>(x,y,z, w,w,k, w,wpos,nobj, minsize,maxsize, sm_int,maxtop,coords);
 }
 
-void* BuildKSimpleFieldFlat(double* x, double* y, double* k,
-                            double* w, double* wpos, long nobj)
+void* BuildNField(double* x, double* y, double* z,
+                  double* w, double* wpos, long nobj,
+                  double minsize, double maxsize,
+                  int sm_int, int maxtop, int coords)
 {
-    dbg<<"Start BuildKSimpleFieldFlat\n";
-    SimpleField<KData,Flat>* field = new SimpleField<KData,Flat>(
-        x, y, 0, w, w, k,
-        w, wpos, nobj);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildKSimpleField3D(double* x, double* y, double* z, double* k,
-                          double* w, double* wpos, long nobj)
-{
-    dbg<<"Start BuildKSimpleField3D\n";
-    SimpleField<KData,ThreeD>* field = new SimpleField<KData,ThreeD>(
-        x, y, z, w, w, k,
-        w, wpos, nobj);
-    dbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildKSimpleFieldSphere(double* x, double* y, double* z, double* k,
-                              double* w, double* wpos, long nobj)
-{
-    dbg<<"Start BuildKSimpleField3D\n";
-    SimpleField<KData,Sphere>* field = new SimpleField<KData,Sphere>(
-        x, y, z, w, w, k,
-        w, wpos, nobj);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
+    // Note: Use w for g1,g2,k for same reasons as above.
+    return BuildField<NData>(x,y,z, w,w,w, w,wpos,nobj, minsize,maxsize, sm_int,maxtop,coords);
 }
 
-void* BuildNSimpleFieldFlat(double* x, double* y,
-                            double* w, double* wpos, long nobj)
+template <int D>
+void DestroyField(void* field, int coords)
 {
-    dbg<<"Start BuildNSimpleFieldFlat\n";
-    SimpleField<NData,Flat>* field = new SimpleField<NData,Flat>(
-        x, y, 0, w, w, w,
-        w, wpos, nobj);
+    dbg<<"Start DestroyField "<<D<<"  "<<coords<<std::endl;
     xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildNSimpleField3D(double* x, double* y, double* z,
-                          double* w, double* wpos, long nobj)
-{
-    dbg<<"Start BuildNSimpleField3D\n";
-    SimpleField<NData,ThreeD>* field = new SimpleField<NData,ThreeD>(
-        x, y, z, w, w, w,
-        w, wpos, nobj);
-    dbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
-}
-void* BuildNSimpleFieldSphere(double* x, double* y, double* z,
-                              double* w, double* wpos, long nobj)
-{
-    dbg<<"Start BuildNSimpleField3D\n";
-    SimpleField<NData,Sphere>* field = new SimpleField<NData,Sphere>(
-        x, y, z, w, w, w,
-        w, wpos, nobj);
-    xdbg<<"field = "<<field<<std::endl;
-    return static_cast<void*>(field);
+    switch(coords) {
+      case Flat:
+           delete static_cast<Field<D,Flat>*>(field);
+           break;
+      case Sphere:
+           delete static_cast<Field<D,Sphere>*>(field);
+           break;
+      case ThreeD:
+           delete static_cast<Field<D,ThreeD>*>(field);
+           break;
+    }
 }
 
-void DestroyGSimpleFieldFlat(void* field)
+void DestroyGField(void* field, int coords)
+{ DestroyField<GData>(field, coords); }
+
+void DestroyKField(void* field, int coords)
+{ DestroyField<KData>(field, coords); }
+
+void DestroyNField(void* field, int coords)
+{ DestroyField<NData>(field, coords); }
+
+template <int D>
+void* BuildSimpleField(double* x, double* y, double* z, double* g1, double* g2, double* k,
+                       double* w, double* wpos, long nobj, int coords)
 {
-    dbg<<"Start DestroyGSimpleFieldFlat\n";
+    dbg<<"Start BuildSimpleField "<<D<<"  "<<coords<<std::endl;
+    void* field=0;
+    switch (coords) {
+      case Flat:
+           field = static_cast<void*>(new SimpleField<D,Flat>(x, y, 0, g1, g2, k,
+                                                              w, wpos, nobj));
+           break;
+      case Sphere:
+           field = static_cast<void*>(new SimpleField<D,Sphere>(x, y, z, g1, g2, k,
+                                                                w, wpos, nobj));
+           break;
+      case ThreeD:
+           field = static_cast<void*>(new SimpleField<D,ThreeD>(x, y, z, g1, g2, k,
+                                                                w, wpos, nobj));
+           break;
+    }
     xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<GData,Flat>*>(field);
-}
-void DestroyGSimpleField3D(void* field)
-{
-    dbg<<"Start DestroyGSimpleField3D\n";
-    dbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<GData,ThreeD>*>(field);
-}
-void DestroyGSimpleFieldSphere(void* field)
-{
-    dbg<<"Start DestroyGSimpleField3D\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<GData,Sphere>*>(field);
+    return field;
 }
 
-void DestroyKSimpleFieldFlat(void* field)
+void* BuildGSimpleField(double* x, double* y, double* z, double* g1, double* g2,
+                        double* w, double* wpos, long nobj, int coords)
+{ return BuildSimpleField<GData>(x,y,z,g1,g2,w,w,wpos,nobj,coords); }
+
+void* BuildKSimpleField(double* x, double* y, double* z, double* k,
+                        double* w, double* wpos, long nobj, int coords)
+{ return BuildSimpleField<KData>(x,y,z,w,w,k,w,wpos,nobj,coords); }
+
+void* BuildNSimpleField(double* x, double* y, double* z,
+                        double* w, double* wpos, long nobj, int coords)
+{ return BuildSimpleField<NData>(x,y,z,w,w,w,w,wpos,nobj,coords); }
+
+template <int D>
+void DestroySimpleField(void* field, int coords)
 {
-    dbg<<"Start DestroyKSimpleFieldFlat\n";
+    dbg<<"Start DestroySimpleField "<<D<<"  "<<coords<<std::endl;
     xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<KData,Flat>*>(field);
-}
-void DestroyKSimpleField3D(void* field)
-{
-    dbg<<"Start DestroyKSimpleField3D\n";
-    dbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<KData,ThreeD>*>(field);
-}
-void DestroyKSimpleFieldSphere(void* field)
-{
-    dbg<<"Start DestroyKSimpleField3D\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<KData,Sphere>*>(field);
+    switch(coords) {
+      case Flat:
+           delete static_cast<SimpleField<D,Flat>*>(field);
+           break;
+      case Sphere:
+           delete static_cast<SimpleField<D,Sphere>*>(field);
+           break;
+      case ThreeD:
+           delete static_cast<SimpleField<D,ThreeD>*>(field);
+           break;
+    }
 }
 
-void DestroyNSimpleFieldFlat(void* field)
+void DestroyGSimpleField(void* field, int coords)
+{ DestroySimpleField<GData>(field, coords); }
+
+void DestroyKSimpleField(void* field, int coords)
+{ DestroySimpleField<KData>(field, coords); }
+
+void DestroyNSimpleField(void* field, int coords)
+{ DestroySimpleField<NData>(field, coords); }
+
+template <int D>
+long GetNTopLevel(void* field, int coords)
 {
-    dbg<<"Start DestroyNSimpleFieldFlat\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<NData,Flat>*>(field);
-}
-void DestroyNSimpleField3D(void* field)
-{
-    dbg<<"Start DestroyNSimpleField3D\n";
-    dbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<NData,ThreeD>*>(field);
-}
-void DestroyNSimpleFieldSphere(void* field)
-{
-    dbg<<"Start DestroyNSimpleField3D\n";
-    xdbg<<"field = "<<field<<std::endl;
-    delete static_cast<SimpleField<NData,Sphere>*>(field);
+    switch(coords) {
+      case Flat:
+           return static_cast<Field<D,Flat>*>(field)->getNTopLevel();
+           break;
+      case Sphere:
+           return static_cast<Field<D,Sphere>*>(field)->getNTopLevel();
+           break;
+      case ThreeD:
+           return static_cast<Field<D,ThreeD>*>(field)->getNTopLevel();
+           break;
+    }
+    return 0;  // Can't get here, but saves a compiler warning
 }
 
-long GFieldFlatGetNTopLevel(void* field)
-{ return static_cast<Field<GData,Flat>*>(field)->getNTopLevel(); }
-long GField3DGetNTopLevel(void* field)
-{ return static_cast<Field<GData,ThreeD>*>(field)->getNTopLevel(); }
-long GFieldSphereGetNTopLevel(void* field)
-{ return static_cast<Field<GData,Sphere>*>(field)->getNTopLevel(); }
+long GFieldGetNTopLevel(void* field, int coords)
+{ return GetNTopLevel<GData>(field, coords); }
 
-long KFieldFlatGetNTopLevel(void* field)
-{ return static_cast<Field<KData,Flat>*>(field)->getNTopLevel(); }
-long KField3DGetNTopLevel(void* field)
-{ return static_cast<Field<KData,ThreeD>*>(field)->getNTopLevel(); }
-long KFieldSphereGetNTopLevel(void* field)
-{ return static_cast<Field<KData,Sphere>*>(field)->getNTopLevel(); }
+long KFieldGetNTopLevel(void* field, int coords)
+{ return GetNTopLevel<KData>(field, coords); }
 
-long NFieldFlatGetNTopLevel(void* field)
-{ return static_cast<Field<NData,Flat>*>(field)->getNTopLevel(); }
-long NField3DGetNTopLevel(void* field)
-{ return static_cast<Field<NData,ThreeD>*>(field)->getNTopLevel(); }
-long NFieldSphereGetNTopLevel(void* field)
-{ return static_cast<Field<NData,Sphere>*>(field)->getNTopLevel(); }
+long NFieldGetNTopLevel(void* field, int coords)
+{ return GetNTopLevel<NData>(field, coords); }
 

--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -455,7 +455,7 @@ void DestroyNField(void* field, int coords)
 { DestroyField<NData>(field, coords); }
 
 template <int D>
-long GetNTopLevel(void* field, int coords)
+long FieldGetNTopLevel1(void* field, int coords)
 {
     switch(coords) {
       case Flat:
@@ -471,17 +471,24 @@ long GetNTopLevel(void* field, int coords)
     return 0;  // Can't get here, but saves a compiler warning
 }
 
-long GFieldGetNTopLevel(void* field, int coords)
-{ return GetNTopLevel<GData>(field, coords); }
-
-long KFieldGetNTopLevel(void* field, int coords)
-{ return GetNTopLevel<KData>(field, coords); }
-
-long NFieldGetNTopLevel(void* field, int coords)
-{ return GetNTopLevel<NData>(field, coords); }
+long FieldGetNTopLevel(void* field, int d, int coords)
+{
+    switch(d) {
+      case NData:
+        return FieldGetNTopLevel1<NData>(field, coords);
+        break;
+      case KData:
+        return FieldGetNTopLevel1<KData>(field, coords);
+        break;
+      case GData:
+        return FieldGetNTopLevel1<GData>(field, coords);
+        break;
+    }
+    return 0;  // Can't get here, but saves a compiler warning
+}
 
 template <int D>
-long CountNear(void* field, double x, double y, double z, double sep, int coords)
+long FieldCountNear1(void* field, double x, double y, double z, double sep, int coords)
 {
     switch(coords) {
       case Flat:
@@ -497,14 +504,21 @@ long CountNear(void* field, double x, double y, double z, double sep, int coords
     return 0;  // Can't get here, but saves a compiler warning
 }
 
-long GFieldCountNear(void* field, double x, double y, double z, double sep, int coords)
-{ return CountNear<GData>(field, x, y, z, sep, coords); }
-
-long KFieldCountNear(void* field, double x, double y, double z, double sep, int coords)
-{ return CountNear<KData>(field, x, y, z, sep, coords); }
-
-long NFieldCountNear(void* field, double x, double y, double z, double sep, int coords)
-{ return CountNear<NData>(field, x, y, z, sep, coords); }
+long FieldCountNear(void* field, double x, double y, double z, double sep, int d, int coords)
+{
+    switch(d) {
+      case NData:
+           return FieldCountNear1<NData>(field, x, y, z, sep, coords);
+           break;
+      case KData:
+           return FieldCountNear1<KData>(field, x, y, z, sep, coords);
+           break;
+      case GData:
+           return FieldCountNear1<GData>(field, x, y, z, sep, coords);
+           break;
+    }
+    return 0;  // Can't get here, but saves a compiler warning
+}
 
 template <int D>
 void* BuildSimpleField(double* x, double* y, double* z, double* g1, double* g2, double* k,

--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -19,15 +19,6 @@
 #include "Cell.h"
 #include "dbg.h"
 
-// To turn on debugging statements, set dbgout to &std::cerr or some other stream.
-std::ostream* dbgout=0;
-//std::ostream* dbgout=&std::cerr;
-// For even more debugging, set this to true.
-bool XDEBUG = false;
-// Note: You will also need to compile with
-//     python setup.py build --debug`
-//     python setup.py install
-
 // This function just works on the top level data to figure out which data goes into
 // each top-level Cell.  It is building up the top_* vectors, which can then be used
 // to build the actual Cells.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -717,7 +717,6 @@ def test_field():
     # when doing this manually.  The real functionality tests of using the fields are
     # all elsewhere.
 
-    print('Start test_field')
     ngal = 2000
     s = 10.
     np.random.seed(8675309)
@@ -750,6 +749,9 @@ def test_field():
     nfield2b = cat2.getNField(0.01, 1)
     nfield3b = cat3.getNField(1,300, logger=logger)
     t2 = time.time()
+    assert cat1.nfields.count == 1
+    assert cat2.nfields.count == 1
+    assert cat3.nfields.count == 1
     # The second time, they should already be made and taken from the cache, so much faster.
     print('nfield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
@@ -763,6 +765,9 @@ def test_field():
     gfield2b = cat2.getGField(0.01, 1)
     gfield3b = cat3.getGField(1,300, logger=logger)
     t2 = time.time()
+    assert cat1.gfields.count == 1
+    assert cat2.gfields.count == 1
+    assert cat3.gfields.count == 1
     print('gfield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
 
@@ -775,6 +780,9 @@ def test_field():
     kfield2b = cat2.getKField(0.01, 1)
     kfield3b = cat3.getKField(1,300, logger=logger)
     t2 = time.time()
+    assert cat1.kfields.count == 1
+    assert cat2.kfields.count == 1
+    assert cat3.kfields.count == 1
     print('kfield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
 
@@ -787,6 +795,9 @@ def test_field():
     nsimplefield2b = cat2.getNSimpleField()
     nsimplefield3b = cat3.getNSimpleField(logger=logger)
     t2 = time.time()
+    assert cat1.nsimplefields.count == 1
+    assert cat2.nsimplefields.count == 1
+    assert cat3.nsimplefields.count == 1
     print('nsimplefield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
 
@@ -799,6 +810,9 @@ def test_field():
     gsimplefield2b = cat2.getGSimpleField()
     gsimplefield3b = cat3.getGSimpleField(logger=logger)
     t2 = time.time()
+    assert cat1.gsimplefields.count == 1
+    assert cat2.gsimplefields.count == 1
+    assert cat3.gsimplefields.count == 1
     print('gsimplefield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
 
@@ -811,17 +825,26 @@ def test_field():
     ksimplefield2b = cat2.getKSimpleField()
     ksimplefield3b = cat3.getKSimpleField(logger=logger)
     t2 = time.time()
+    assert cat1.ksimplefields.count == 1
+    assert cat2.ksimplefields.count == 1
+    assert cat3.ksimplefields.count == 1
     print('ksimplefield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
 
     # By default, only one is saved.  Check resize_cache option.
     cat1.resize_cache(3)
-    assert len(cat1.nfields.cache) == 3
-    assert len(cat1.kfields.cache) == 3
-    assert len(cat1.gfields.cache) == 3
-    assert len(cat1.nsimplefields.cache) == 3
-    assert len(cat1.ksimplefields.cache) == 3
-    assert len(cat1.gsimplefields.cache) == 3
+    assert cat1.nfields.size == 3
+    assert cat1.kfields.size == 3
+    assert cat1.gfields.size == 3
+    assert cat1.nsimplefields.size == 3
+    assert cat1.ksimplefields.size == 3
+    assert cat1.gsimplefields.size == 3
+    assert cat1.nfields.count == 1
+    assert cat1.kfields.count == 1
+    assert cat1.gfields.count == 1
+    assert cat1.nsimplefields.count == 1
+    assert cat1.ksimplefields.count == 1
+    assert cat1.gsimplefields.count == 1
 
     t0 = time.time()
     nfield1 = cat1.getNField(1,1000)
@@ -832,6 +855,7 @@ def test_field():
     nfield2b = cat1.getNField(0.01, 1)
     nfield3b = cat1.getNField(1,300, logger=logger)
     t2 = time.time()
+    assert cat1.nfields.count == 3
     print('after resize(3) nfield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
     assert nfield1b is nfield1
@@ -846,11 +870,17 @@ def test_field():
     assert nfield1 not in [v[3] for v in cat1.nfields.cache.values()]
     assert nfield2 not in [v[3] for v in cat1.nfields.cache.values()]
     assert nfield3 not in [v[3] for v in cat1.nfields.cache.values()]
+    assert cat1.nfields.count == 0
+    assert cat1.gfields.count == 0
+    assert cat1.kfields.count == 0
+    assert cat1.nsimplefields.count == 0
+    assert cat1.gsimplefields.count == 0
+    assert cat1.ksimplefields.count == 0
 
     # Can also resize to 0
-    print('before resize_cache(0)')
     cat1.resize_cache(0)
-    print('after resize_cache(0)')
+    assert cat1.nfields.count == 0
+    assert cat1.nfields.size == 0
     t0 = time.time()
     nfield1 = cat1.getNField(1,1000)
     nfield2 = cat1.getNField(0.01, 1)
@@ -862,12 +892,7 @@ def test_field():
     t2 = time.time()
     # This time, not much time difference.
     print('after resize(0) nfield: ',t1-t0,t2-t1)
-    assert len(cat1.nfields.cache) == 0
-    assert len(cat1.kfields.cache) == 0
-    assert len(cat1.gfields.cache) == 0
-    assert len(cat1.nsimplefields.cache) == 0
-    assert len(cat1.ksimplefields.cache) == 0
-    assert len(cat1.gsimplefields.cache) == 0
+    assert cat1.nfields.count == 0
     assert nfield1b is not nfield1
     assert nfield2b is not nfield2
     assert nfield3b is not nfield3
@@ -877,28 +902,36 @@ def test_field():
     assert nfield1b not in [v[3] for v in cat1.nfields.cache.values()]
     assert nfield2b not in [v[3] for v in cat1.nfields.cache.values()]
     assert nfield3b not in [v[3] for v in cat1.nfields.cache.values()]
-    print('done')
 
 
 def test_lru():
-    print('Start test_lru')
     f = lambda x: x+1
     size = 10
     # Test correct size cache gets created
     cache = treecorr.util.LRU_Cache(f, maxsize=size)
     assert len(cache.cache) == size
+    assert cache.size == size
+    assert cache.count == 0
     # Insert f(0) = 1 into cache and check that we can get it back
     assert cache(0) == f(0)
+    assert cache.size == size
+    assert cache.count == 1
     assert cache(0) == f(0)
+    assert cache.size == size
+    assert cache.count == 1
 
     # Manually manipulate cache so we can check for hit
     cache.cache[(0,)][3] = 2
+    cache.count += 1
     assert cache(0) == 2
+    assert cache.count == 2
 
     # Insert (and check) 1 thru size into cache.  This should bump out the (0,).
     for i in range(1, size+1):
         assert cache(i) == f(i)
     assert (0,) not in cache.cache
+    assert cache.size == size
+    assert cache.count == size
 
     # Test non-destructive cache expansion
     newsize = 20
@@ -906,19 +939,27 @@ def test_lru():
     for i in range(1, size+1):
         assert (i,) in cache.cache
         assert cache(i) == f(i)
-    assert len(cache.cache) == 20
+    assert len(cache.cache) == newsize
+    assert cache.size == newsize
+    assert cache.count == size
 
     # Add new items until the (1,) gets bumped
     for i in range(size+1, newsize+2):
         assert cache(i) == f(i)
     assert (1,) not in cache.cache
+    assert cache.size == newsize
+    assert cache.count == newsize
 
     # "Resize" to same size does nothing.
     cache.resize(newsize)
-    assert len(cache.cache) == 20
+    assert len(cache.cache) == newsize
+    assert cache.size == newsize
+    assert cache.count == newsize
     assert (1,) not in cache.cache
     for i in range(2, newsize+2):
         assert (i,) in cache.cache
+    assert cache.size == newsize
+    assert cache.count == newsize
 
     # Test mostly non-destructive cache contraction.
     # Already bumped (0,) and (1,), so (2,) should be the first to get bumped
@@ -933,15 +974,18 @@ def test_lru():
     print('cache.root = ',cache.root)
     assert cache.root[0] == cache.root
     assert cache.root[1] == cache.root
+    assert cache.size == 0
+    assert cache.count == 0
     for i in range(10):
         assert cache(i) == f(i)
     print('=> cache.cache = ',cache.cache)
     print('=> cache.root = ',cache.root)
     assert cache.root[0] == cache.root
     assert cache.root[1] == cache.root
+    assert cache.size == 0
+    assert cache.count == 0
 
     assert_raises(ValueError, cache.resize, -20)
-    print('Done test_lru')
 
 
 if __name__ == '__main__':

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -110,8 +110,8 @@ def test_ascii():
     cat4 = treecorr.Catalog(file_name, config)
     np.testing.assert_almost_equal(cat4.w[flags < 16], 1.)
     np.testing.assert_almost_equal(cat4.w[flags >= 16], 0.)
-    config['w_col'] = 8  # Put it back for later.
-    config['wpos_col'] = 11  # Put them back for later.
+    config['w_col'] = 8  # Put them back for later.
+    config['wpos_col'] = 11
 
     # Check different units for x,y
     config['x_units'] = 'arcsec'
@@ -227,10 +227,13 @@ def test_ascii():
     np.testing.assert_almost_equal(cat10.w, w)
 
     # And if there is wpos, but no w, copy over the zeros, but not the other values
-    cat10 = treecorr.Catalog(file_name, config, w_col=0, wpos_col=11, flag_col=0)
+    with CaptureLog() as cl:
+        cat10 = treecorr.Catalog(file_name, config, w_col=0, wpos_col=11, flag_col=0,
+                                 logger=cl.logger)
     np.testing.assert_almost_equal(cat10.wpos, wpos)
     np.testing.assert_almost_equal(cat10.w[wpos==0], 0)
     np.testing.assert_almost_equal(cat10.w[wpos!=0], 1)
+    assert 'Some wpos values are zero, setting w=0 for these points' in cl.output
 
 
 def test_fits():

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -752,6 +752,9 @@ def test_field():
     assert cat1.nfields.count == 1
     assert cat2.nfields.count == 1
     assert cat3.nfields.count == 1
+    assert nfield1 is cat1.nfields.last_value
+    assert nfield2 is cat2.nfields.last_value
+    assert nfield3 is cat3.nfields.last_value
     # The second time, they should already be made and taken from the cache, so much faster.
     print('nfield: ',t1-t0,t2-t1)
     assert t2-t1 < t1-t0
@@ -861,15 +864,16 @@ def test_field():
     assert nfield1b is nfield1
     assert nfield2b is nfield2
     assert nfield3b is nfield3
-    assert nfield1 in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield2 in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield3 in [v[3] for v in cat1.nfields.cache.values()]
+    assert nfield1 in cat1.nfields.values()
+    assert nfield2 in cat1.nfields.values()
+    assert nfield3 in cat1.nfields.values()
+    assert nfield3 is cat1.nfields.last_value
 
     # clear_cache will manually remove them.
     cat1.clear_cache()
-    assert nfield1 not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield2 not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield3 not in [v[3] for v in cat1.nfields.cache.values()]
+    print('values = ',cat1.nfields.values())
+    print('len(cache) = ',len(cat1.nfields.cache))
+    assert len(cat1.nfields.values()) == 0
     assert cat1.nfields.count == 0
     assert cat1.gfields.count == 0
     assert cat1.kfields.count == 0
@@ -896,12 +900,8 @@ def test_field():
     assert nfield1b is not nfield1
     assert nfield2b is not nfield2
     assert nfield3b is not nfield3
-    assert nfield1 not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield2 not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield3 not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield1b not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield2b not in [v[3] for v in cat1.nfields.cache.values()]
-    assert nfield3b not in [v[3] for v in cat1.nfields.cache.values()]
+    assert len(cat1.nfields.values()) == 0
+    assert cat1.nfields.last_value is None
 
 
 def test_lru():

--- a/tests/test_gg.py
+++ b/tests/test_gg.py
@@ -1301,6 +1301,28 @@ def test_rlens():
     print('max diff = ',max(abs(gg1.xim - theory_gQ)))
     assert max(abs(gg1.xim - theory_gQ)) < 4.e-5
 
+    # Can also do brute force just on one cat or the other.
+    # In this case, just cat2 is equivalent to full brute force, since nlens << nsource.
+    gg1a = treecorr.GGCorrelation(bin_size=bin_size, min_sep=min_sep, max_sep=max_sep, verbose=1,
+                                  metric='Rlens', bin_slop=0, brute=1)
+    gg1a.process(lens_cat, source_cat)
+    assert lens_cat.field.brute == True
+    assert source_cat.field.brute == False
+    gg1b = treecorr.GGCorrelation(bin_size=bin_size, min_sep=min_sep, max_sep=max_sep, verbose=1,
+                                  metric='Rlens', bin_slop=0, brute=2)
+    gg1b.process(lens_cat, source_cat)
+    assert lens_cat.field.brute == False
+    assert source_cat.field.brute == True
+
+    assert max(abs(gg0.xim - true_gQ)) < 2.e-6
+    assert max(abs(gg1.xim - true_gQ)) < 2.e-5
+    assert max(abs(gg1a.xim - true_gQ)) < 2.e-5
+    assert max(abs(gg1b.xim - true_gQ)) < 2.e-6
+    assert max(abs(gg0.xip - true_gCr)) < 2.e-6
+    assert max(abs(gg1.xip - true_gCr)) < 2.e-5
+    assert max(abs(gg1a.xip - true_gCr)) < 2.e-5
+    assert max(abs(gg1b.xip - true_gCr)) < 2.e-6
+
     # Now use a more normal value for bin_slop.
     gg2 = treecorr.GGCorrelation(bin_size=bin_size, min_sep=min_sep, max_sep=max_sep, verbose=1,
                                  metric='Rlens', bin_slop=0.3)

--- a/tests/test_ggg.py
+++ b/tests/test_ggg.py
@@ -21,7 +21,7 @@ from test_helper import get_script_name, do_pickle
 
 def test_direct():
     # If the catalogs are small enough, we can do a direct calculation to see if comes out right.
-    # This should exactly match the treecorr result if bin_slop=0.
+    # This should exactly match the treecorr result if brute=True.
 
     ngal = 100
     s = 10.
@@ -40,7 +40,7 @@ def test_direct():
     nubins = 5
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
-    ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
+    ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, brute=True)
     ggg.process(cat, num_threads=2)
 
     true_ntri = np.zeros((nrbins, nubins, nvbins), dtype=int)
@@ -154,7 +154,7 @@ def test_direct():
     np.testing.assert_allclose(data['gam3i'], ggg.gam3i.flatten(), rtol=1.e-3)
 
     # Also check the "cross" calculation.  (Real cross doesn't work, but this should.)
-    ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
+    ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, brute=True)
     ggg.process(cat, cat, cat, num_threads=2)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -185,10 +185,10 @@ def test_direct():
     np.testing.assert_allclose(data['gam3r'], ggg.gam3r.flatten(), rtol=1.e-3)
     np.testing.assert_allclose(data['gam3i'], ggg.gam3i.flatten(), rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0, since the code flow is different from brute=True.
     # And don't do any top-level recursion so we actually test not going to the leaves.
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  bin_slop=1.e-16, max_top=0)
+                                  bin_slop=0, max_top=0)
     ggg.process(cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -317,7 +317,7 @@ def test_direct_spherical():
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=0.)
+                                  sep_units='deg', brute=True)
     ggg.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)
@@ -439,10 +439,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['gam3r'], ggg.gam3r.flatten(), rtol=1.e-3)
     np.testing.assert_allclose(data['gam3i'], ggg.gam3i.flatten(), rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                  sep_units='deg', bin_slop=0, max_top=0)
     ggg.process(cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)

--- a/tests/test_ggg.py
+++ b/tests/test_ggg.py
@@ -41,7 +41,7 @@ def test_direct():
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
-    ggg.process(cat, num_threads=1)
+    ggg.process(cat, num_threads=2)
 
     true_ntri = np.zeros((nrbins, nubins, nvbins), dtype=int)
     true_weight = np.zeros((nrbins, nubins, nvbins), dtype=float)
@@ -155,7 +155,7 @@ def test_direct():
 
     # Also check the "cross" calculation.  (Real cross doesn't work, but this should.)
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
-    ggg.process(cat, cat, cat, num_threads=1)
+    ggg.process(cat, cat, cat, num_threads=2)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
     np.testing.assert_allclose(ggg.gam0r, true_gam0.real, rtol=1.e-5, atol=1.e-8)
@@ -318,7 +318,7 @@ def test_direct_spherical():
     max_sep = min_sep * np.exp(nrbins * bin_size)
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
                                   sep_units='deg', bin_slop=0.)
-    ggg.process(cat, num_threads=1)
+    ggg.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)
     x /= r;  y /= r;  z /= r

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -32,17 +32,22 @@ def test_count_near():
     use = np.random.randint(30, size=nobj).astype(float)
     w[use == 0] = 0
 
+    x0 = 0.5
+    y0 = 0.8
+    z0 = 0.3
+    sep = 0.03
+
     # Start with flat coords
 
     cat = treecorr.Catalog(x=x, y=y, w=w, g1=w, g2=w, k=w)
     field = cat.getNField()
 
     t0 = time.time()
-    n1 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 < 0.1**2)
+    n1 = np.sum((x[w>0]-x0)**2 + (y[w>0]-y0)**2 < sep**2)
     t1 = time.time()
-    n2 = field.count_near(x=0.5, y=0.8, sep=0.1)
+    n2 = field.count_near(x=x0, y=y0, sep=sep)
     t2 = time.time()
-    n3 = field.count_near(x=0.5, y=0.8, sep=0.1)
+    n3 = field.count_near(x=x0, y=y0, sep=sep)
     t3 = time.time()
     print('n1 = ',n1,'  time = ',t1-t0)
     print('n2 = ',n2,'  time = ',t2-t1)
@@ -53,10 +58,10 @@ def test_count_near():
     assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField()
-    gfield = cat.getGField()
-    n4 = kfield.count_near(0.5, 0.8, sep=0.1)
-    n5 = gfield.count_near(0.5, 0.8, 0.1)
+    kfield = cat.getKField(max_size=sep)
+    gfield = cat.getGField(max_size=sep, max_top=2)
+    n4 = kfield.count_near(x0, y0, sep=sep)
+    n5 = gfield.count_near(x0, y0, sep)
     assert n4 == n1
     assert n5 == n1
 
@@ -71,13 +76,13 @@ def test_count_near():
     field = cat.getNField()
 
     t0 = time.time()
-    n1 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 + (z[w>0]-0.3)**2 < 0.1**2)
+    n1 = np.sum((x[w>0]-x0)**2 + (y[w>0]-y0)**2 + (z[w>0]-z0)**2 < sep**2)
     t1 = time.time()
-    n2 = field.count_near(x=0.5, y=0.8, z=0.3, sep=0.1)
+    n2 = field.count_near(x=x0, y=y0, z=z0, sep=sep)
     t2 = time.time()
-    c = coord.CelestialCoord.from_xyz(0.5,0.8,0.3)
-    r0 = np.sqrt(0.5**2+0.8**2+0.3**2)
-    n3 = field.count_near(ra=c.ra, dec=c.dec, r=r0, sep=0.1)
+    c = coord.CelestialCoord.from_xyz(x0,y0,z0)
+    r0 = np.sqrt(x0**2+y0**2+z0**2)
+    n3 = field.count_near(ra=c.ra, dec=c.dec, r=r0, sep=sep)
     t3 = time.time()
     print('n1 = ',n1,'  time = ',t1-t0)
     print('n2 = ',n2,'  time = ',t2-t1)
@@ -88,18 +93,18 @@ def test_count_near():
     assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField()
-    gfield = cat.getGField()
-    n4 = kfield.count_near(0.5, 0.8, 0.3, sep=0.1)
-    n5 = gfield.count_near(0.5, 0.8, 0.3, 0.1)
-    n6 = kfield.count_near(c, r0, 0.1)
-    n7 = kfield.count_near(c.ra, c.dec, r0, 0.1)
-    n8 = gfield.count_near(c.ra.rad, c.dec.rad, r0, 0.1, ra_units='rad', dec_units='rad')
-    n9 = gfield.count_near(c, r0, sep=0.1)
-    n10 = kfield.count_near(c.ra, c.dec, r0, sep=0.1)
-    n11 = kfield.count_near(c.ra.rad, c.dec.rad, r0, ra_units='rad', dec_units='rad', sep=0.1)
-    n12 = gfield.count_near(c, r=r0, sep=0.1)
-    n13 = gfield.count_near(c.ra/coord.hours, c.dec/coord.degrees, r=r0, sep=0.1,
+    kfield = cat.getKField(max_size=sep)
+    gfield = cat.getGField(max_size=sep, max_top=2)
+    n4 = kfield.count_near(x0, y0, z0, sep=sep)
+    n5 = gfield.count_near(x0, y0, z0, sep)
+    n6 = kfield.count_near(c, r0, sep)
+    n7 = kfield.count_near(c.ra, c.dec, r0, sep)
+    n8 = gfield.count_near(c.ra.rad, c.dec.rad, r0, sep, ra_units='rad', dec_units='rad')
+    n9 = gfield.count_near(c, r0, sep=sep)
+    n10 = kfield.count_near(c.ra, c.dec, r0, sep=sep)
+    n11 = kfield.count_near(c.ra.rad, c.dec.rad, r0, ra_units='rad', dec_units='rad', sep=sep)
+    n12 = gfield.count_near(c, r=r0, sep=sep)
+    n13 = gfield.count_near(c.ra/coord.hours, c.dec/coord.degrees, r=r0, sep=sep,
                             ra_units='hrs', dec_units='degrees')
     assert n4 == n1
     assert n5 == n1
@@ -120,15 +125,16 @@ def test_count_near():
     x /= r
     y /= r
     z /= r
-    c = coord.CelestialCoord.from_xyz(0.5,0.8,0.3)
+    c = coord.CelestialCoord.from_xyz(x0,y0,z0)
     x0,y0,z0 = c.get_xyz()
+    r0 = 2 * np.sin(sep/2)  # length of chord subtending 0.1 radians.
     t0 = time.time()
-    n1 = np.sum((x[w>0]-x0)**2 + (y[w>0]-y0)**2 + (z[w>0]-z0)**2 < 0.1**2)
+    n1 = np.sum((x[w>0]-x0)**2 + (y[w>0]-y0)**2 + (z[w>0]-z0)**2 < r0**2)
     t1 = time.time()
-    n2 = field.count_near(c, sep=0.1*coord.radians)
+    n2 = field.count_near(c, sep=sep*coord.radians)
     t2 = time.time()
     n3 = field.count_near(ra=c.ra.rad, dec=c.dec.rad, ra_units='radians', dec_units='radians',
-                          sep=0.1 * coord.radians)
+                          sep=sep * coord.radians)
     t3 = time.time()
     print('n1 = ',n1,'  time = ',t1-t0)
     print('n2 = ',n2,'  time = ',t2-t1)
@@ -139,14 +145,14 @@ def test_count_near():
     assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField()
-    gfield = cat.getGField()
+    kfield = cat.getKField(max_size=0.1)
+    gfield = cat.getGField(max_size=0.1, max_top=2)
     n4 = kfield.count_near(ra=c.ra/coord.degrees, dec=c.dec/coord.degrees,
-                           ra_units='deg', dec_units='deg', sep=0.1, sep_units='rad')
-    n5 = gfield.count_near(ra=c.ra, dec=c.dec, sep=0.1*coord.radians/coord.degrees, sep_units='deg')
-    n6 = gfield.count_near(c, 0.1*coord.radians/coord.degrees, sep_units='deg')
-    n7 = kfield.count_near(c.ra, c.dec, sep=0.1*coord.radians)
-    n8 = kfield.count_near(c.ra, c.dec, 18./np.pi*coord.degrees)
+                           ra_units='deg', dec_units='deg', sep=sep, sep_units='rad')
+    n5 = gfield.count_near(ra=c.ra, dec=c.dec, sep=sep*coord.radians/coord.degrees, sep_units='deg')
+    n6 = gfield.count_near(c, sep*coord.radians/coord.degrees, sep_units='deg')
+    n7 = kfield.count_near(c.ra, c.dec, sep=sep*coord.radians)
+    n8 = kfield.count_near(c.ra, c.dec, sep*180./np.pi*coord.degrees)
     assert n4 == n1
     assert n5 == n1
     assert n6 == n1
@@ -154,5 +160,131 @@ def test_count_near():
     assert n8 == n1
 
 
+def test_get_near():
+
+    nobj = 300000
+    np.random.seed(8675309)
+    x = np.random.random_sample(nobj)   # All from 0..1
+    y = np.random.random_sample(nobj)
+    z = np.random.random_sample(nobj)
+    w = np.random.random_sample(nobj)
+    use = np.random.randint(30, size=nobj).astype(float)
+    w[use == 0] = 0
+
+    x0 = 0.5
+    y0 = 0.8
+    z0 = 0.3
+    sep = 0.03
+
+    # Put a small cluster inside our search radius
+    x[100:130] = np.random.normal(x0+0.03, 0.001, 30)
+    y[100:130] = np.random.normal(y0-0.02, 0.001, 30)
+    z[100:130] = np.random.normal(z0+0.01, 0.001, 30)
+
+    # Put another small cluster right on the edge of our search radius
+    x[500:550] = np.random.normal(x0+sep, 0.001, 50)
+    y[500:550] = np.random.normal(y0, 0.001, 50)
+    z[500:550] = np.random.normal(z0, 0.001, 50)
+
+    # Start with flat coords
+
+    cat = treecorr.Catalog(x=x, y=y, w=w, g1=w, g2=w, k=w)
+    field = cat.getNField()
+
+    t0 = time.time()
+    i1 = np.where(((x-x0)**2 + (y-y0)**2 < sep**2) & (w > 0))[0]
+    t1 = time.time()
+    i2 = field.get_near(x=x0, y=y0, sep=sep)
+    t2 = time.time()
+    i3 = field.get_near(x0, y0, sep)
+    t3 = time.time()
+    print('i1 = ',i1[:20],'  time = ',t1-t0)
+    print('i2 = ',i2[:20],'  time = ',t2-t1)
+    print('i3 = ',i3[:20],'  time = ',t3-t2)
+    np.testing.assert_array_equal(i2, i1)
+    np.testing.assert_array_equal(i3, i1)
+    #assert t2-t1 < t1-t0  # These don't always pass.  The tree version is usually a bit faster,
+    #assert t3-t2 < t1-t0  # but not by much and not always.  So don't require it in unit test.
+
+    # Check G and K
+    kfield = cat.getKField(min_size=0.001, max_size=sep)
+    gfield = cat.getGField(min_size=0.01, max_size=sep, max_top=2)
+    i4 = kfield.get_near(x0, y0, sep=sep)
+    i5 = gfield.get_near(x0, y0, sep=sep)
+    np.testing.assert_array_equal(i4, i1)
+    np.testing.assert_array_equal(i5, i1)
+
+    # 3D coords
+
+    r = np.sqrt(x*x+y*y+z*z)
+    dec = np.arcsin(z/r) * coord.radians / coord.degrees
+    ra = np.arctan2(y,x) * coord.radians / coord.degrees
+
+    cat = treecorr.Catalog(ra=ra, dec=dec, r=r, ra_units='deg', dec_units='deg',
+                           w=w, g1=w, g2=w, k=w)
+    field = cat.getNField()
+
+    t0 = time.time()
+    i1 = np.where(((x-x0)**2 + (y-y0)**2 + (z-z0)**2 < sep**2) & (w > 0))[0]
+    t1 = time.time()
+    i2 = field.get_near(x=x0, y=y0, z=z0, sep=sep)
+    t2 = time.time()
+    c = coord.CelestialCoord.from_xyz(x0,y0,z0)
+    r0 = np.sqrt(x0**2+y0**2+z0**2)
+    i3 = field.get_near(ra=c.ra, dec=c.dec, r=r0, sep=sep)
+    t3 = time.time()
+    print('i1 = ',i1[:20],'  time = ',t1-t0)
+    print('i2 = ',i2[:20],'  time = ',t2-t1)
+    print('i3 = ',i3[:20],'  time = ',t3-t2)
+    np.testing.assert_array_equal(i2, i1)
+    np.testing.assert_array_equal(i3, i1)
+    #assert t2-t1 < t1-t0
+    #assert t3-t2 < t1-t0
+
+    # Check G and K
+    kfield = cat.getKField(max_size=sep)
+    gfield = cat.getGField(max_size=sep, max_top=2)
+    i4 = kfield.get_near(c, r0, sep)
+    i5 = gfield.get_near(c.ra, c.dec, r0, sep=sep)
+    np.testing.assert_array_equal(i4, i1)
+    np.testing.assert_array_equal(i5, i1)
+
+    # Spherical
+    cat = treecorr.Catalog(ra=ra, dec=dec, ra_units='deg', dec_units='deg',
+                           w=w, g1=w, g2=w, k=w)
+    field = cat.getNField()
+
+    x /= r
+    y /= r
+    z /= r
+    c = coord.CelestialCoord.from_xyz(x0,y0,z0)
+    x0,y0,z0 = c.get_xyz()
+    r0 = 2 * np.sin(sep / 2)  # length of chord subtending sep radians.
+    t0 = time.time()
+    i1 = np.where(((x-x0)**2 + (y-y0)**2 + (z-z0)**2 < r0**2) & (w > 0))[0]
+    t1 = time.time()
+    i2 = field.get_near(c, sep=sep, sep_units='rad')
+    t2 = time.time()
+    i3 = field.get_near(ra=c.ra.rad, dec=c.dec.rad, ra_units='radians', dec_units='radians',
+                        sep=sep * coord.radians)
+    t3 = time.time()
+    print('i1 = ',i1[:20],'  time = ',t1-t0)
+    print('i2 = ',i2[:20],'  time = ',t2-t1)
+    print('i3 = ',i3[:20],'  time = ',t3-t2)
+    np.testing.assert_array_equal(i2, i1)
+    np.testing.assert_array_equal(i3, i1)
+    #assert t2-t1 < t1-t0
+    #assert t3-t2 < t1-t0
+
+    # Check G and K with other allowed argument patterns.
+    kfield = cat.getKField(max_size=sep)
+    gfield = cat.getGField(max_size=sep, max_top=2)
+    i4 = gfield.get_near(c, sep*coord.radians/coord.degrees, sep_units='deg')
+    i5 = kfield.get_near(c.ra, c.dec, sep*coord.radians)
+    np.testing.assert_array_equal(i4, i1)
+    np.testing.assert_array_equal(i5, i1)
+
+
 if __name__ == '__main__':
     test_count_near()
+    test_get_near()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2003-2015 by Mike Jarvis
+#
+# TreeCorr is free software: redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions, and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+from __future__ import print_function
+import numpy as np
+import time
+import coord
+import treecorr
+
+from test_helper import CaptureLog, assert_raises
+
+def test_count_near():
+
+    nobj = 100000
+    np.random.seed(8675309)
+    x = np.random.random_sample(nobj)   # All from 0..1
+    y = np.random.random_sample(nobj)
+    z = np.random.random_sample(nobj)
+    w = np.random.random_sample(nobj)
+
+    # Some elements have w = 0.
+    use = np.random.randint(30, size=nobj).astype(float)
+    w[use == 0] = 0
+
+    # Start with flat coords
+
+    cat = treecorr.Catalog(x=x, y=y, w=w)
+    field = cat.getNField()
+
+    t0 = time.time()
+    n1 = field.count_near(0.5, 0.8, 0., 0.1)
+    t1 = time.time()
+    n2 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 < 0.1**2)
+    t2 = time.time()
+    n3 = field.count_near(0.5, 0.8, 0., 0.1)
+    t3 = time.time()
+    print('n1 = ',n1,'  time = ',t1-t0)
+    print('n2 = ',n2,'  time = ',t2-t1)
+    print('n3 = ',n3,'  time = ',t3-t2)
+    assert n2 == n1
+    assert n2 == n3
+    assert t1-t0 < t2-t1
+    assert t3-t2 < t2-t1
+
+    # 3D coords
+
+    r = np.sqrt(x*x+y*y+z*z)
+    dec = np.arcsin(z/r) * coord.radians / coord.degrees
+    ra = np.arctan2(y,x) * coord.radians / coord.degrees
+
+    cat = treecorr.Catalog(ra=ra, dec=dec, r=r, ra_units='deg', dec_units='deg',
+                           w=w, g1=w, g2=w, k=w)
+    field = cat.getNField()
+
+    t0 = time.time()
+    n1 = field.count_near(0.5, 0.8, 0.3, 0.1)
+    t1 = time.time()
+    n2 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 + (z[w>0]-0.3)**2 < 0.1**2)
+    t2 = time.time()
+    n3 = field.count_near(0.5, 0.8, 0.3, 0.1)
+    t3 = time.time()
+    print('n1 = ',n1,'  time = ',t1-t0)
+    print('n2 = ',n2,'  time = ',t2-t1)
+    print('n3 = ',n3,'  time = ',t3-t2)
+    assert n2 == n1
+    assert n2 == n3
+    assert t1-t0 < t2-t1
+    assert t3-t2 < t2-t1
+
+    # Spherical
+    cat = treecorr.Catalog(ra=ra, dec=dec, ra_units='deg', dec_units='deg',
+                           w=w, g1=w, g2=w, k=w)
+    field = cat.getNField()
+
+    x /= r
+    y /= r
+    z /= r
+    t0 = time.time()
+    n1 = field.count_near(0.5, 0.8, 0.3317, 0.1)
+    t1 = time.time()
+    n2 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 + (z[w>0]-0.3317)**2 < 0.1**2)
+    t2 = time.time()
+    n3 = field.count_near(0.5, 0.8, 0.3317, 0.1)
+    t3 = time.time()
+    print('n1 = ',n1,'  time = ',t1-t0)
+    print('n2 = ',n2,'  time = ',t2-t1)
+    print('n3 = ',n3,'  time = ',t3-t2)
+    assert n1 == n2
+    assert n3 == n2
+    assert t1-t0 < t2-t1
+    assert t3-t2 < t2-t1
+
+    # Finally, check that GField and KField also work.
+    kfield = cat.getKField()
+    gfield = cat.getGField()
+    t4 = time.time()
+    n4 = kfield.count_near(0.5, 0.8, 0.3317, 0.1)
+    t5 = time.time()
+    n5 = gfield.count_near(0.5, 0.8, 0.3317, 0.1)
+    t6 = time.time()
+    print('n4 = ',n4,'  time = ',t5-t4)
+    print('n5 = ',n5,'  time = ',t6-t5)
+    assert n4 == n2
+    assert n5 == n2
+
+
+if __name__ == '__main__':
+    test_count_near()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -321,7 +321,7 @@ def test_sample_pairs():
 
     # Note: extend range low enough that some bins have < 100 pairs.
     nn = treecorr.NNCorrelation(min_sep=0.001, max_sep=0.01, bin_size=0.1, max_top=0)
-    nn.process(cat1, cat2, num_threads=1)
+    nn.process(cat1, cat2)
     print('rnom = ',nn.rnom)
     print('npairs = ',nn.npairs.astype(int))
 
@@ -369,7 +369,7 @@ def test_sample_pairs():
     cat2 = treecorr.Catalog(x=x2, y=y2, z=z2, w=w2, g1=g12, g2=g22, k=k2)
 
     gg = treecorr.GGCorrelation(min_sep=0.4, max_sep=1.0, bin_size=0.1, max_top=0)
-    gg.process(cat1, cat2, num_threads=1)
+    gg.process(cat1, cat2)
     print('rnom = ',gg.rnom)
     print('npairs = ',gg.npairs.astype(int))
     for b in [0,5]:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -59,8 +59,8 @@ def test_count_near():
     assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField(max_size=sep)
-    gfield = cat.getGField(max_size=sep, max_top=2)
+    kfield = cat.getKField(min_size=0.01, max_size=sep)
+    gfield = cat.getGField(min_size=0.05, max_size=sep, max_top=2)
     n4 = kfield.count_near(x0, y0, sep=sep)
     n5 = gfield.count_near(x0, y0, sep)
     assert n4 == n1
@@ -94,8 +94,8 @@ def test_count_near():
     assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField(max_size=sep)
-    gfield = cat.getGField(max_size=sep, max_top=2)
+    kfield = cat.getKField(min_size=0.01, max_size=sep)
+    gfield = cat.getGField(min_size=0.05, max_size=sep, max_top=2)
     n4 = kfield.count_near(x0, y0, z0, sep=sep)
     n5 = gfield.count_near(x0, y0, z0, sep)
     n6 = kfield.count_near(c, r0, sep)
@@ -146,8 +146,8 @@ def test_count_near():
     assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField(max_size=0.1)
-    gfield = cat.getGField(max_size=0.1, max_top=2)
+    kfield = cat.getKField(min_size=0.01, max_size=0.1)
+    gfield = cat.getGField(max_size=0.05, max_top=2)
     n4 = kfield.count_near(ra=c.ra/coord.degrees, dec=c.dec/coord.degrees,
                            ra_units='deg', dec_units='deg', sep=sep, sep_units='rad')
     n5 = gfield.count_near(ra=c.ra, dec=c.dec, sep=sep*coord.radians/coord.degrees, sep_units='deg')
@@ -167,7 +167,7 @@ def test_count_near():
 
 def test_get_near():
 
-    nobj = 300000
+    nobj = 100000
     np.random.seed(8675309)
     x = np.random.random_sample(nobj)   # All from 0..1
     y = np.random.random_sample(nobj)
@@ -212,8 +212,8 @@ def test_get_near():
     #assert t3-t2 < t1-t0  # but not by much and not always.  So don't require it in unit test.
 
     # Check G and K
-    kfield = cat.getKField(min_size=0.001, max_size=sep)
-    gfield = cat.getGField(min_size=0.01, max_size=sep, max_top=2)
+    kfield = cat.getKField(min_size=0.01, max_size=sep)
+    gfield = cat.getGField(min_size=0.05, max_size=sep, max_top=2)
     i4 = kfield.get_near(x0, y0, sep=sep)
     i5 = gfield.get_near(x0, y0, sep=sep)
     np.testing.assert_array_equal(i4, i1)
@@ -247,8 +247,8 @@ def test_get_near():
     #assert t3-t2 < t1-t0
 
     # Check G and K
-    kfield = cat.getKField(max_size=sep)
-    gfield = cat.getGField(max_size=sep, max_top=2)
+    kfield = cat.getKField(min_size=0.01, max_size=sep)
+    gfield = cat.getGField(min_size=0.05, max_size=sep, max_top=2)
     i4 = kfield.get_near(c, r0, sep)
     i5 = gfield.get_near(c.ra, c.dec, r0, sep=sep)
     np.testing.assert_array_equal(i4, i1)
@@ -282,8 +282,8 @@ def test_get_near():
     #assert t3-t2 < t1-t0
 
     # Check G and K with other allowed argument patterns.
-    kfield = cat.getKField(max_size=sep)
-    gfield = cat.getGField(max_size=sep, max_top=2)
+    kfield = cat.getKField(min_size=0.01, max_size=sep)
+    gfield = cat.getGField(min_size=0.05, max_size=sep, max_top=2)
     i4 = gfield.get_near(c, sep*coord.radians/coord.degrees, sep_units='deg')
     i5 = kfield.get_near(c.ra, c.dec, sep*coord.radians)
     np.testing.assert_array_equal(i4, i1)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 import numpy as np
 import time
 import coord
+import gc
 import treecorr
 
 from test_helper import CaptureLog, assert_raises
@@ -158,6 +159,10 @@ def test_count_near():
     assert n6 == n1
     assert n7 == n1
     assert n8 == n1
+
+    # I haven't figured this out yet, but in python 3.7, if I omit this, then
+    # things eventually hang when garbage collecting the fields.
+    gc.collect()
 
 
 def test_get_near():

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -34,23 +34,31 @@ def test_count_near():
 
     # Start with flat coords
 
-    cat = treecorr.Catalog(x=x, y=y, w=w)
+    cat = treecorr.Catalog(x=x, y=y, w=w, g1=w, g2=w, k=w)
     field = cat.getNField()
 
     t0 = time.time()
-    n1 = field.count_near(0.5, 0.8, 0., 0.1)
+    n1 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 < 0.1**2)
     t1 = time.time()
-    n2 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 < 0.1**2)
+    n2 = field.count_near(x=0.5, y=0.8, sep=0.1)
     t2 = time.time()
-    n3 = field.count_near(0.5, 0.8, 0., 0.1)
+    n3 = field.count_near(x=0.5, y=0.8, sep=0.1)
     t3 = time.time()
     print('n1 = ',n1,'  time = ',t1-t0)
     print('n2 = ',n2,'  time = ',t2-t1)
     print('n3 = ',n3,'  time = ',t3-t2)
     assert n2 == n1
-    assert n2 == n3
-    assert t1-t0 < t2-t1
-    assert t3-t2 < t2-t1
+    assert n3 == n1
+    assert t2-t1 < t1-t0
+    assert t3-t2 < t1-t0
+
+    # Check G and K with other allowed argument patterns.
+    kfield = cat.getKField()
+    gfield = cat.getGField()
+    n4 = kfield.count_near(0.5, 0.8, sep=0.1)
+    n5 = gfield.count_near(0.5, 0.8, 0.1)
+    assert n4 == n1
+    assert n5 == n1
 
     # 3D coords
 
@@ -63,19 +71,46 @@ def test_count_near():
     field = cat.getNField()
 
     t0 = time.time()
-    n1 = field.count_near(0.5, 0.8, 0.3, 0.1)
+    n1 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 + (z[w>0]-0.3)**2 < 0.1**2)
     t1 = time.time()
-    n2 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 + (z[w>0]-0.3)**2 < 0.1**2)
+    n2 = field.count_near(x=0.5, y=0.8, z=0.3, sep=0.1)
     t2 = time.time()
-    n3 = field.count_near(0.5, 0.8, 0.3, 0.1)
+    c = coord.CelestialCoord.from_xyz(0.5,0.8,0.3)
+    r0 = np.sqrt(0.5**2+0.8**2+0.3**2)
+    n3 = field.count_near(ra=c.ra, dec=c.dec, r=r0, sep=0.1)
     t3 = time.time()
     print('n1 = ',n1,'  time = ',t1-t0)
     print('n2 = ',n2,'  time = ',t2-t1)
     print('n3 = ',n3,'  time = ',t3-t2)
     assert n2 == n1
-    assert n2 == n3
-    assert t1-t0 < t2-t1
-    assert t3-t2 < t2-t1
+    assert n3 == n1
+    assert t2-t1 < t1-t0
+    assert t3-t2 < t1-t0
+
+    # Check G and K with other allowed argument patterns.
+    kfield = cat.getKField()
+    gfield = cat.getGField()
+    n4 = kfield.count_near(0.5, 0.8, 0.3, sep=0.1)
+    n5 = gfield.count_near(0.5, 0.8, 0.3, 0.1)
+    n6 = kfield.count_near(c, r0, 0.1)
+    n7 = kfield.count_near(c.ra, c.dec, r0, 0.1)
+    n8 = gfield.count_near(c.ra.rad, c.dec.rad, r0, 0.1, ra_units='rad', dec_units='rad')
+    n9 = gfield.count_near(c, r0, sep=0.1)
+    n10 = kfield.count_near(c.ra, c.dec, r0, sep=0.1)
+    n11 = kfield.count_near(c.ra.rad, c.dec.rad, r0, ra_units='rad', dec_units='rad', sep=0.1)
+    n12 = gfield.count_near(c, r=r0, sep=0.1)
+    n13 = gfield.count_near(c.ra/coord.hours, c.dec/coord.degrees, r=r0, sep=0.1,
+                            ra_units='hrs', dec_units='degrees')
+    assert n4 == n1
+    assert n5 == n1
+    assert n6 == n1
+    assert n7 == n1
+    assert n8 == n1
+    assert n9 == n1
+    assert n10 == n1
+    assert n11 == n1
+    assert n12 == n1
+    assert n13 == n1
 
     # Spherical
     cat = treecorr.Catalog(ra=ra, dec=dec, ra_units='deg', dec_units='deg',
@@ -85,33 +120,38 @@ def test_count_near():
     x /= r
     y /= r
     z /= r
+    c = coord.CelestialCoord.from_xyz(0.5,0.8,0.3)
+    x0,y0,z0 = c.get_xyz()
     t0 = time.time()
-    n1 = field.count_near(0.5, 0.8, 0.3317, 0.1)
+    n1 = np.sum((x[w>0]-x0)**2 + (y[w>0]-y0)**2 + (z[w>0]-z0)**2 < 0.1**2)
     t1 = time.time()
-    n2 = np.sum((x[w>0]-0.5)**2 + (y[w>0]-0.8)**2 + (z[w>0]-0.3317)**2 < 0.1**2)
+    n2 = field.count_near(c, sep=0.1*coord.radians)
     t2 = time.time()
-    n3 = field.count_near(0.5, 0.8, 0.3317, 0.1)
+    n3 = field.count_near(ra=c.ra.rad, dec=c.dec.rad, ra_units='radians', dec_units='radians',
+                          sep=0.1 * coord.radians)
     t3 = time.time()
     print('n1 = ',n1,'  time = ',t1-t0)
     print('n2 = ',n2,'  time = ',t2-t1)
     print('n3 = ',n3,'  time = ',t3-t2)
-    assert n1 == n2
-    assert n3 == n2
-    assert t1-t0 < t2-t1
-    assert t3-t2 < t2-t1
+    assert n2 == n1
+    assert n3 == n1
+    assert t2-t1 < t1-t0
+    assert t3-t2 < t1-t0
 
-    # Finally, check that GField and KField also work.
+    # Check G and K with other allowed argument patterns.
     kfield = cat.getKField()
     gfield = cat.getGField()
-    t4 = time.time()
-    n4 = kfield.count_near(0.5, 0.8, 0.3317, 0.1)
-    t5 = time.time()
-    n5 = gfield.count_near(0.5, 0.8, 0.3317, 0.1)
-    t6 = time.time()
-    print('n4 = ',n4,'  time = ',t5-t4)
-    print('n5 = ',n5,'  time = ',t6-t5)
-    assert n4 == n2
-    assert n5 == n2
+    n4 = kfield.count_near(ra=c.ra/coord.degrees, dec=c.dec/coord.degrees,
+                           ra_units='deg', dec_units='deg', sep=0.1, sep_units='rad')
+    n5 = gfield.count_near(ra=c.ra, dec=c.dec, sep=0.1*coord.radians/coord.degrees, sep_units='deg')
+    n6 = gfield.count_near(c, 0.1*coord.radians/coord.degrees, sep_units='deg')
+    n7 = kfield.count_near(c.ra, c.dec, sep=0.1*coord.radians)
+    n8 = kfield.count_near(c.ra, c.dec, 18./np.pi*coord.degrees)
+    assert n4 == n1
+    assert n5 == n1
+    assert n6 == n1
+    assert n7 == n1
+    assert n8 == n1
 
 
 if __name__ == '__main__':

--- a/tests/test_kg.py
+++ b/tests/test_kg.py
@@ -21,7 +21,7 @@ from test_helper import get_script_name, do_pickle, CaptureLog
 
 def test_direct():
     # If the catalogs are small enough, we can do a direct calculation to see if comes out right.
-    # This should exactly match the treecorr result if bin_slop=0.
+    # This should exactly match the treecorr result if brute=True.
 
     ngal = 200
     s = 10.
@@ -44,7 +44,7 @@ def test_direct():
     max_sep = 50.
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
-    kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     kg.process(cat1, cat2)
 
     true_npairs = np.zeros(nbins, dtype=int)
@@ -101,9 +101,9 @@ def test_direct():
     np.testing.assert_allclose(data['kgamT'], kg.xi, rtol=1.e-3)
     np.testing.assert_allclose(data['kgamX'], kg.xi_im, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0, since code is different for bin_slop=0 and brute=True.
     # And don't do any top-level recursion so we actually test not going to the leaves.
-    kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16,
+    kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
                                 max_top=0)
     kg.process(cat1, cat2)
     np.testing.assert_array_equal(kg.npairs, true_npairs)
@@ -185,7 +185,7 @@ def test_direct_spherical():
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
     kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=0.)
+                                sep_units='deg', brute=True)
     kg.process(cat1, cat2)
 
     r1 = np.sqrt(x1**2 + y1**2 + z1**2)
@@ -260,10 +260,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['kgamT'], kg.xi, rtol=1.e-3)
     np.testing.assert_allclose(data['kgamX'], kg.xi_im, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                sep_units='deg', bin_slop=0, max_top=0)
     kg.process(cat1, cat2)
     np.testing.assert_array_equal(kg.npairs, true_npairs)
     np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-5, atol=1.e-8)

--- a/tests/test_kk.py
+++ b/tests/test_kk.py
@@ -21,7 +21,7 @@ from test_helper import get_script_name, do_pickle, CaptureLog
 
 def test_direct():
     # If the catalogs are small enough, we can do a direct calculation to see if comes out right.
-    # This should exactly match the treecorr result if bin_slop=0.
+    # This should exactly match the treecorr result if brute force.
 
     ngal = 200
     s = 10.
@@ -43,7 +43,7 @@ def test_direct():
     max_sep = 50.
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
-    kk = treecorr.KKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    kk = treecorr.KKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     kk.process(cat1, cat2)
 
     true_npairs = np.zeros(nbins, dtype=int)
@@ -97,9 +97,9 @@ def test_direct():
     np.testing.assert_allclose(data['weight'], kk.weight)
     np.testing.assert_allclose(data['xi'], kk.xi, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
-    kk = treecorr.KKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16,
+    kk = treecorr.KKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
                                 max_top=0)
     kk.process(cat1, cat2)
     np.testing.assert_array_equal(kk.npairs, true_npairs)
@@ -175,7 +175,7 @@ def test_direct_spherical():
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
     kk = treecorr.KKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=0.)
+                                sep_units='deg', brute=True)
     kk.process(cat1, cat2)
 
     r1 = np.sqrt(x1**2 + y1**2 + z1**2)
@@ -240,10 +240,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['weight'], kk.weight)
     np.testing.assert_allclose(data['xi'], kk.xi, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     kk = treecorr.KKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                sep_units='deg', bin_slop=0, max_top=0)
     kk.process(cat1, cat2)
     np.testing.assert_array_equal(kk.npairs, true_npairs)
     np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-5, atol=1.e-8)

--- a/tests/test_kkk.py
+++ b/tests/test_kkk.py
@@ -21,7 +21,7 @@ from test_helper import get_script_name, do_pickle
 
 def test_direct():
     # If the catalogs are small enough, we can do a direct calculation to see if comes out right.
-    # This should exactly match the treecorr result if bin_slop=0.
+    # This should exactly match the treecorr result if brute=True.
 
     ngal = 100
     s = 10.
@@ -39,7 +39,7 @@ def test_direct():
     nubins = 5
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
-    kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
+    kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, brute=True)
     kkk.process(cat, num_threads=2)
 
     true_ntri = np.zeros((nrbins, nubins, nvbins), dtype=int)
@@ -109,7 +109,7 @@ def test_direct():
     np.testing.assert_allclose(data['zeta'], kkk.zeta.flatten(), rtol=1.e-3)
 
     # Also check the "cross" calculation.  (Real cross doesn't work, but this should.)
-    kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
+    kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, brute=True)
     kkk.process(cat, cat, cat, num_threads=2)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -126,10 +126,10 @@ def test_direct():
     np.testing.assert_allclose(data['weight'], kkk.weight.flatten())
     np.testing.assert_allclose(data['zeta'], kkk.zeta.flatten(), rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  bin_slop=1.e-16, max_top=0)
+                                  bin_slop=0, max_top=0)
     kkk.process(cat)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -222,7 +222,7 @@ def test_direct_spherical():
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=0.)
+                                  sep_units='deg', brute=True)
     kkk.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)
@@ -301,10 +301,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['weight'], kkk.weight.flatten())
     np.testing.assert_allclose(data['zeta'], kkk.zeta.flatten(), rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                  sep_units='deg', bin_slop=0, max_top=0)
     kkk.process(cat)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)

--- a/tests/test_kkk.py
+++ b/tests/test_kkk.py
@@ -40,7 +40,7 @@ def test_direct():
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
-    kkk.process(cat, num_threads=1)
+    kkk.process(cat, num_threads=2)
 
     true_ntri = np.zeros((nrbins, nubins, nvbins), dtype=int)
     true_weight = np.zeros((nrbins, nubins, nvbins), dtype=float)
@@ -110,7 +110,7 @@ def test_direct():
 
     # Also check the "cross" calculation.  (Real cross doesn't work, but this should.)
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins, bin_slop=0.)
-    kkk.process(cat, cat, cat, num_threads=1)
+    kkk.process(cat, cat, cat, num_threads=2)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
     np.testing.assert_allclose(kkk.zeta, true_zeta, rtol=1.e-5, atol=1.e-8)
@@ -223,7 +223,7 @@ def test_direct_spherical():
     max_sep = min_sep * np.exp(nrbins * bin_size)
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
                                   sep_units='deg', bin_slop=0.)
-    kkk.process(cat, num_threads=1)
+    kkk.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)
     x /= r;  y /= r;  z /= r

--- a/tests/test_ng.py
+++ b/tests/test_ng.py
@@ -1455,7 +1455,10 @@ def test_rlens_bkg():
     print('ratio = ',ng2.xi / true_gt_arc)
     print('diff = ',ng2.xi - true_gt_arc)
     print('max diff = ',max(abs(ng2.xi - true_gt_arc)))
+    np.testing.assert_array_equal(ng2.npairs, true_npairs_arc)
     np.testing.assert_allclose(ng2.xi, true_gt_arc, rtol=5.e-3)
+    print('ng.xi_im = ',ng2.xi_im)
+    print('max im = ',max(abs(ng2.xi_im)))
     np.testing.assert_allclose(ng2.xi_im, 0, atol=5.e-4)
 
     # Without min_rpar, this should fail.
@@ -1480,8 +1483,9 @@ def test_rlens_bkg():
     print('Results with bin_slop = 0.5')
     print('ng.npairs = ',ng3.npairs)
     print('ng.xi = ',ng3.xi)
+    print('ratio = ',ng3.xi / true_gt_arc)
     print('ng.xi_im = ',ng3.xi_im)
-    np.testing.assert_allclose(ng3.xi, true_gt_arc, rtol=1.e-2)
+    np.testing.assert_allclose(ng3.xi, true_gt_arc, rtol=1.e-2, atol=5.e-5)
     np.testing.assert_allclose(ng3.xi_im, 0, atol=1.e-3)
 
 

--- a/tests/test_nk.py
+++ b/tests/test_nk.py
@@ -22,7 +22,7 @@ from test_helper import get_script_name, do_pickle, CaptureLog, assert_raises
 
 def test_direct():
     # If the catalogs are small enough, we can do a direct calculation to see if comes out right.
-    # This should exactly match the treecorr result if bin_slop=0.
+    # This should exactly match the treecorr result if brute force.
 
     ngal = 200
     s = 10.
@@ -43,7 +43,7 @@ def test_direct():
     max_sep = 50.
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
-    nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     nk.process(cat1, cat2)
 
     true_npairs = np.zeros(nbins, dtype=int)
@@ -96,9 +96,9 @@ def test_direct():
     np.testing.assert_allclose(data['weight'], nk.weight)
     np.testing.assert_allclose(data['kappa'], nk.xi, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0, since the code flow is different from brute=True
     # And don't do any top-level recursion so we actually test not going to the leaves.
-    nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16,
+    nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
                                 max_top=0)
     nk.process(cat1, cat2)
     np.testing.assert_array_equal(nk.npairs, true_npairs)
@@ -179,7 +179,7 @@ def test_direct_spherical():
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
     nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=0.)
+                                sep_units='deg', brute=True)
     nk.process(cat1, cat2)
 
     r1 = np.sqrt(x1**2 + y1**2 + z1**2)
@@ -251,10 +251,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['weight'], nk.weight)
     np.testing.assert_allclose(data['kappa'], nk.xi, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0, since the code flow is different from brute=True.
     # And don't do any top-level recursion so we actually test not going to the leaves.
     nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                sep_units='deg', bin_slop=0, max_top=0)
     nk.process(cat1, cat2)
     np.testing.assert_array_equal(nk.npairs, true_npairs)
     np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-5, atol=1.e-8)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -407,7 +407,7 @@ def test_direct_count():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     dd.process(cat1, cat2, num_threads=1)
     print('dd.npairs = ',dd.npairs)
 
@@ -453,7 +453,7 @@ def test_direct_count():
     with open(rand_file_name2, 'w') as fid:
         for i in range(nrand):
             fid.write(('%.20f %.20f\n')%(rx2[i],ry2[i]))
-    rr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    rr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                 verbose=0)
     rr.process(rcat1,rcat2)
     xi, varxi = dd.calculateXi(rr)
@@ -497,13 +497,13 @@ def test_direct_count():
                                     skip_header=1)
     np.testing.assert_allclose(corr2_output['xi'], xi, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16)
+    # Repeat with binslop = 0, since the code flow is different from brute=True
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0)
     dd.process(cat1, cat2)
     np.testing.assert_array_equal(dd.npairs, true_npairs)
 
     # And again with no top-level recursion
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16,
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
                                 max_top=0)
     dd.process(cat1, cat2)
     np.testing.assert_array_equal(dd.npairs, true_npairs)
@@ -513,7 +513,7 @@ def test_direct_count():
     config = treecorr.config.read_config('configs/nn_direct.yaml')
     config['verbose'] = 2
     config['max_top'] = 0
-    config['bin_slop'] = 1.e-16
+    config['bin_slop'] = 0
     treecorr.corr2(config)
     data = np.genfromtxt(config['nn_file_name'], names=True, skip_header=1)
     np.testing.assert_array_equal(data['npairs'], true_npairs)
@@ -589,7 +589,7 @@ def test_direct_spherical():
     nbins = 50
     bin_size = np.log(max_sep/min_sep) / nbins
     dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=0.)
+                                sep_units='deg', brute=True)
     dd.process(cat1, cat2)
 
     r1 = np.sqrt(x1**2 + y1**2 + z1**2)
@@ -655,10 +655,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['npairs'], dd.npairs)
     np.testing.assert_allclose(data['DD'], dd.weight)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
-                                sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                sep_units='deg', bin_slop=0, max_top=0)
     dd.process(cat1, cat2)
     np.testing.assert_array_equal(dd.npairs, true_npairs)
     np.testing.assert_allclose(dd.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -746,7 +746,7 @@ def test_direct_3d():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     dd.process(cat1, cat2)
     print('dd.npairs = ',dd.npairs)
 
@@ -799,7 +799,7 @@ def test_direct_perp():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     dd.process(cat1, cat2, metric='FisherRperp')
     print('dd.npairs = ',dd.npairs)
 
@@ -855,7 +855,7 @@ def test_direct_old_perp():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     dd.process(cat1, cat2, metric='OldRperp')
     print('dd.npairs = ',dd.npairs)
 
@@ -913,7 +913,7 @@ def test_direct_lens():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     dd.process(cat1, cat2, metric='Rlens')
     print('dd.npairs = ',dd.npairs)
 
@@ -980,7 +980,7 @@ def test_direct_arc():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                 sep_units='arcmin')
     dd.process(cat1, cat2, metric='Arc')
     print('dd.npairs = ',dd.npairs)
@@ -1007,7 +1007,7 @@ def test_direct_arc():
 
     # Repeat with cat2 using 3d positions
     cat2r = treecorr.Catalog(ra=ra2, dec=dec2, r=r2, ra_units='rad', dec_units='rad')
-    dd2r = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    dd2r = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                   sep_units='arcmin')
     dd2r.process(cat1, cat2r, metric='Arc')
     print('dd2r.npairs = ',dd2r.npairs)
@@ -1017,7 +1017,7 @@ def test_direct_arc():
 
     # And cat1 with 3d positions
     cat1r = treecorr.Catalog(ra=ra1, dec=dec1, r=r1, ra_units='rad', dec_units='rad')
-    dd1r = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    dd1r = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                   sep_units='arcmin')
     dd1r.process(cat1r, cat2, metric='Arc')
     print('dd1r.npairs = ',dd1r.npairs)
@@ -1026,7 +1026,7 @@ def test_direct_arc():
     np.testing.assert_array_equal(dd1r.npairs, true_npairs)
 
     # And now both with 3d positions
-    ddr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    ddr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                  sep_units='arcmin')
     ddr.process(cat1r, cat2r, metric='Arc')
     print('ddr.npairs = ',ddr.npairs)
@@ -1064,7 +1064,7 @@ def test_direct_partial():
     min_sep = 1.
     max_sep = 50.
     nbins = 50
-    dda = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    dda = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     dda.process(cat1a, cat2a)
     print('dda.npairs = ',dda.npairs)
 
@@ -1093,7 +1093,7 @@ def test_direct_partial():
     w2[47:129] = 1.
     cat1b = treecorr.Catalog(x=x1, y=y1, w=w1)
     cat2b = treecorr.Catalog(x=x2, y=y2, w=w2)
-    ddb = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.)
+    ddb = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
     ddb.process(cat1b, cat2b)
     print('ddb.npairs = ',ddb.npairs)
     print('diff = ',ddb.npairs - true_npairs)
@@ -1125,7 +1125,7 @@ def test_direct_linear():
     min_sep = 1.
     max_sep = 50.
     nbins = 49
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                 bin_type='Linear')
     dd.process(cat1, cat2)
     print('dd.npairs = ',dd.npairs)
@@ -1178,13 +1178,13 @@ def test_direct_linear():
     with open(rand_file_name2, 'w') as fid:
         for i in range(nrand):
             fid.write(('%.20f %.20f %.20f\n')%(rx2[i],ry2[i],rz2[i]))
-    rr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    rr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                 bin_type='Linear', verbose=0)
     rr.process(rcat1,rcat2)
-    dr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    dr = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                 bin_type='Linear', verbose=0)
     dr.process(cat1,rcat2)
-    rd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0.,
+    rd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True,
                                 bin_type='Linear', verbose=0)
     rd.process(rcat1,cat2)
     xi, varxi = dd.calculateXi(rr, dr, rd)
@@ -1216,14 +1216,14 @@ def test_direct_linear():
     print('diff[diffs] = ',xi[diff_index] - corr2_output['xi'][diff_index])
     np.testing.assert_allclose(corr2_output['xi'], xi, rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16,
+    # Repeat with binslop = 0
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
                                 bin_type='Linear')
     dd.process(cat1, cat2)
     np.testing.assert_array_equal(dd.npairs, true_npairs)
 
     # And again with no top-level recursion
-    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=1.e-16,
+    dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
                                 bin_type='Linear', max_top=0)
     dd.process(cat1, cat2)
     np.testing.assert_array_equal(dd.npairs, true_npairs)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -408,7 +408,7 @@ def test_direct_count():
     max_sep = 50.
     nbins = 50
     dd = treecorr.NNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
-    dd.process(cat1, cat2, num_threads=1)
+    dd.process(cat1, cat2)
     print('dd.npairs = ',dd.npairs)
 
     log_min_sep = np.log(min_sep)
@@ -1830,7 +1830,7 @@ def test_split():
 
     dd_random1 = treecorr.NNCorrelation(bin_size=0.1, min_sep=5., max_sep=25., split_method='random')
     t0 = time.time()
-    dd_random1.process(cat, num_threads=1)
+    dd_random1.process(cat)
     t1 = time.time()
     print('random1: time = ',t1-t0)
     print('npairs = ',dd_random1.npairs)
@@ -1840,7 +1840,7 @@ def test_split():
     cat.nfields.clear()
     dd_random2 = treecorr.NNCorrelation(bin_size=0.1, min_sep=5., max_sep=25., split_method='random')
     t0 = time.time()
-    dd_random2.process(cat, num_threads=1)
+    dd_random2.process(cat)
     t1 = time.time()
     print('random2: time = ',t1-t0)
     print('npairs = ',dd_random2.npairs)

--- a/tests/test_nnn.py
+++ b/tests/test_nnn.py
@@ -501,7 +501,7 @@ def test_direct_count_auto():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=0., verbose=1)
+                                  brute=True, verbose=1)
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
 
@@ -579,7 +579,7 @@ def test_direct_count_auto():
     rrr = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=0, verbose=0)
+                                  brute=True, verbose=0)
     rrr.process(rcat)
     zeta, varzeta = ddd.calculateZeta(rrr)
 
@@ -627,11 +627,11 @@ def test_direct_count_auto():
                                     skip_header=1)
     np.testing.assert_allclose(corr3_output['zeta'], zeta.flatten(), rtol=1.e-3)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0, since the code flow is different from bture=True
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1)
+                                  bin_slop=0, verbose=1)
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
     #print('true_ntri => ',true_ntri)
@@ -642,7 +642,7 @@ def test_direct_count_auto():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1, max_top=0)
+                                  bin_slop=0, verbose=1, max_top=0)
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
     #print('true_ntri => ',true_ntri)
@@ -663,7 +663,7 @@ def test_direct_count_auto():
     config = treecorr.config.read_config('configs/nnn_direct.yaml')
     config['verbose'] = 2
     config['max_top'] = 0
-    config['bin_slop'] = 1.e-16
+    config['bin_slop'] = 0
     treecorr.corr3(config)
     data = np.genfromtxt(config['nnn_file_name'], names=True, skip_header=1)
     np.testing.assert_array_equal(data['ntri'], true_ntri.flatten())
@@ -741,7 +741,7 @@ def test_direct_count_auto():
 
 def test_direct_count_cross():
     # If the catalogs are small enough, we can do a direct count of the number of triangles
-    # to see if comes out right.  This should exactly match the treecorr code if bin_slop=0.
+    # to see if comes out right.  This should exactly match the treecorr code if brute=True
 
     ngal = 50
     s = 10.
@@ -769,7 +769,7 @@ def test_direct_count_cross():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=0., verbose=1)
+                                  brute=True, verbose=1)
     ddd.process(cat1, cat2, cat3)
     #print('ddd.ntri = ',ddd.ntri)
 
@@ -810,11 +810,11 @@ def test_direct_count_cross():
     #print('diff = ',ddd.ntri - true_ntri)
     np.testing.assert_array_equal(ddd.ntri, true_ntri)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1)
+                                  bin_slop=0, verbose=1)
     ddd.process(cat1, cat2, cat3)
     #print('binslop > 0: ddd.ntri = ',ddd.ntri)
     #print('diff = ',ddd.ntri - true_ntri)
@@ -824,7 +824,7 @@ def test_direct_count_cross():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1, max_top=0)
+                                  bin_slop=0, verbose=1, max_top=0)
     ddd.process(cat1, cat2, cat3)
     #print('max_top = 0: ddd.ntri = ',ddd.ntri)
     #print('true_ntri = ',true_ntri)
@@ -888,7 +888,7 @@ def test_direct_spherical():
     nvbins = 10
     max_sep = min_sep * np.exp(nrbins * bin_size)
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=0.)
+                                  sep_units='deg', brute=True)
     ddd.process(cat, num_threads=2)
 
     r = np.sqrt(x**2 + y**2 + z**2)
@@ -958,10 +958,10 @@ def test_direct_spherical():
     np.testing.assert_allclose(data['ntri'], ddd.ntri.flatten())
     np.testing.assert_allclose(data['DDD'], ddd.weight.flatten())
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                  sep_units='deg', bin_slop=0, max_top=0)
     ddd.process(cat)
     np.testing.assert_array_equal(ddd.ntri, true_ntri)
     np.testing.assert_allclose(ddd.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -993,7 +993,7 @@ def test_direct_arc():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nrbins,
                                   nubins=nubins, ubin_size=ubin_size,
                                   nvbins=nvbins, vbin_size=vbin_size,
-                                  sep_units='deg', bin_slop=0.)
+                                  sep_units='deg', brute=True)
     ddd.process(cat, metric='Arc')
 
     r = np.sqrt(x**2 + y**2 + z**2)
@@ -1061,12 +1061,12 @@ def test_direct_arc():
     np.testing.assert_allclose(data['ntri'], ddd.ntri.flatten())
     np.testing.assert_allclose(data['DDD'], ddd.weight.flatten())
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     # And don't do any top-level recursion so we actually test not going to the leaves.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nrbins,
                                   nubins=nubins, ubin_size=ubin_size,
                                   nvbins=nvbins, vbin_size=vbin_size,
-                                  sep_units='deg', bin_slop=1.e-16, max_top=0)
+                                  sep_units='deg', bin_slop=0, max_top=0)
     ddd.process(cat)
     np.testing.assert_array_equal(ddd.ntri, true_ntri)
     np.testing.assert_allclose(ddd.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -1101,7 +1101,7 @@ def test_direct_partial():
     ddda = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                    min_u=min_u, max_u=max_u, nubins=nubins,
                                    min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                   bin_slop=0.)
+                                   brute=True)
     ddda.process(cat1a, cat2a, cat3a)
     #print('ddda.ntri = ',ddda.ntri)
 
@@ -1156,7 +1156,7 @@ def test_direct_partial():
     dddb = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                    min_u=min_u, max_u=max_u, nubins=nubins,
                                    min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                   bin_slop=0.)
+                                   brute=True)
     dddb.process(cat1b, cat2b, cat3b)
     #print('dddb.ntri = ',dddb.ntri)
     #print('diff = ',dddb.ntri - true_ntri)
@@ -1206,7 +1206,7 @@ def test_direct_3d_auto():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=0., verbose=1)
+                                  brute=True, verbose=1)
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
 
@@ -1268,11 +1268,11 @@ def test_direct_3d_auto():
     #print('diff = ',ddd.ntri - true_ntri)
     np.testing.assert_array_equal(ddd.ntri, true_ntri)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1)
+                                  bin_slop=0, verbose=1)
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
     #print('diff = ',ddd.ntri - true_ntri)
@@ -1282,7 +1282,7 @@ def test_direct_3d_auto():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1, max_top=0)
+                                  bin_slop=0, verbose=1, max_top=0)
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
     #print('true_ntri => ',true_ntri)
@@ -1345,7 +1345,7 @@ def test_direct_3d_cross():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=0., verbose=1)
+                                  brute=True, verbose=1)
     ddd.process(cat1, cat2, cat3)
     #print('ddd.ntri = ',ddd.ntri)
 
@@ -1389,11 +1389,11 @@ def test_direct_3d_cross():
     #print('diff = ',ddd.ntri - true_ntri)
     np.testing.assert_array_equal(ddd.ntri, true_ntri)
 
-    # Repeat with binslop not precisely 0, since the code flow is different for bin_slop == 0.
+    # Repeat with binslop = 0
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1)
+                                  bin_slop=0, verbose=1)
     ddd.process(cat1, cat2, cat3)
     #print('binslop > 0: ddd.ntri = ',ddd.ntri)
     #print('diff = ',ddd.ntri - true_ntri)
@@ -1403,7 +1403,7 @@ def test_direct_3d_cross():
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
                                   min_u=min_u, max_u=max_u, nubins=nubins,
                                   min_v=min_v, max_v=max_v, nvbins=nvbins,
-                                  bin_slop=1.e-16, verbose=1, max_top=0)
+                                  bin_slop=0, verbose=1, max_top=0)
     ddd.process(cat1, cat2, cat3)
     #print('max_top = 0: ddd.ntri = ',ddd.ntri)
     #print('true_ntri = ',true_ntri)

--- a/tests/test_nnn.py
+++ b/tests/test_nnn.py
@@ -652,7 +652,7 @@ def test_direct_count_auto():
     # This should be equivalent to processing a cross correlation with each catalog being
     # the same thing.
     ddd.clear()
-    ddd.process(cat,cat,cat, num_threads=1)
+    ddd.process(cat,cat,cat, num_threads=2)
     #print('ddd.ntri = ',ddd.ntri)
     #print('true_ntri => ',true_ntri)
     #print('diff = ',ddd.ntri - true_ntri)
@@ -889,7 +889,7 @@ def test_direct_spherical():
     max_sep = min_sep * np.exp(nrbins * bin_size)
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
                                   sep_units='deg', bin_slop=0.)
-    ddd.process(cat, num_threads=1)
+    ddd.process(cat, num_threads=2)
 
     r = np.sqrt(x**2 + y**2 + z**2)
     x /= r;  y /= r;  z /= r
@@ -994,7 +994,7 @@ def test_direct_arc():
                                   nubins=nubins, ubin_size=ubin_size,
                                   nvbins=nvbins, vbin_size=vbin_size,
                                   sep_units='deg', bin_slop=0.)
-    ddd.process(cat, metric='Arc', num_threads=1)
+    ddd.process(cat, metric='Arc')
 
     r = np.sqrt(x**2 + y**2 + z**2)
     x /= r;  y /= r;  z /= r

--- a/tests/test_twod.py
+++ b/tests/test_twod.py
@@ -116,7 +116,8 @@ def test_twod():
     xi_brut = corr2d(x, y, kappa, kappa, w=None, rmax=max_sep, bins=nbins)
 
     cat1 = treecorr.Catalog(x=x, y=y, k=kappa, g1=gamma1, g2=gamma2)
-    kk = treecorr.KKCorrelation(min_sep=0., max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    kk = treecorr.KKCorrelation(min_sep=0., max_sep=max_sep, nbins=nbins, bin_type='TwoD',
+                                brute=True)
 
     # First the simplest case to get right: cross correlation of the catalog with itself.
     kk.process(cat1, cat1)
@@ -135,7 +136,7 @@ def test_twod():
     xi_brut = corr2d(x, y, kappa, kappa, w=1./kappa_err**2, rmax=max_sep, bins=nbins)
     cat2 = treecorr.Catalog(x=x, y=y, k=kappa, g1=gamma1, g2=gamma2, w=1./kappa_err**2)
     # NB. Testing that min_sep = 0 is default
-    kk = treecorr.KKCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    kk = treecorr.KKCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', brute=True)
     kk.process(cat2, cat2)
     print('max abs diff = ',np.max(np.abs(kk.xi - xi_brut)))
     print('max rel diff = ',np.max(np.abs(kk.xi - xi_brut)/np.abs(kk.xi)))
@@ -147,7 +148,7 @@ def test_twod():
     # Check GG
     xi_brut = corr2d(x, y, gamma, np.conj(gamma), rmax=max_sep, bins=nbins)
     # Equivalent bin_size = 2.  Check omitting nbins
-    gg = treecorr.GGCorrelation(max_sep=max_sep, bin_size=2., bin_type='TwoD', bin_slop=0)
+    gg = treecorr.GGCorrelation(max_sep=max_sep, bin_size=2., bin_type='TwoD', brute=True)
     gg.process(cat1)
     print('max abs diff = ',np.max(np.abs(gg.xip - xi_brut)))
     print('max rel diff = ',np.max(np.abs(gg.xip - xi_brut)/np.abs(gg.xip)))
@@ -155,7 +156,7 @@ def test_twod():
 
     xi_brut = corr2d(x, y, gamma, np.conj(gamma), w=1./kappa_err**2, rmax=max_sep, bins=nbins)
     # Check omitting max_sep
-    gg = treecorr.GGCorrelation(bin_size=2, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    gg = treecorr.GGCorrelation(bin_size=2, nbins=nbins, bin_type='TwoD', brute=True)
     gg.process(cat2)
     print('max abs diff = ',np.max(np.abs(gg.xip - xi_brut)))
     print('max rel diff = ',np.max(np.abs(gg.xip - xi_brut)/np.abs(gg.xip)))
@@ -164,7 +165,7 @@ def test_twod():
     # Check NK
     xi_brut = corr2d(x, y, np.ones_like(kappa), kappa, rmax=max_sep, bins=nbins)
     # Check slightly smaller max_sep gets rounded up.
-    nk = treecorr.NKCorrelation(max_sep=max_sep-0.5, bin_size=2, bin_type='TwoD', bin_slop=0)
+    nk = treecorr.NKCorrelation(max_sep=max_sep-0.5, bin_size=2, bin_type='TwoD', brute=True)
     nk.process(cat1, cat1)
     print('max abs diff = ',np.max(np.abs(nk.xi - xi_brut)))
     print('max rel diff = ',np.max(np.abs(nk.xi - xi_brut)/np.abs(nk.xi)))
@@ -172,7 +173,7 @@ def test_twod():
 
     xi_brut = corr2d(x, y, np.ones_like(kappa), kappa, w=1./kappa_err**2, rmax=max_sep, bins=nbins)
     # Check very small, but non-zeo min_sep
-    nk = treecorr.NKCorrelation(min_sep=1.e-6, max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    nk = treecorr.NKCorrelation(min_sep=1.e-6, max_sep=max_sep, nbins=nbins, bin_type='TwoD', brute=True)
     nk.process(cat2, cat2)
     print('max abs diff = ',np.max(np.abs(nk.xi - xi_brut)))
     print('max rel diff = ',np.max(np.abs(nk.xi - xi_brut)/np.abs(nk.xi)))
@@ -181,7 +182,7 @@ def test_twod():
     # Check NN
     xi_brut, counts = corr2d(x, y, np.ones_like(kappa), np.ones_like(kappa),
                              rmax=max_sep, bins=nbins, return_counts=True)
-    nn = treecorr.NNCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    nn = treecorr.NNCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', brute=True)
     nn.process(cat1)
     print('max abs diff = ',np.max(np.abs(nn.npairs - counts)))
     print('max rel diff = ',np.max(np.abs(nn.npairs - counts)/np.abs(nn.npairs)))
@@ -194,7 +195,7 @@ def test_twod():
 
     xi_brut, counts = corr2d(x, y, np.ones_like(kappa), np.ones_like(kappa),
                              w=1./kappa_err**2, rmax=max_sep, bins=nbins, return_counts=True)
-    nn = treecorr.NNCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    nn = treecorr.NNCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', brute=True)
     nn.process(cat2)
     print('max abs diff = ',np.max(np.abs(nn.weight - counts)))
     print('max rel diff = ',np.max(np.abs(nn.weight - counts)/np.abs(nn.weight)))
@@ -228,15 +229,15 @@ def test_twod_singlebin():
     max_sep = 21.
     nbins = 5  # Use very chunky bins, so more pairs of non-leaf cells can fall in single bin.
 
-    # First use bin_slop=0 for reference
-    gg0 = treecorr.GGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    # First use brute force for reference
+    gg0 = treecorr.GGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', brute=True)
     t0 = time.time()
     gg0.process(cat)
     t1 = time.time()
     print('t for bs=0 = ',t1-t0)
 
-    # Now do bin_slop << 1, but not 0.
-    gg1 = treecorr.GGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=1.e-10)
+    # Now do bin_slop = 0
+    gg1 = treecorr.GGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
     t0 = time.time()
     gg1.process(cat)
     t1 = time.time()
@@ -263,13 +264,13 @@ def test_twod_singlebin():
     np.testing.assert_allclose(gg2.xim, gg0.xim, atol=1.e-4)
 
     # Repeat with NG and KG so we can test those routines too.
-    ng0 = treecorr.NGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
+    ng0 = treecorr.NGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', brute=True)
     t0 = time.time()
     ng0.process(cat, cat)
     t1 = time.time()
     print('t for bs=0 = ',t1-t0)
 
-    ng1 = treecorr.NGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=1.e-10)
+    ng1 = treecorr.NGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
     t0 = time.time()
     ng1.process(cat, cat)
     t1 = time.time()
@@ -289,7 +290,7 @@ def test_twod_singlebin():
     np.testing.assert_allclose(ng2.npairs, ng0.npairs, rtol=1.e-2)
     np.testing.assert_allclose(ng2.xi, ng0.xi, atol=5.e-4)
 
-    kg1 = treecorr.KGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=1.e-10)
+    kg1 = treecorr.KGCorrelation(max_sep=max_sep, nbins=nbins, bin_type='TwoD', bin_slop=0)
     t0 = time.time()
     kg1.process(cat, cat)
     t1 = time.time()

--- a/treecorr/__init__.py
+++ b/treecorr/__init__.py
@@ -37,7 +37,8 @@ if not os.path.exists(lib_file): # pragma: no cover
 # Load the C functions with cffi
 _ffi = cffi.FFI()
 for file_name in glob.glob(os.path.join(include_dir,'*_C.h')):
-    _ffi.cdef(open(file_name).read())
+    with open(file_name) as fin:
+        _ffi.cdef(fin.read())
 _lib = _ffi.dlopen(lib_file)
 
 from . import util

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -531,6 +531,9 @@ class BinnedCorr2(object):
         f2 = cat2.field
 
         if f1 is None or f1._coords != self._coords:
+            # I don't really know if it's possible to get the coords out of sync,
+            # so the 2nd check might be superfluous.
+            # The first one though is definitely possible, so we need to check that.
             self.logger.debug("In sample_pairs, making default field for cat1")
             f1 = cat1.getNField()
         if f2 is None or f2._coords != self._coords:

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -568,8 +568,8 @@ class BinnedCorr2(object):
         i2 = np.zeros(n, dtype=int)
         sep = np.zeros(n, dtype=float)
         ntot = treecorr._lib.SamplePairs(self.corr, f1.data, f2.data, min_sep, max_sep,
-                                         f1._d, f2._d, self._coords, self._metric,
-                                         self._bintype, lp(i1), lp(i2), dp(sep), n)
+                                         f1._d, f2._d, self._coords, self._bintype, self._metric,
+                                         lp(i1), lp(i2), dp(sep), n)
 
         if ntot < n:
             n = ntot

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -501,6 +501,11 @@ class BinnedCorr2(object):
         using an exact range without any slop, you should construct a new Correlation instance
         with bin_slop=0, and call sample_pairs with that.
 
+        The returned separations will likewise correspond to the separation of the cells in the
+        tree where the correlation function would have decided that the pair falls into the
+        given bin.  Therefore, if these cells were not leaf cells, then they will not typically
+        be equal to the real separation for the given metric.
+
         Also, note that min_sep and max_sep may be arbitrary.  There is no requirement that they
         be edges of one of the standard bins for this correlation function.  There is also no
         requirement that this correlation instance has already accumulated pairs via a call

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -456,8 +456,7 @@ class BinnedCorr3(object):
                     self.process_cross(c1,c3,c2, metric, num_threads)
                     self.process_cross(c3,c1,c2, metric, num_threads)
 
-    # These are not actually implemented yet.
-    def _process_all_cross(self, cat1, cat2, cat3, metric, num_threads): # pragma: nocover
+    def _process_all_cross(self, cat1, cat2, cat3, metric, num_threads):
         for c1 in cat1:
             for c2 in cat2:
                 for c3 in cat3:

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -119,6 +119,13 @@ class BinnedCorr3(object):
     :param min_v:       Analogous to min_sep for the v direction. (default: -1)
     :param max_v:       Analogous to max_sep for the v direction. (default: 1)
 
+    :param brute:       Whether to use the "brute force" algorithm.  (default: False) Options are:
+
+                        - False (the default): Stop at non-leaf cells whenever the error in the
+                          separation is compatible with the given bin_slop.
+                        - True: Go to the leaves for all catalogs.
+                        (The number options allowed for 2pt correlations are not enabled here.)
+
     :param verbose:     If no logger is provided, this will optionally specify a logging level to
                         use:
 
@@ -189,6 +196,8 @@ class BinnedCorr3(object):
                 'The minimum v to include in the output.'),
         'max_v' : (float, False, None, None,
                 'The maximum v to include in the output.'),
+        'brute' : (bool, False, False, [False, True],
+                'Whether to use brute-force algorithm'),
         'verbose' : (int, False, 1, [0, 1, 2, 3],
                 'How verbose the code should be during processing. ',
                 '0 = Errors Only, 1 = Warnings, 2 = Progress, 3 = Debugging'),
@@ -398,6 +407,9 @@ class BinnedCorr3(object):
         self.v = np.tile(self.v1d[np.newaxis, np.newaxis, :],
                             (self.nbins, self.nubins, 1))
         self.rnom = np.exp(self.logr)
+        self.brute = treecorr.config.get(self.config,'brute',bool,False)
+        if self.brute:
+            self.logger.info("Doing brute force calculation.",)
         self.coords = None
         self.metric = None
         self.min_rpar = treecorr.config.get(self.config,'min_rpar',float,-sys.float_info.max)

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -602,21 +602,19 @@ class Catalog(object):
         # Copy w to wpos if necessary (Do this after checkForNaN's, since this may set some
         # entries to have w=0.)
         if self.wpos is None:
-            self.nontrivial_wpos = False
-            self.wpos = self.w
             self.logger.debug('Using w for wpos')
         else:
-            self.nontrivial_wpos = True
-            # Also check that any wpos == 0 points also have w == 0
+            # Check that any wpos == 0 points also have w == 0
             if np.any(self.wpos == 0.):
-                if self.nontrivial_w:
+                if self.w is None:
+                    self.logger.warning('Some wpos values are zero, setting w=0 for these points.')
+                    self.w = np.ones((self.ntot), dtype=float)
+                    self.w[self.wpos == 0.] = 0.
+                else:
                     if np.any(self.w[self.wpos == 0.] != 0.):
                         self.logger.error('Some wpos values = 0 but have w!=0. This is invalid.\n'
                                           'Setting w=0 for these points.')
                         self.w[self.wpos == 0.] = 0.
-                else:
-                    self.logger.warning('Some wpos values are zero, setting w=0 for these points.')
-                    self.w[self.wpos == 0.] = 0.
 
         if self.ra is not None:
             # Should have already been checked above, so just use assert here.
@@ -1237,7 +1235,7 @@ class Catalog(object):
             :y:         if self.y is not None
             :z:         if self.z is not None
             :w:         if self.w is not None and self.nontrivial_w
-            :wpos:      if self.wpos is not None and self.nontrivial_wpos
+            :wpos:      if self.wpos is not None
             :g1:        if self.g1 is not None
             :g2:        if self.g2 is not None
             :k:         if self.k is not None
@@ -1274,7 +1272,7 @@ class Catalog(object):
         if self.nontrivial_w:
             col_names.append('w')
             columns.append(self.w)
-        if self.nontrivial_wpos:
+        if self.wpos is not None:
             col_names.append('wpos')
             columns.append(self.wpos)
         if self.g1 is not None:

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -1081,21 +1081,21 @@ class Catalog(object):
         self.gsimplefields.clear()
 
 
-    def getNField(self, min_size, max_size, split_method=None, max_top=10, coords=None,
+    def getNField(self, min_size=0, max_size=None, split_method=None, max_top=10, coords=None,
                   logger=None):
         """Return an NField based on the positions in this catalog.
 
         The NField object is cached, so this is efficient to call multiple times.
         cf. resize_cache() and clear_cache()
 
-        :param min_size:    The minimum radius cell required (usually min_sep).
-        :param max_size:    The maximum radius cell required (usually max_sep).
+        :param min_size:    The minimum radius cell required (usually min_sep). (default: 0)
+        :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
         :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                             (default: 'mean'; this value can also be given in the Catalog
                             constructor in the config dict.)
         :param max_top:     The maximum number of top layers to use when setting up the
                             field. (default: 10)
-        :param coords       The kind of coordinate system to use. (default self.coords)
+        :param coords       The kind of coordinate system to use. (default: self.coords)
         :param logger:      A logger file if desired (default: self.logger)
 
         :returns:           A :class:`~treecorr.NField` object
@@ -1108,15 +1108,15 @@ class Catalog(object):
                             logger=logger)
 
 
-    def getKField(self, min_size, max_size, split_method=None, max_top=10, coords=None,
+    def getKField(self, min_size=0, max_size=None, split_method=None, max_top=10, coords=None,
                   logger=None):
         """Return a KField based on the k values in this catalog.
 
         The KField object is cached, so this is efficient to call multiple times.
         cf. resize_cache() and clear_cache()
 
-        :param min_size:    The minimum radius cell required (usually min_sep).
-        :param max_size:    The maximum radius cell required (usually max_sep).
+        :param min_size:    The minimum radius cell required (usually min_sep). (default: 0)
+        :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
         :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                             (default: 'mean'; this value can also be given in the Catalog
                             constructor in the config dict.)
@@ -1137,15 +1137,15 @@ class Catalog(object):
                             logger=logger)
 
 
-    def getGField(self, min_size, max_size, split_method=None, max_top=10, coords=None,
+    def getGField(self, min_size=0, max_size=None, split_method=None, max_top=10, coords=None,
                   logger=None):
         """Return a GField based on the g1,g2 values in this catalog.
 
         The GField object is cached, so this is efficient to call multiple times.
         cf. resize_cache() and clear_cache()
 
-        :param min_size:    The minimum radius cell required (usually min_sep).
-        :param max_size:    The maximum radius cell required (usually max_sep).
+        :param min_size:    The minimum radius cell required (usually min_sep). (default: 0)
+        :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
         :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                             (default: 'mean'; this value can also be given in the Catalog
                             constructor in the config dict.)

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -1097,8 +1097,8 @@ class Catalog(object):
         # But if the weakref is alive, this returns the field we want.
         return self._field()
 
-    def getNField(self, min_size=0, max_size=None, split_method=None, max_top=10, coords=None,
-                  logger=None):
+    def getNField(self, min_size=0, max_size=None, split_method=None, brute=False,
+                  max_top=10, coords=None, logger=None):
         """Return an NField based on the positions in this catalog.
 
         The NField object is cached, so this is efficient to call multiple times.
@@ -1109,6 +1109,7 @@ class Catalog(object):
         :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                             (default: 'mean'; this value can also be given in the Catalog
                             constructor in the config dict.)
+        :param brute        Whether to force traversal to the leaves. (default: False)
         :param max_top:     The maximum number of top layers to use when setting up the
                             field. (default: 10)
         :param coords       The kind of coordinate system to use. (default: self.coords)
@@ -1120,14 +1121,14 @@ class Catalog(object):
             split_method = treecorr.config.get(self.config,'split_method',str,'mean')
         if logger is None:
             logger = self.logger
-        field = self.nfields(min_size, max_size, split_method, max_top, coords,
+        field = self.nfields(min_size, max_size, split_method, brute, max_top, coords,
                              logger=logger)
         self._field = weakref.ref(field)
         return field
 
 
-    def getKField(self, min_size=0, max_size=None, split_method=None, max_top=10, coords=None,
-                  logger=None):
+    def getKField(self, min_size=0, max_size=None, split_method=None, brute=False,
+                  max_top=10, coords=None, logger=None):
         """Return a KField based on the k values in this catalog.
 
         The KField object is cached, so this is efficient to call multiple times.
@@ -1138,6 +1139,7 @@ class Catalog(object):
         :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                             (default: 'mean'; this value can also be given in the Catalog
                             constructor in the config dict.)
+        :param brute        Whether to force traversal to the leaves. (default: False)
         :param max_top:     The maximum number of top layers to use when setting up the
                             field. (default: 10)
         :param coords       The kind of coordinate system to use. (default self.coords)
@@ -1151,14 +1153,14 @@ class Catalog(object):
             raise AttributeError("k is not defined.")
         if logger is None:
             logger = self.logger
-        field = self.kfields(min_size, max_size, split_method, max_top, coords,
+        field = self.kfields(min_size, max_size, split_method, brute, max_top, coords,
                              logger=logger)
         self._field = weakref.ref(field)
         return field
 
 
-    def getGField(self, min_size=0, max_size=None, split_method=None, max_top=10, coords=None,
-                  logger=None):
+    def getGField(self, min_size=0, max_size=None, split_method=None, brute=False,
+                  max_top=10, coords=None, logger=None):
         """Return a GField based on the g1,g2 values in this catalog.
 
         The GField object is cached, so this is efficient to call multiple times.
@@ -1169,6 +1171,7 @@ class Catalog(object):
         :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                             (default: 'mean'; this value can also be given in the Catalog
                             constructor in the config dict.)
+        :param brute        Whether to force traversal to the leaves. (default: False)
         :param max_top:     The maximum number of top layers to use when setting up the
                             field. (default: 10)
         :param coords       The kind of coordinate system to use. (default self.coords)
@@ -1182,7 +1185,7 @@ class Catalog(object):
             raise AttributeError("g1,g2 are not defined.")
         if logger is None:
             logger = self.logger
-        field = self.gfields(min_size, max_size, split_method, max_top, coords,
+        field = self.gfields(min_size, max_size, split_method, brute, max_top, coords,
                              logger=logger)
         self._field = weakref.ref(field)
         return field

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -383,7 +383,7 @@ class Catalog(object):
         self.g2 = None
         self.k = None
 
-        # Make simple functions that call NField, etc. with self ast the first argument.
+        # Make simple functions that call NField, etc. with self as the first argument.
 
         def get_nfield(*args, **kwargs): return treecorr.NField(self, *args, **kwargs)
         def get_kfield(*args, **kwargs): return treecorr.KField(self, *args, **kwargs)

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -577,6 +577,22 @@ class Catalog(object):
         self.checkForNaN(self.w,'w')
         self.checkForNaN(self.wpos,'wpos')
 
+        # Copy w to wpos if necessary (Do this after checkForNaN's, since this may set some
+        # entries to have w=0.)
+        if self.wpos is None:
+            self.logger.debug('Using w for wpos')
+        else:
+            # Check that any wpos == 0 points also have w == 0
+            if np.any(self.wpos == 0.):
+                if self.w is None:
+                    self.logger.warning('Some wpos values are zero, setting w=0 for these points.')
+                    self.w = np.ones((self.ntot), dtype=float)
+                else:
+                    if np.any(self.w[self.wpos == 0.] != 0.):
+                        self.logger.error('Some wpos values = 0 but have w!=0. This is invalid.\n'
+                                          'Setting w=0 for these points.')
+                self.w[self.wpos == 0.] = 0.
+
         # Calculate some summary parameters here that will typically be needed
         if self.w is not None:
             self.nontrivial_w = True
@@ -608,23 +624,6 @@ class Catalog(object):
             else:
                 self.vark = 0.
             self.w = np.ones((self.ntot), dtype=float)
-
-        # Copy w to wpos if necessary (Do this after checkForNaN's, since this may set some
-        # entries to have w=0.)
-        if self.wpos is None:
-            self.logger.debug('Using w for wpos')
-        else:
-            # Check that any wpos == 0 points also have w == 0
-            if np.any(self.wpos == 0.):
-                if self.w is None:
-                    self.logger.warning('Some wpos values are zero, setting w=0 for these points.')
-                    self.w = np.ones((self.ntot), dtype=float)
-                    self.w[self.wpos == 0.] = 0.
-                else:
-                    if np.any(self.w[self.wpos == 0.] != 0.):
-                        self.logger.error('Some wpos values = 0 but have w!=0. This is invalid.\n'
-                                          'Setting w=0 for these points.')
-                        self.w[self.wpos == 0.] = 0.
 
         if self.ra is not None:
             # Should have already been checked above, so just use assert here.

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -75,7 +75,7 @@ def parse_bool(value):
             except Exception:
                 raise ValueError("Unable to parse %s as a bool."%value)
     elif isinstance(value,(bool, int)):
-        return int(value)
+        return value
     else:
         raise ValueError("Unable to parse %s as a bool."%value)
 

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -75,7 +75,7 @@ def parse_bool(value):
             except Exception:
                 raise ValueError("Unable to parse %s as a bool."%value)
     elif isinstance(value,(bool, int)):
-        return bool(value)
+        return int(value)
     else:
         raise ValueError("Unable to parse %s as a bool."%value)
 

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -305,8 +305,8 @@ class KField(Field):
         self.max_size = float(max_size) if max_size is not None else 1.e300
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
-        self._d = 2  # KData
         self.max_top = int(max_top)
+        self._d = 2  # KData
         self.coords = coords if coords is not None else cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 
@@ -359,8 +359,8 @@ class GField(Field):
         self.max_size = float(max_size) if max_size is not None else 1.e300
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
-        self._d = 3  # GData
         self.max_top = int(max_top)
+        self._d = 3  # GData
         self.coords = coords if coords is not None else cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -80,6 +80,25 @@ class NField(object):
         """The number of top-level nodes."""
         return treecorr._lib.NFieldGetNTopLevel(self.data, self._coords)
 
+    def count_near(self, x, y, z, sep):
+        """Count how many points are near a given coordinate.
+
+        Note: This function requires the coordinate to be given as (x,y,z) and the separation
+              in compatible units.  There is also a version of this function in the Catalog
+              class, which allows for more flexible specification of the coordinate
+              (e.g. using ra, dec).
+
+        :param x:       The x coordinate of the location for which to count nearby points.
+        :param y:       The y coordinate of the location for which to count nearby points.
+        :param z:       The z coordinate of the location for which to count nearby points.
+        :param sep:     The separation distance
+        """
+        x = float(x)
+        y = float(y)
+        z = float(z)
+        sep = float(sep)
+        return treecorr._lib.NFieldCountNear(self.data, x, y, z, sep, self._coords)
+
 
 class KField(object):
     """This class stores the kappa field in a tree structure from which it is efficient
@@ -137,6 +156,25 @@ class KField(object):
     def nTopLevelNodes(self):
         """The number of top-level nodes."""
         return treecorr._lib.NFieldGetNTopLevel(self.data, self._coords)
+
+    def count_near(self, x, y, z, sep):
+        """Count how many points are near a given coordinate.
+
+        Note: This function requires the coordinate to be given as (x,y,z) and the separation
+              in compatible units.  There is also a version of this function in the Catalog
+              class, which allows for more flexible specification of the coordinate
+              (e.g. using ra, dec).
+
+        :param x:       The x coordinate of the location for which to count nearby points.
+        :param y:       The y coordinate of the location for which to count nearby points.
+        :param z:       The z coordinate of the location for which to count nearby points.
+        :param sep:     The separation distance
+        """
+        x = float(x)
+        y = float(y)
+        z = float(z)
+        sep = float(sep)
+        return treecorr._lib.KFieldCountNear(self.data, x, y, z, sep, self._coords)
 
 
 
@@ -196,6 +234,25 @@ class GField(object):
     def nTopLevelNodes(self):
         """The number of top-level nodes."""
         return treecorr._lib.GFieldGetNTopLevel(self.data, self._coords)
+
+    def count_near(self, x, y, z, sep):
+        """Count how many points are near a given coordinate.
+
+        Note: This function requires the coordinate to be given as (x,y,z) and the separation
+              in compatible units.  There is also a version of this function in the Catalog
+              class, which allows for more flexible specification of the coordinate
+              (e.g. using ra, dec).
+
+        :param x:       The x coordinate of the location for which to count nearby points.
+        :param y:       The y coordinate of the location for which to count nearby points.
+        :param z:       The z coordinate of the location for which to count nearby points.
+        :param sep:     The separation distance
+        """
+        x = float(x)
+        y = float(y)
+        z = float(z)
+        sep = float(sep)
+        return treecorr._lib.GFieldCountNear(self.data, x, y, z, sep, self._coords)
 
 
 class NSimpleField(object):

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -233,13 +233,14 @@ class NField(Field):
     :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
     :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                         (default: 'mean')
+    :param brute        Whether to force traversal to the leaves for this field. (default: False)
     :param max_top:     The maximum number of top layers to use when setting up the field.
                         (default: 10)
     :param coords       The kind of coordinate system to use. (default: cat.coords)
     :param logger:      A logger file if desired (default: None)
     """
-    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', max_top=10, coords=None,
-                 logger=None):
+    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', brute=False,
+                 max_top=10, coords=None, logger=None):
         from treecorr.util import double_ptr as dp
         if logger:
             if cat.name != '':
@@ -248,19 +249,20 @@ class NField(Field):
                 logger.info('Building NField')
 
         self._cat = weakref.ref(cat)
-        self.min_size = float(min_size)
-        self.max_size = float(max_size) if max_size is not None else 1.e300
+        self.min_size = float(min_size) if not brute else 0.
+        self.max_size = float(max_size) if max_size is not None else np.inf
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
-        self.max_top = int(max_top)
         self._d = 1  # NData
+        self.brute = bool(brute)
+        self.max_top = int(max_top)
         self.coords = coords if coords is not None else cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 
         self.data = treecorr._lib.BuildNField(dp(cat.x), dp(cat.y), dp(cat.z),
                                               dp(cat.w), dp(cat.wpos), cat.ntot,
                                               self.min_size, self.max_size, self._sm,
-                                              self.max_top, self._coords)
+                                              self.brute, self.max_top, self._coords)
         if logger:
             logger.debug('Finished building NField (%s)',self.coords)
 
@@ -286,13 +288,14 @@ class KField(Field):
     :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
     :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                         (default: 'mean')
+    :param brute        Whether to force traversal to the leaves for this field. (default: False)
     :param max_top:     The maximum number of top layers to use when setting up the field.
                         (default: 10)
     :param coords       The kind of coordinate system to use. (default: cat.coords)
     :param logger:      A logger file if desired (default: None)
     """
-    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', max_top=10, coords=None,
-                 logger=None):
+    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', brute=False,
+                 max_top=10, coords=None, logger=None):
         from treecorr.util import double_ptr as dp
         if logger:
             if cat.name != '':
@@ -301,12 +304,13 @@ class KField(Field):
                 logger.info('Building KField')
 
         self._cat = weakref.ref(cat)
-        self.min_size = float(min_size)
-        self.max_size = float(max_size) if max_size is not None else 1.e300
+        self.min_size = float(min_size) if not brute else 0.
+        self.max_size = float(max_size) if max_size is not None else np.inf
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
-        self.max_top = int(max_top)
         self._d = 2  # KData
+        self.brute = bool(brute)
+        self.max_top = int(max_top)
         self.coords = coords if coords is not None else cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 
@@ -314,7 +318,7 @@ class KField(Field):
                                               dp(cat.k),
                                               dp(cat.w), dp(cat.wpos), cat.ntot,
                                               self.min_size, self.max_size, self._sm,
-                                              self.max_top, self._coords)
+                                              self.brute, self.max_top, self._coords)
         if logger:
             logger.debug('Finished building KField (%s)',self.coords)
 
@@ -340,13 +344,14 @@ class GField(Field):
     :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
     :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                         (default: 'mean')
+    :param brute        Whether to force traversal to the leaves for this field. (default: False)
     :param max_top:     The maximum number of top layers to use when setting up the field.
                         (default: 10)
     :param coords       The kind of coordinate system to use. (default: cat.coords)
     :param logger:      A logger file if desired (default: None)
     """
-    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', max_top=10, coords=None,
-                 logger=None):
+    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', brute=False,
+                 max_top=10, coords=None, logger=None):
         from treecorr.util import double_ptr as dp
         if logger:
             if cat.name != '':
@@ -355,12 +360,13 @@ class GField(Field):
                 logger.info('Building GField')
 
         self._cat = weakref.ref(cat)
-        self.min_size = float(min_size)
-        self.max_size = float(max_size) if max_size is not None else 1.e300
+        self.min_size = float(min_size) if not brute else 0.
+        self.max_size = float(max_size) if max_size is not None else np.inf
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
-        self.max_top = int(max_top)
         self._d = 3  # GData
+        self.brute = bool(brute)
+        self.max_top = int(max_top)
         self.coords = coords if coords is not None else cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 
@@ -368,7 +374,7 @@ class GField(Field):
                                               dp(cat.g1), dp(cat.g2),
                                               dp(cat.w), dp(cat.wpos), cat.ntot,
                                               self.min_size, self.max_size, self._sm,
-                                              self.max_top, self._coords)
+                                              self.brute, self.max_top, self._coords)
         if logger:
             logger.debug('Finished building GField (%s)',self.coords)
 

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -34,16 +34,16 @@ class NField(object):
         >>> nfield = cat.getNField(min_size, max_size, b)
 
     :param cat:         The catalog from which to make the field.
-    :param min_size:    The minimum radius cell required (usually min_sep).
-    :param max_size:    The maximum radius cell required (usually max_sep).
+    :param min_size:    The minimum radius cell required (usually min_sep). (default: 0)
+    :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
     :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                         (default: 'mean')
     :param max_top:     The maximum number of top layers to use when setting up the field.
                         (default: 10)
-    :param coords       The kind of coordinate system to use. (default cat.coords)
+    :param coords       The kind of coordinate system to use. (default: cat.coords)
     :param logger:      A logger file if desired (default: None)
     """
-    def __init__(self, cat, min_size, max_size, split_method='mean', max_top=10, coords=None,
+    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', max_top=10, coords=None,
                  logger=None):
         from treecorr.util import double_ptr as dp
         if logger:
@@ -52,8 +52,8 @@ class NField(object):
             else:
                 logger.info('Building NField')
 
-        self.min_size = min_size
-        self.max_size = max_size
+        self.min_size = float(min_size)
+        self.max_size = float(max_size) if max_size is not None else 1.e300
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
         self.max_top = int(max_top)
@@ -90,16 +90,16 @@ class KField(object):
         >>> kfield = cat.getKField(min_size, max_size, b)
 
     :param cat:         The catalog from which to make the field.
-    :param min_size:    The minimum radius cell required (usually min_sep).
-    :param max_size:    The maximum radius cell required (usually max_sep).
+    :param min_size:    The minimum radius cell required (usually min_sep). (default: 0)
+    :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
     :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                         (default: 'mean')
-    :param max_top:     The maximum number of top layers to use when setting up the
-                        field. (default: 10)
-    :param coords       The kind of coordinate system to use. (default cat.coords)
+    :param max_top:     The maximum number of top layers to use when setting up the field.
+                        (default: 10)
+    :param coords       The kind of coordinate system to use. (default: cat.coords)
     :param logger:      A logger file if desired (default: None)
     """
-    def __init__(self, cat, min_size, max_size, split_method='mean', max_top=10, coords=None,
+    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', max_top=10, coords=None,
                  logger=None):
         from treecorr.util import double_ptr as dp
         if logger:
@@ -108,8 +108,8 @@ class KField(object):
             else:
                 logger.info('Building KField')
 
-        self.min_size = min_size
-        self.max_size = max_size
+        self.min_size = float(min_size)
+        self.max_size = float(max_size) if max_size is not None else 1.e300
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
         self.max_top = int(max_top)
@@ -149,16 +149,16 @@ class GField(object):
         >>> gfield = cat.getGField(min_size, max_size, b)
 
     :param cat:         The catalog from which to make the field.
-    :param min_size:    The minimum radius cell required (usually min_sep).
-    :param max_size:    The maximum radius cell required (usually max_sep).
+    :param min_size:    The minimum radius cell required (usually min_sep). (default: 0)
+    :param max_size:    The maximum radius cell required (usually max_sep). (default: None)
     :param split_method: Which split method to use ('mean', 'median', 'middle', or 'random')
                         (default: 'mean')
-    :param max_top:     The maximum number of top layers to use when setting up the
-                        field. (default: 10)
-    :param coords       The kind of coordinate system to use. (default cat.coords)
+    :param max_top:     The maximum number of top layers to use when setting up the field.
+                        (default: 10)
+    :param coords       The kind of coordinate system to use. (default: cat.coords)
     :param logger:      A logger file if desired (default: None)
     """
-    def __init__(self, cat, min_size, max_size, split_method='mean', max_top=10, coords=None,
+    def __init__(self, cat, min_size=0, max_size=None, split_method='mean', max_top=10, coords=None,
                  logger=None):
         from treecorr.util import double_ptr as dp
         if logger:
@@ -167,8 +167,8 @@ class GField(object):
             else:
                 logger.info('Building GField')
 
-        self.min_size = min_size
-        self.max_size = max_size
+        self.min_size = float(min_size)
+        self.max_size = float(max_size) if max_size is not None else 1.e300
         self.split_method = split_method
         self._sm = _parse_split_method(split_method)
         self.max_top = int(max_top)

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -80,23 +80,46 @@ class NField(object):
         """The number of top-level nodes."""
         return treecorr._lib.NFieldGetNTopLevel(self.data, self._coords)
 
-    def count_near(self, x, y, z, sep):
+    def count_near(self, *args, **kwargs):
         """Count how many points are near a given coordinate.
 
-        Note: This function requires the coordinate to be given as (x,y,z) and the separation
-              in compatible units.  There is also a version of this function in the Catalog
-              class, which allows for more flexible specification of the coordinate
-              (e.g. using ra, dec).
+        There are several options for how to specify the reference coordinate, which depends
+        on the type of coordinate system this field implements.
 
-        :param x:       The x coordinate of the location for which to count nearby points.
-        :param y:       The y coordinate of the location for which to count nearby points.
-        :param z:       The z coordinate of the location for which to count nearby points.
-        :param sep:     The separation distance
+        1. If self.coords == 'flat', you should provide:
+
+            :param x:       The x coordinate of the location for which to count nearby points.
+            :param y:       The y coordinate of the location for which to count nearby points.
+            :param sep:     The separation distance
+
+        2. If self.coords == '3d', you should provide:
+
+        Either
+            :param x:       The x coordinate of the location for which to count nearby points.
+            :param y:       The y coordinate of the location for which to count nearby points.
+            :param z:       The z coordinate of the location for which to count nearby points.
+            :param sep:     The separation distance
+
+        Or
+            :param ra:      The right ascension of the location for which to count nearby points.
+            :param dec:     The declination of the location for which to count nearby points.
+            :param r:       The distance to the location for which to count nearby points.
+            :param sep:     The separation distance
+
+        3. If self.coords == 'spherical', you should provide:
+
+            :param ra:      The right ascension of the location for which to count nearby points.
+            :param dec:     The declination of the location for which to count nearby points.
+            :param sep:     The separation distance as an angle
+
+        In all cases, for parameters that angles (ra, dec, sep for 'spherical'), you may either
+        provide this quantity as a coord.Angle instance, or you may provide ra_units, dec_units
+        or sep_units respectively to specify which angular units are providing.
+
+        Finally, in cases where ra, dec are allowed, you may instead provide a
+        coord.CelestialCoord instance as the first argument to specify both RA and Dec.
         """
-        x = float(x)
-        y = float(y)
-        z = float(z)
-        sep = float(sep)
+        x,y,z,sep = treecorr.util.parse_xyzsep(args, kwargs, self._coords)
         return treecorr._lib.NFieldCountNear(self.data, x, y, z, sep, self._coords)
 
 
@@ -157,23 +180,14 @@ class KField(object):
         """The number of top-level nodes."""
         return treecorr._lib.NFieldGetNTopLevel(self.data, self._coords)
 
-    def count_near(self, x, y, z, sep):
+    def count_near(self, *args, **kwargs):
         """Count how many points are near a given coordinate.
 
-        Note: This function requires the coordinate to be given as (x,y,z) and the separation
-              in compatible units.  There is also a version of this function in the Catalog
-              class, which allows for more flexible specification of the coordinate
-              (e.g. using ra, dec).
-
-        :param x:       The x coordinate of the location for which to count nearby points.
-        :param y:       The y coordinate of the location for which to count nearby points.
-        :param z:       The z coordinate of the location for which to count nearby points.
-        :param sep:     The separation distance
+        There are several options for how to specify the reference coordinate, which depends
+        on the type of coordinate system this field implements.  See NField.count_near
+        for details.
         """
-        x = float(x)
-        y = float(y)
-        z = float(z)
-        sep = float(sep)
+        x,y,z,sep = treecorr.util.parse_xyzsep(args, kwargs, self._coords)
         return treecorr._lib.KFieldCountNear(self.data, x, y, z, sep, self._coords)
 
 
@@ -235,23 +249,14 @@ class GField(object):
         """The number of top-level nodes."""
         return treecorr._lib.GFieldGetNTopLevel(self.data, self._coords)
 
-    def count_near(self, x, y, z, sep):
+    def count_near(self, *args, **kwargs):
         """Count how many points are near a given coordinate.
 
-        Note: This function requires the coordinate to be given as (x,y,z) and the separation
-              in compatible units.  There is also a version of this function in the Catalog
-              class, which allows for more flexible specification of the coordinate
-              (e.g. using ra, dec).
-
-        :param x:       The x coordinate of the location for which to count nearby points.
-        :param y:       The y coordinate of the location for which to count nearby points.
-        :param z:       The z coordinate of the location for which to count nearby points.
-        :param sep:     The separation distance
+        There are several options for how to specify the reference coordinate, which depends
+        on the type of coordinate system this field implements.  See NField.count_near
+        for details.
         """
-        x = float(x)
-        y = float(y)
-        z = float(z)
-        sep = float(sep)
+        x,y,z,sep = treecorr.util.parse_xyzsep(args, kwargs, self._coords)
         return treecorr._lib.GFieldCountNear(self.data, x, y, z, sep, self._coords)
 
 

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -420,6 +420,7 @@ class NSimpleField(SimpleField):
                 logger.info('Building NSimpleField from cat %s',cat.name)
             else:
                 logger.info('Building NSimpleField')
+        self._d = 1  # NData
         self.coords = cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 
@@ -455,6 +456,7 @@ class KSimpleField(SimpleField):
                 logger.info('Building KSimpleField from cat %s',cat.name)
             else:
                 logger.info('Building KSimpleField')
+        self._d = 2  # KData
         self.coords = cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 
@@ -491,6 +493,7 @@ class GSimpleField(SimpleField):
                 logger.info('Building GSimpleField from cat %s',cat.name)
             else:
                 logger.info('Building GSimpleField')
+        self._d = 3  # GData
         self.coords = cat.coords
         self._coords = treecorr.util.coord_enum(self.coords)  # These are the C++-layer enums
 

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -174,7 +174,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        field = cat.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        field = cat.getGField(min_size, max_size, self.split_method,
+                              bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         treecorr._lib.ProcessAutoGG(self.corr, field.data, self.output_dots,
@@ -211,8 +212,10 @@ class GGCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getGField(min_size, max_size, self.split_method,
+                            self.brute in [True, 1], self.max_top, self.coords)
+        f2 = cat2.getGField(min_size, max_size, self.split_method,
+                            self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossGG(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -75,6 +75,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
     def __init__(self, config=None, logger=None, **kwargs):
         treecorr.BinnedCorr2.__init__(self, config, logger, **kwargs)
 
+        self._d1 = 3  # GData
+        self._d2 = 3  # GData
         self.xip = np.zeros_like(self.rnom, dtype=float)
         self.xim = np.zeros_like(self.rnom, dtype=float)
         self.xip_im = np.zeros_like(self.rnom, dtype=float)
@@ -89,8 +91,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
 
     def _build_corr(self):
         from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildGGCorr(
-                self._bintype,
+        self.corr = treecorr._lib.BuildCorr2(
+                self._d1, self._d2, self._bintype,
                 self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
                 self.min_rpar, self.max_rpar,
                 dp(self.xip),dp(self.xip_im),dp(self.xim),dp(self.xim_im),
@@ -101,7 +103,7 @@ class GGCorrelation(treecorr.BinnedCorr2):
         # rather than being able to rely on the Python memory manager.
         # In case __init__ failed to get that far
         if hasattr(self,'corr'):  # pragma: no branch
-            treecorr._lib.DestroyGGCorr(self.corr, self._bintype)
+            treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
     def __eq__(self, other):
         return (isinstance(other, GGCorrelation) and
@@ -178,8 +180,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
                               bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
-        treecorr._lib.ProcessAutoGG(self.corr, field.data, self.output_dots,
-                                    self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessAuto2(self.corr, field.data, self.output_dots,
+                                   field._d, self._coords, self._bintype, self._metric)
 
 
     def process_cross(self, cat1, cat2, metric=None, num_threads=None):
@@ -218,8 +220,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
                             self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
-        treecorr._lib.ProcessCrossGG(self.corr, f1.data, f2.data, self.output_dots,
-                                     self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,
+                                    f1._d, f2._d, self._coords, self._bintype, self._metric)
 
 
     def process_pairwise(self, cat1, cat2, metric=None, num_threads=None):
@@ -254,8 +256,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
         f1 = cat1.getGSimpleField()
         f2 = cat2.getGSimpleField()
 
-        treecorr._lib.ProcessPairGG(self.corr, f1.data, f2.data, self.output_dots,
-                                    self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessPair(self.corr, f1.data, f2.data, self.output_dots,
+                                  f1._d, f2._d, self._coords, self._bintype, self._metric)
 
 
     def finalize(self, varg1, varg2):

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -215,9 +215,11 @@ class GGCorrelation(treecorr.BinnedCorr2):
         min_size, max_size = self._get_minmax_size()
 
         f1 = cat1.getGField(min_size, max_size, self.split_method,
-                            self.brute in [True, 1], self.max_top, self.coords)
+                            self.brute is True or self.brute is 1,
+                            self.max_top, self.coords)
         f2 = cat2.getGField(min_size, max_size, self.split_method,
-                            self.brute in [True, 2], self.max_top, self.coords)
+                            self.brute is True or self.brute is 2,
+                            self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -119,6 +119,9 @@ class GGGCorrelation(treecorr.BinnedCorr3):
     def __init__(self, config=None, logger=None, **kwargs):
         treecorr.BinnedCorr3.__init__(self, config, logger, **kwargs)
 
+        self._d1 = 3  # GData
+        self._d2 = 3  # GData
+        self._d3 = 3  # GData
         shape = (self.nbins, self.nubins, self.nvbins)
         self.gam0r = np.zeros(shape, dtype=float)
         self.gam1r = np.zeros(shape, dtype=float)
@@ -153,8 +156,8 @@ class GGGCorrelation(treecorr.BinnedCorr3):
 
     def _build_corr(self):
         from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildGGGCorr(
-                self._bintype,
+        self.corr = treecorr._lib.BuildCorr3(
+                self._d1, self._d2, self._d3, self._bintype,
                 self._min_sep,self._max_sep,self.nbins,self._bin_size,self.b,
                 self.min_u,self.max_u,self.nubins,self.ubin_size,self.bu,
                 self.min_v,self.max_v,self.nvbins,self.vbin_size,self.bv,
@@ -170,7 +173,7 @@ class GGGCorrelation(treecorr.BinnedCorr3):
         # rather than being able to rely on the Python memory manager.
         # In case __init__ failed to get that far
         if hasattr(self,'corr'):  # pragma: no branch
-            treecorr._lib.DestroyGGGCorr(self.corr, self._bintype)
+            treecorr._lib.DestroyCorr3(self.corr, self._d1, self._d2, self._d3, self._bintype)
 
     def __eq__(self, other):
         return (isinstance(other, GGGCorrelation) and
@@ -264,8 +267,8 @@ class GGGCorrelation(treecorr.BinnedCorr3):
                               bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
-        treecorr._lib.ProcessAutoGGG(self.corr, field.data, self.output_dots,
-                                     self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessAuto3(self.corr, field.data, self.output_dots,
+                                   field._d, self._coords, self._bintype, self._metric)
 
     def process_cross21(self, cat1, cat2, metric=None, num_threads=None):
         """Process two catalogs, accumulating the 3pt cross-correlation, where two of the
@@ -326,8 +329,8 @@ class GGGCorrelation(treecorr.BinnedCorr3):
                             bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
-        treecorr._lib.ProcessCrossGGG(self.corr, f1.data, f2.data, f3.data, self.output_dots,
-                                      self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessCross3(self.corr, f1.data, f2.data, f3.data, self.output_dots,
+                                    f1._d, f2._d, f3._d, self._coords, self._bintype, self._metric)
 
 
     def finalize(self, varg1, varg2, varg3):

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -260,7 +260,8 @@ class GGGCorrelation(treecorr.BinnedCorr3):
 
         min_size, max_size = self._get_minmax_size()
 
-        field = cat.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        field = cat.getGField(min_size, max_size, self.split_method,
+                              bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         treecorr._lib.ProcessAutoGGG(self.corr, field.data, self.output_dots,
@@ -317,9 +318,12 @@ class GGGCorrelation(treecorr.BinnedCorr3):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f3 = cat3.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getGField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
+        f2 = cat2.getGField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
+        f3 = cat3.getGField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossGGG(self.corr, f1.data, f2.data, f3.data, self.output_dots,

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -171,9 +171,11 @@ class KGCorrelation(treecorr.BinnedCorr2):
         min_size, max_size = self._get_minmax_size()
 
         f1 = cat1.getKField(min_size, max_size, self.split_method,
-                            self.brute in [True, 1], self.max_top, self.coords)
+                            self.brute is True or self.brute is 1,
+                            self.max_top, self.coords)
         f2 = cat2.getGField(min_size, max_size, self.split_method,
-                            self.brute in [True, 2], self.max_top, self.coords)
+                            self.brute is True or self.brute is 2,
+                            self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -168,8 +168,10 @@ class KGCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getKField(min_size, max_size, self.split_method,
+                            self.brute in [True, 1], self.max_top, self.coords)
+        f2 = cat2.getGField(min_size, max_size, self.split_method,
+                            self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossKG(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -168,7 +168,8 @@ class KKCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        field = cat.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        field = cat.getKField(min_size, max_size, self.split_method,
+                              bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         treecorr._lib.ProcessAutoKK(self.corr, field.data, self.output_dots,
@@ -205,8 +206,10 @@ class KKCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getKField(min_size, max_size, self.split_method,
+                            self.brute in [True, 1], self.max_top, self.coords)
+        f2 = cat2.getKField(min_size, max_size, self.split_method,
+                            self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossKK(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -209,9 +209,11 @@ class KKCorrelation(treecorr.BinnedCorr2):
         min_size, max_size = self._get_minmax_size()
 
         f1 = cat1.getKField(min_size, max_size, self.split_method,
-                            self.brute in [True, 1], self.max_top, self.coords)
+                            self.brute is True or self.brute is 1,
+                            self.max_top, self.coords)
         f2 = cat2.getKField(min_size, max_size, self.split_method,
-                            self.brute in [True, 2], self.max_top, self.coords)
+                            self.brute is True or self.brute is 2,
+                            self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/kkkcorrelation.py
+++ b/treecorr/kkkcorrelation.py
@@ -213,7 +213,8 @@ class KKKCorrelation(treecorr.BinnedCorr3):
 
         min_size, max_size = self._get_minmax_size()
 
-        field = cat.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        field = cat.getKField(min_size, max_size, self.split_method,
+                              bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         treecorr._lib.ProcessAutoKKK(self.corr, field.data, self.output_dots,
@@ -270,9 +271,12 @@ class KKKCorrelation(treecorr.BinnedCorr3):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f3 = cat3.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getKField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
+        f2 = cat2.getKField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
+        f3 = cat3.getKField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossKKK(self.corr, f1.data, f2.data, f3.data, self.output_dots,

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -73,6 +73,8 @@ class NGCorrelation(treecorr.BinnedCorr2):
     def __init__(self, config=None, logger=None, **kwargs):
         treecorr.BinnedCorr2.__init__(self, config, logger, **kwargs)
 
+        self._d1 = 1  # NData
+        self._d2 = 3  # GData
         self.xi = np.zeros_like(self.rnom, dtype=float)
         self.xi_im = np.zeros_like(self.rnom, dtype=float)
         self.varxi = np.zeros_like(self.rnom, dtype=float)
@@ -85,11 +87,11 @@ class NGCorrelation(treecorr.BinnedCorr2):
 
     def _build_corr(self):
         from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildNGCorr(
-                self._bintype,
+        self.corr = treecorr._lib.BuildCorr2(
+                self._d1, self._d2, self._bintype,
                 self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
                 self.min_rpar, self.max_rpar,
-                dp(self.xi),dp(self.xi_im),
+                dp(self.xi),dp(self.xi_im), dp(None), dp(None),
                 dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
 
     def __del__(self):
@@ -97,7 +99,7 @@ class NGCorrelation(treecorr.BinnedCorr2):
         # rather than being able to rely on the Python memory manager.
         # In case __init__ failed to get that far
         if hasattr(self,'corr'):  # pragma: no branch
-            treecorr._lib.DestroyNGCorr(self.corr, self._bintype)
+            treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
     def __eq__(self, other):
         return (isinstance(other, NGCorrelation) and
@@ -175,8 +177,8 @@ class NGCorrelation(treecorr.BinnedCorr2):
                             self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
-        treecorr._lib.ProcessCrossNG(self.corr, f1.data, f2.data, self.output_dots,
-                                     self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,
+                                    f1._d, f2._d, self._coords, self._bintype, self._metric)
 
 
     def process_pairwise(self, cat1, cat2, metric=None, num_threads=None):
@@ -211,8 +213,8 @@ class NGCorrelation(treecorr.BinnedCorr2):
         f1 = cat1.getNSimpleField()
         f2 = cat2.getGSimpleField()
 
-        treecorr._lib.ProcessPairNG(self.corr, f1.data, f2.data, self.output_dots,
-                                    self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessPair(self.corr, f1.data, f2.data, self.output_dots,
+                                  f1._d, f2._d, self._coords, self._bintype, self._metric)
 
 
     def finalize(self, varg):

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -172,9 +172,11 @@ class NGCorrelation(treecorr.BinnedCorr2):
         min_size, max_size = self._get_minmax_size()
 
         f1 = cat1.getNField(min_size, max_size, self.split_method,
-                            self.brute in [True, 1], self.max_top, self.coords)
+                            self.brute is True or self.brute is 1,
+                            self.max_top, self.coords)
         f2 = cat2.getGField(min_size, max_size, self.split_method,
-                            self.brute in [True, 2], self.max_top, self.coords)
+                            self.brute is True or self.brute is 2,
+                            self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -169,8 +169,10 @@ class NGCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getGField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getNField(min_size, max_size, self.split_method,
+                            self.brute in [True, 1], self.max_top, self.coords)
+        f2 = cat2.getGField(min_size, max_size, self.split_method,
+                            self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossNG(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -165,8 +165,10 @@ class NKCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getKField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getNField(min_size, max_size, self.split_method,
+                            self.brute in [True, 1], self.max_top, self.coords)
+        f2 = cat2.getKField(min_size, max_size, self.split_method,
+                            self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossNK(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -168,9 +168,11 @@ class NKCorrelation(treecorr.BinnedCorr2):
         min_size, max_size = self._get_minmax_size()
 
         f1 = cat1.getNField(min_size, max_size, self.split_method,
-                            self.brute in [True, 1], self.max_top, self.coords)
+                            self.brute is True or self.brute is 1,
+                            self.max_top, self.coords)
         f2 = cat2.getKField(min_size, max_size, self.split_method,
-                            self.brute in [True, 2], self.max_top, self.coords)
+                            self.brute is True or self.brute is 2,
+                            self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -71,6 +71,8 @@ class NKCorrelation(treecorr.BinnedCorr2):
     def __init__(self, config=None, logger=None, **kwargs):
         treecorr.BinnedCorr2.__init__(self, config, logger, **kwargs)
 
+        self._d1 = 1  # NData
+        self._d2 = 2  # KData
         self.xi = np.zeros_like(self.rnom, dtype=float)
         self.varxi = np.zeros_like(self.rnom, dtype=float)
         self.meanr = np.zeros_like(self.rnom, dtype=float)
@@ -82,11 +84,11 @@ class NKCorrelation(treecorr.BinnedCorr2):
 
     def _build_corr(self):
         from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildNKCorr(
-                self._bintype,
+        self.corr = treecorr._lib.BuildCorr2(
+                self._d1, self._d2, self._bintype,
                 self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
                 self.min_rpar, self.max_rpar,
-                dp(self.xi),
+                dp(self.xi), dp(None), dp(None), dp(None),
                 dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
 
     def __del__(self):
@@ -94,7 +96,7 @@ class NKCorrelation(treecorr.BinnedCorr2):
         # rather than being able to rely on the Python memory manager.
         # In case __init__ failed to get that far
         if hasattr(self,'corr'):  # pragma: no branch
-            treecorr._lib.DestroyNKCorr(self.corr, self._bintype)
+            treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
     def __eq__(self, other):
         return (isinstance(other, NKCorrelation) and
@@ -171,8 +173,8 @@ class NKCorrelation(treecorr.BinnedCorr2):
                             self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
-        treecorr._lib.ProcessCrossNK(self.corr, f1.data, f2.data, self.output_dots,
-                                     self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,
+                                    f1._d, f2._d, self._coords, self._bintype, self._metric)
 
 
     def process_pairwise(self, cat1, cat2, metric=None, num_threads=None):
@@ -207,8 +209,8 @@ class NKCorrelation(treecorr.BinnedCorr2):
         f1 = cat1.getNSimpleField()
         f2 = cat2.getKSimpleField()
 
-        treecorr._lib.ProcessPairNK(self.corr, f1.data, f2.data, self.output_dots,
-                                    self._coords, self._bintype, self._metric)
+        treecorr._lib.ProcessPair(self.corr, f1.data, f2.data, self.output_dots,
+                                  f1._d, f2._d, self._coords, self._bintype, self._metric)
 
 
     def finalize(self, vark):

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -161,7 +161,8 @@ class NNCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        field = cat.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        field = cat.getNField(min_size, max_size, self.split_method,
+                              bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         treecorr._lib.ProcessAutoNN(self.corr, field.data, self.output_dots,
@@ -198,8 +199,10 @@ class NNCorrelation(treecorr.BinnedCorr2):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getNField(min_size, max_size, self.split_method,
+                            self.brute in [True, 1], self.max_top, self.coords)
+        f2 = cat2.getNField(min_size, max_size, self.split_method,
+                            self.brute in [True, 2], self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossNN(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -203,9 +203,11 @@ class NNCorrelation(treecorr.BinnedCorr2):
         min_size, max_size = self._get_minmax_size()
 
         f1 = cat1.getNField(min_size, max_size, self.split_method,
-                            self.brute in [True, 1], self.max_top, self.coords)
+                            self.brute is True or self.brute is 1,
+                            self.max_top, self.coords)
         f2 = cat2.getNField(min_size, max_size, self.split_method,
-                            self.brute in [True, 2], self.max_top, self.coords)
+                            self.brute is True or self.brute is 2,
+                            self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCross2(self.corr, f1.data, f2.data, self.output_dots,

--- a/treecorr/nnncorrelation.py
+++ b/treecorr/nnncorrelation.py
@@ -210,7 +210,8 @@ class NNNCorrelation(treecorr.BinnedCorr3):
 
         min_size, max_size = self._get_minmax_size()
 
-        field = cat.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        field = cat.getNField(min_size, max_size, self.split_method,
+                              bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         treecorr._lib.ProcessAutoNNN(self.corr, field.data, self.output_dots,
@@ -268,9 +269,12 @@ class NNNCorrelation(treecorr.BinnedCorr3):
 
         min_size, max_size = self._get_minmax_size()
 
-        f1 = cat1.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f2 = cat2.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
-        f3 = cat3.getNField(min_size, max_size, self.split_method, self.max_top, self.coords)
+        f1 = cat1.getNField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
+        f2 = cat2.getNField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
+        f3 = cat3.getNField(min_size, max_size, self.split_method,
+                            bool(self.brute), self.max_top, self.coords)
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         treecorr._lib.ProcessCrossNNN(self.corr, f1.data, f2.data, f3.data, self.output_dots,

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -213,6 +213,7 @@ class LRU_Cache:
             key = object()
             self.cache[key] = last[1] = last = [last, self.root, key, None]
         self.root[0] = last
+        self.count = 0
 
     def __call__(self, *key, **kwargs):
         link = self.cache.get(key)
@@ -237,6 +238,7 @@ class LRU_Cache:
         self.root[3], oldvalue = None, self.root[3]
         self.cache[key] = oldroot
         del self.cache[oldkey]
+        if self.count < self.size: self.count += 1
         return result
 
     def resize(self, maxsize):
@@ -260,6 +262,7 @@ class LRU_Cache:
                     new_next_link = self.root[1] = self.root[1][1]
                     new_next_link[0] = self.root
                     del self.cache[current_next_link[2]]
+                self.count = min(self.count, maxsize)
             else: # maxsize > oldsize:
                 for i in range(maxsize - oldsize):
                     # Insert between root and root.next
@@ -279,6 +282,11 @@ class LRU_Cache:
             key = object()
             self.cache[key] = last[1] = last = [last, self.root, key, None]
         self.root[0] = last
+        self.count = 0
+
+    @property
+    def size(self):
+        return len(self.cache)
 
 
 def double_ptr(x):

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -289,10 +289,13 @@ def double_ptr(x):
 
     :returns:   A version of the array that can be passed to cffi C functions.
     """
-    # This fails if x is read_only
-    #return treecorr._ffi.cast('double*', treecorr._ffi.from_buffer(x))
-    # This works, presumably by ignoring the numpy read_only flag.  Although, I think it's ok.
-    return treecorr._ffi.cast('double*', x.ctypes.data)
+    if x is None:
+        return treecorr._ffi.cast('double*', 0)
+    else:
+        # This fails if x is read_only
+        #return treecorr._ffi.cast('double*', treecorr._ffi.from_buffer(x))
+        # This works, presumably by ignoring the numpy read_only flag.  Although, I think it's ok.
+        return treecorr._ffi.cast('double*', x.ctypes.data)
 
 def parse_metric(metric, coords, coords2=None, coords3=None):
     """

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -242,6 +242,15 @@ class LRU_Cache:
         if self.count < self.size: self.count += 1
         return result
 
+    def values(self):
+        """Lists all items stored in the cache"""
+        return list([v[3] for v in self.cache.values() if v[3] is not None])
+
+    @property
+    def last_value(self):
+        """Return the most recently used value"""
+        return self.root[0][3]
+
     def resize(self, maxsize):
         """ Resize the cache.  Increasing the size of the cache is non-destructive, i.e.,
         previously cached inputs remain in the cache.  Decreasing the size of the cache will

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -323,7 +323,7 @@ def long_ptr(x):
 
     :returns:   A version of the array that can be passed to cffi C functions.
     """
-    if x is None:
+    if x is None:  # pragma: no cover   (I don't ever have x=None for this one.)
         return treecorr._ffi.cast('long*', 0)
     else:
         return treecorr._ffi.cast('long*', x.ctypes.data)

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -315,6 +315,19 @@ def double_ptr(x):
         # This works, presumably by ignoring the numpy read_only flag.  Although, I think it's ok.
         return treecorr._ffi.cast('double*', x.ctypes.data)
 
+def long_ptr(x):
+    """
+    Cast x as a long* to pass to library C functions
+
+    :param x:   A numpy array assumed to have dtype = int.
+
+    :returns:   A version of the array that can be passed to cffi C functions.
+    """
+    if x is None:
+        return treecorr._ffi.cast('long*', 0)
+    else:
+        return treecorr._ffi.cast('long*', x.ctypes.data)
+
 def parse_metric(metric, coords, coords2=None, coords3=None):
     """
     Convert a string metric into the corresponding enum to pass to the C code.


### PR DESCRIPTION
@ebaxter requested that TreeCorr implement a fairly standard function that trees are good at.  Namely the ability to find points near a given position.  cf. Issue #44.

In the TreeCorr context, this means getting the indices from the original Catalog, which are some distance from a given position.  This PR adds two new methods of the Field class:

* `field.count_nearby` counts how many points are within some separation of a given position.
* `field.get_nearby` returns the indices of these points.

In order to allocate the memory needed for the numpy array returned by the second method, I had to have it call the first method first.  But it seems plausible that users may find the first method useful as well, so I made it a public API method.  The second one is what Eric asked for though.

The main requirement for implementing this was to add the index value to the C++-layer cells used in the tree.  I wanted to do this without adding to the overall memory footprint of the tree, since some people are already finding that the trees are close to their available memory.

The key to doing this is to recognize that we only need to store the indices for the leaves.  These are cells that don't have a `left` or `right` points to daughter cells, so the trick is to use the `union` construct to use the same memory that normally is used for the `right` pointer to store the `index` when `right` would be `NULL`.