### PR TITLE
Fix code to work with negative weights

### DIFF
--- a/include/dbg.h
+++ b/include/dbg.h
@@ -15,6 +15,8 @@
 #ifndef TreeCorr_dbg_H
 #define TreeCorr_dbg_H
 
+//#define DEBUGLOGGING
+
 #ifdef DEBUGLOGGING
 // Python usually turns this on automatically.  If we are debugging, turn it off so assert works.
 #ifdef NDEBUG
@@ -74,8 +76,8 @@ private:
 #define get_dbgout() Debugger::instance().get_dbgout()
 #define set_verbose(level) Debugger::instance().set_verbose(level)
 #define verbose_level Debugger::instance().get_level()
-#define XAssert(x) do { if (verbose_level >= 3) assert(x); } while (false)
-#define Assert(x) assert(x)
+#define Assert(x) do { if (!(x)) { dbg<<"Failed Assert: "<<#x<<std::endl; throw std::runtime_error("Failed Assert: " #x); } } while (false)
+#define XAssert(x) do { if (verbose_level >= 3) Assert(x); } while (false)
 #else
 #define dbg if(false) (std::cerr)
 #define xdbg if(false) (std::cerr)
@@ -83,8 +85,9 @@ private:
 #define set_dbgout(dbgout)
 #define get_dbgout()
 #define set_verbose(level)
+// When not in debug mode, don't bomb out for assert failures.  Just print to screen.
+#define Assert(x) do { if (!(x)) std::cerr<<"Failed Assert: "<<(#x); } while (false)
 #define XAssert(x)
-#define Assert(x) assert(x)
 #endif
 
 #endif

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -140,7 +140,7 @@ void BuildCellData(
         w += data.getW();
         if (data.getW() != 0.) ++n;
     }
-    if (sumwp > 0.) {
+    if (sumwp != 0.) {
         pos /= sumwp;
         // If C == Sphere, the average position is no longer on the surface of the unit sphere.
         // Divide by the new r.  (This is a noop if C == Flat or ThreeD.)

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -458,7 +458,6 @@ Cell<D,C>* BuildCell(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata
         return new Cell<D,C>(data, size, sizesq, l, r);
     } else {
         // Too small, so stop here anyway.
-        Assert(data->getN() > 1);
         ListLeafInfo info;
         info.indices = new std::vector<long>(end-start);
         for (size_t i=start; i<end; ++i) {

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -602,6 +602,8 @@ def test_direct_count():
     with assert_raises(ValueError):
         dd7.process(cat1, cat2, metric='Arc')
     with assert_raises(ValueError):
+        dd7.process(cat1, metric='Arc')
+    with assert_raises(ValueError):
         dd7.process(cat1, cat2, metric='Rlens')
 
     try:

--- a/tests/test_nnn.py
+++ b/tests/test_nnn.py
@@ -846,7 +846,7 @@ def test_direct_count_auto():
                                         min_u=min_u, max_u=max_u, nubins=nubins,
                                         min_v=min_v, max_v=max_v, nvbins=nvbins,
                                         logger=cl.logger)
-        ddd14.process_auto(cat, metric='Arc')
+        ddd14.process_auto(cat2, metric='Arc')
         ddd14 += ddd2
     assert "Detected a change in metric" in cl.output
 

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -342,8 +342,6 @@ def parse_metric(metric, coords, coords2=None, coords3=None):
             if coords3 == 'spherical': coords3 = '3d'
 
         if metric == 'Arc':
-            if coords not in ['spherical', '3d']:
-                raise ValueError("Arc metric is only valid for catalogs with spherical positions.")
             # If all coords are 3d, then leave it 3d, but if any are spherical,
             # then convert to spherical.
             if all([c in [None, '3d'] for c in [coords, coords2, coords3]]):
@@ -373,6 +371,8 @@ def parse_metric(metric, coords, coords2=None, coords3=None):
         raise ValueError("Rlens metric is only valid for cross correlations.")
     if metric == 'Rlens' and coords != '3d':
         raise ValueError("Rlens metric is only valid for catalogs with 3d positions.")
+    if metric == 'Arc' and coords not in ['spherical', '3d']:
+        raise ValueError("Arc metric is only valid for catalogs with spherical positions.")
 
     return coords, metric
 


### PR DESCRIPTION
@danielgruen has a application which involves negative weight values.  It turns out that there was a place in the code that assumed w >= 0, and it crashed with an Assert error.

So this PR fixes the code to not assume w >= 0.  Which was really just a one-line fix.  At least I couldn't find any other locations where I assumed that.  I also added a unit test using negative weights, which seems to work fine now.