### PR TITLE
Provide option to run in "low memory" mode when using patches

### DIFF
--- a/include/Field.h
+++ b/include/Field.h
@@ -47,25 +47,33 @@ public:
 
     long getNObj() const { return _nobj; }
     double getSizeSq() const { return _sizesq; }
-    long getNTopLevel() const { return long(_cells.size()); }
-    const std::vector<Cell<D,C>*>& getCells() const { return _cells; }
+    Position<C> getCenter() const { return _center; }
+    double getSize() const { return std::sqrt(_sizesq); }
+    long getNTopLevel() const { BuildCells(); return long(_cells.size()); }
+    const std::vector<Cell<D,C>*>& getCells() const { BuildCells(); return _cells; }
     long countNear(double x, double y, double z, double sep) const;
     void getNear(double x, double y, double z, double sep, long* indices, long n) const;
 
 private:
 
-    // This finishes the work of the Field constructor.
-    template <int SM>
-    void BuildCells(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& celldata,
-                    double minsize, double maxsize,
-                    bool brute, int mintop, int maxtop);
-
     long _nobj;
     double _minsize;
     double _maxsize;
     SplitMethod _sm;
+    bool _brute;
+    int _mintop;
+    int _maxtop;
+    Position<C> _center;
     double _sizesq;
-    std::vector<Cell<D,C>*> _cells;
+    mutable std::vector<Cell<D,C>*> _cells;
+
+    // This is set at the start, but once we finish making all the cells, we don't need it anymore.
+    mutable std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> > _celldata;
+
+    // This finishes the work of the Field constructor.
+    void BuildCells() const;
+    template <int SM> void DoBuildCells() const;
+
 };
 
 // A SimpleField just stores the celldata.  It doesn't go on to build up the Cells.

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -45,6 +45,11 @@ def test_count_near():
     cat = treecorr.Catalog(x=x, y=y, w=w, g1=w, g2=w, k=w, keep_zero_weight=True)
     field = cat.getNField()
 
+    # The count_near code is only faster if the tree has been built.
+    # Which is deferred until the first time you need it.
+    # The simplest way to trigger the build is to ask for ntop
+    field.nTopLevelNodes
+
     t0 = time.time()
     n1 = np.sum((x-x0)**2 + (y-y0)**2 < sep**2)
     t1 = time.time()
@@ -80,6 +85,7 @@ def test_count_near():
     cat = treecorr.Catalog(ra=ra, dec=dec, r=r, ra_units='deg', dec_units='deg',
                            w=w, g1=w, g2=w, k=w, keep_zero_weight=True)
     field = cat.getNField()
+    field.nTopLevelNodes
 
     t0 = time.time()
     n1 = np.sum((x-x0)**2 + (y-y0)**2 + (z-z0)**2 < sep**2)
@@ -128,6 +134,7 @@ def test_count_near():
     cat = treecorr.Catalog(ra=ra, dec=dec, ra_units='deg', dec_units='deg',
                            w=w, g1=w, g2=w, k=w, keep_zero_weight=True)
     field = cat.getNField()
+    field.nTopLevelNodes
 
     x /= r
     y /= r
@@ -203,6 +210,7 @@ def test_get_near():
 
     cat = treecorr.Catalog(x=x, y=y, w=w, g1=w, g2=w, k=w, keep_zero_weight=True)
     field = cat.getNField()
+    field.nTopLevelNodes
 
     t0 = time.time()
     i1 = np.where(((x-x0)**2 + (y-y0)**2 < sep**2))[0]
@@ -248,6 +256,7 @@ def test_get_near():
     cat = treecorr.Catalog(ra=ra, dec=dec, r=r, ra_units='deg', dec_units='deg',
                            w=w, g1=w, g2=w, k=w, keep_zero_weight=True)
     field = cat.getNField()
+    field.nTopLevelNodes
 
     t0 = time.time()
     i1 = np.where(((x-x0)**2 + (y-y0)**2 + (z-z0)**2 < sep**2))[0]
@@ -329,6 +338,7 @@ def test_get_near():
     cat = treecorr.Catalog(ra=ra, dec=dec, ra_units='deg', dec_units='deg',
                            w=w, g1=w, g2=w, k=w, keep_zero_weight=True)
     field = cat.getNField()
+    field.nTopLevelNodes
 
     x /= r
     y /= r

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1628,6 +1628,28 @@ def test_save_patches():
         assert cat_i.loaded
         assert cat4.patches[i].loaded
 
+    # If patches are made with patch_centers, then making patches doesn't trigger full load.
+    cat5 = treecorr.Catalog(file_name2,
+                            x_col=1, y_col=2, z_col=3, w_col=4,
+                            g1_col=5, g2_col=6, k_col=7, patch_centers=cat4.patch_centers,
+                            save_patch_dir='output')
+    assert not cat5.loaded
+    assert len(cat5.patches) == npatch
+    assert not cat5.loaded
+    for i in range(npatch):
+        patch_file_name = cat5.patches[i].file_name
+        assert patch_file_name == os.path.join('output','test_save_patches2_%00d.fits'%i)
+        assert os.path.exists(patch_file_name)
+        cat_i = treecorr.Catalog(patch_file_name, patch=i,
+                                 x_col='x', y_col='y', z_col='z', w_col='w',
+                                 g1_col='g1', g2_col='g2', k_col='k')
+        assert not cat_i.loaded
+        assert not cat5.patches[i].loaded
+        assert cat_i == cat5.patches[i]
+        assert cat_i.loaded
+        assert cat5.patches[i].loaded
+    assert not cat5.loaded
+
 @timer
 def test_clusters():
     # The original version of J/K variance assumed that both catalogs had some items

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2135,14 +2135,14 @@ def test_lowmem():
 
     if __name__ == '__main__':
         ngal = 2000000
-        npatch = 128
-        himem = 1.e8
-        lomem = 5.e6
+        npatch = 64
+        himem = 5.e7
+        lomem = 2.e6
     else:
         ngal = 100000
         npatch = 16
-        himem = 4.e6
-        lomem = 4.e5
+        himem = 3.e6
+        lomem = 1.e5
     s = 10.
     rng = np.random.RandomState(8675309)
     x = rng.normal(0,s, (ngal,) )
@@ -2188,7 +2188,7 @@ def test_lowmem():
     assert s1-s0 > himem  # This version uses a lot of memory.
 
     npairs1 = dd.npairs
-    print('npairs = ',npairs1)
+    #print('npairs = ',npairs1)
 
     full_cat.unload()
     dd.clear()
@@ -2199,19 +2199,20 @@ def test_lowmem():
 
     t0 = time.time()
     s0 = hp.heap().size
-    with profile():
+    #with profile():
+    if True:
         dd.process(full_cat, low_mem=True)
     t1 = time.time()
     s1 = hp.heap().size
     print('7: ',hp.heap().size, t1-t0, s1-s0)
-    print(hp.heap())
-    print(hp.heap()[0].byrcs)
-    print(hp.heap()[0].byrcs[0].byvia)
+    #print(hp.heap())
+    #print(hp.heap()[0].byrcs)
+    #print(hp.heap()[0].byrcs[0].byvia)
     assert s1-s0 < lomem  # This version uses a lot less memory
     #print('dict = ',dd.__dict__)
 
     npairs2 = dd.npairs
-    print('npairs = ',npairs2)
+    #print('npairs = ',npairs2)
     np.testing.assert_array_equal(npairs1, npairs2)
 
     # TODO: Add tests of lowmem cross processing.  And other Correlation types.

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -471,7 +471,7 @@ class BinnedCorr2(object):
                 temp.process_auto(c1,metric,num_threads)
                 self.results[(i,i)] = temp._copy_for_results()
                 self += temp
-                for jj,c2 in enumerate(cat1):
+                for jj,c2 in list(enumerate(cat1))[::-1]:
                     j = c2.patch if c2.patch is not None else jj
                     if i < j:
                         temp.clear()
@@ -483,8 +483,9 @@ class BinnedCorr2(object):
                         else:
                             # NNCorrelation needs to add the tot value
                             self._add_tot(i, j, temp)
-                    if low_mem:
-                        c2.unload()
+                        if low_mem and jj != ii+1:
+                            # Don't unload i+1, since that's the next one we'll need.
+                            c2.unload()
                 if low_mem:
                     c1.unload()
 

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -456,7 +456,7 @@ class BinnedCorr2(object):
         # No op for all but NNCorrelation, which needs to add the tot value
         pass
 
-    def _process_all_auto(self, cat1, metric, num_threads):
+    def _process_all_auto(self, cat1, metric, num_threads, low_mem):
         if len(cat1) == 1:
             self.process_auto(cat1[0],metric,num_threads)
         else:
@@ -483,8 +483,12 @@ class BinnedCorr2(object):
                         else:
                             # NNCorrelation needs to add the tot value
                             self._add_tot(i, j, temp)
+                    if low_mem:
+                        c2.unload()
+                if low_mem:
+                    c1.unload()
 
-    def _process_all_cross(self, cat1, cat2, metric, num_threads):
+    def _process_all_cross(self, cat1, cat2, metric, num_threads, low_mem):
         if treecorr.config.get(self.config,'pairwise',bool,False):
             if len(cat1) != len(cat2):
                 raise ValueError("Number of files for 1 and 2 must be equal for pairwise.")
@@ -516,6 +520,10 @@ class BinnedCorr2(object):
                     else:
                         # NNCorrelation needs to add the tot value
                         self._add_tot(i, j, temp)
+                    if low_mem:
+                        c2.unload()
+                if low_mem:
+                    c1.unload()
 
     def _getStatLen(self):
         # The length of the array that will be returned by _getStat.

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -469,7 +469,7 @@ class BinnedCorr2(object):
                 temp.clear()
                 self.logger.info('Process patch %d auto',i)
                 temp.process_auto(c1,metric,num_threads)
-                self.results[(i,i)] = temp.copy()
+                self.results[(i,i)] = temp._copy_for_results()
                 self += temp
                 for jj,c2 in enumerate(cat1):
                     j = c2.patch if c2.patch is not None else jj
@@ -478,7 +478,7 @@ class BinnedCorr2(object):
                         self.logger.info('Process patches %d,%d cross',i,j)
                         temp.process_cross(c1,c2,metric,num_threads)
                         if np.sum(temp.npairs) > 0:
-                            self.results[(i,j)] = temp.copy()
+                            self.results[(i,j)] = temp._copy_for_results()
                             self += temp
                         else:
                             # NNCorrelation needs to add the tot value
@@ -511,7 +511,7 @@ class BinnedCorr2(object):
                     self.logger.info('Process patches %d,%d cross',i,j)
                     temp.process_cross(c1,c2,metric,num_threads)
                     if i==j or np.sum(temp.npairs) > 0:
-                        self.results[(i,j)] = temp.copy()
+                        self.results[(i,j)] = temp._copy_for_results()
                         self += temp
                     else:
                         # NNCorrelation needs to add the tot value

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -524,9 +524,13 @@ class BinnedCorr2(object):
                 for jj,c2 in enumerate(cat2):
                     j = c2.patch if c2.patch is not None else jj
                     temp.clear()
-                    self.logger.info('Process patches %d,%d cross',i,j)
-                    temp.process_cross(c1,c2,metric,num_threads)
-                    if i==j or np.sum(temp.npairs) > 0:
+                    if not self._trivially_zero(c1,c2,metric):
+                        self.logger.info('Process patches %d,%d cross',i,j)
+                        temp.process_cross(c1,c2,metric,num_threads)
+                    else:
+                        self.logger.info('Skipping patches %d,%d cross, ' +
+                                         'which are too far apart',i,j)
+                    if np.sum(temp.npairs) > 0:
                         self.results[(i,j)] = temp._copy_for_results()
                         self += temp
                     else:

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -2031,8 +2031,7 @@ class Catalog(object):
                 if 'ra' in col_names:
                     kwargs['ra_units'] = 'rad'
                     kwargs['dec_units'] = 'rad'
-                self._patches = [Catalog(file_name=file_names[i],
-                                         patch=i, patch_centers=self._centers, **kwargs)
+                self._patches = [Catalog(file_name=file_names[i], patch=i, **kwargs)
                                  for i in range(len(file_names))]
 
         return self._patches

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -836,7 +836,7 @@ class Catalog(object):
             self._w[(self._flag & ignore_flag)!=0] = 0
             if self._wpos is not None:
                 self._wpos[(self._flag & ignore_flag)!=0] = 0
-            self.logger.debug('Applied flag: w => %s',str(self._w))
+            self.logger.debug('Applied flag')
 
         if self._x is not None:
             ntot = len(self._x)
@@ -1187,41 +1187,41 @@ class Catalog(object):
             # We actually want this, since it makes the result contiguous in memory,
             # which we will need.
             self._x = data[:,x_col-1].astype(float)
-            self.logger.debug('read x = %s',str(self._x))
+            self.logger.debug('read x')
             self._y = data[:,y_col-1].astype(float)
-            self.logger.debug('read y = %s',str(self._y))
+            self.logger.debug('read y')
             if z_col != 0:
                 self._z = data[:,z_col-1].astype(float)
-                self.logger.debug('read r = %s',str(self._r))
+                self.logger.debug('read r')
         else:
             self._ra = data[:,ra_col-1].astype(float)
-            self.logger.debug('read ra = %s',str(self._ra))
+            self.logger.debug('read ra')
             self._dec = data[:,dec_col-1].astype(float)
-            self.logger.debug('read dec = %s',str(self._dec))
+            self.logger.debug('read dec')
             if r_col != 0:
                 self._r = data[:,r_col-1].astype(float)
-                self.logger.debug('read r = %s',str(self._r))
+                self.logger.debug('read r')
         self._apply_units()
 
         # Read w
         if w_col != 0:
             self._w = data[:,w_col-1].astype(float)
-            self.logger.debug('read w = %s',str(self._w))
+            self.logger.debug('read w')
 
         # Read wpos
         if wpos_col != 0:
             self._wpos = data[:,wpos_col-1].astype(float)
-            self.logger.debug('read wpos = %s',str(self._wpos))
+            self.logger.debug('read wpos')
 
         # Read flag
         if flag_col != 0:
             self._flag = data[:,flag_col-1].astype(int)
-            self.logger.debug('read flag = %s',str(self._flag))
+            self.logger.debug('read flag')
 
         # Read patch
         if patch_col != 0:
             self._patch = data[:,patch_col-1].astype(int)
-            self.logger.debug('read patch = %s',str(self._patch))
+            self.logger.debug('read patch')
             self._set_npatch()
 
         # Skip g1,g2,k if this file is a random catalog
@@ -1229,14 +1229,14 @@ class Catalog(object):
             # Read g1,g2
             if g1_col >= 0 and g1_col <= ncols:
                 self._g1 = data[:,g1_col-1].astype(float)
-                self.logger.debug('read g1 = %s',str(self._g1))
+                self.logger.debug('read g1')
                 self._g2 = data[:,g2_col-1].astype(float)
-                self.logger.debug('read g2 = %s',str(self._g2))
+                self.logger.debug('read g2')
 
             # Read k
             if k_col >= 0 and k_col <= ncols:
                 self._k = data[:,k_col-1].astype(float)
-                self.logger.debug('read k = %s',str(self._k))
+                self.logger.debug('read k')
 
         if self._single_patch is not None:
             self._select_patch(self._single_patch)
@@ -1415,33 +1415,33 @@ class Catalog(object):
                 x_hdu = treecorr.config.get_from_list(self.config,'x_hdu',num,int,hdu)
                 y_hdu = treecorr.config.get_from_list(self.config,'y_hdu',num,int,hdu)
                 self._x = fits[x_hdu][x_col][s].astype(float)
-                self.logger.debug('read x = %s',str(self._x))
+                self.logger.debug('read x')
                 self._y = fits[y_hdu][y_col][s].astype(float)
-                self.logger.debug('read y = %s',str(self._y))
+                self.logger.debug('read y')
                 ntot = len(self._x)
                 if z_col != '0':
                     z_hdu = treecorr.config.get_from_list(self.config,'z_hdu',num,int,hdu)
                     self._z = fits[z_hdu][z_col][s].astype(float)
-                    self.logger.debug('read z = %s',str(self._z))
+                    self.logger.debug('read z')
             else:
                 ra_hdu = treecorr.config.get_from_list(self.config,'ra_hdu',num,int,hdu)
                 dec_hdu = treecorr.config.get_from_list(self.config,'dec_hdu',num,int,hdu)
                 self._ra = fits[ra_hdu][ra_col][s].astype(float)
-                self.logger.debug('read ra = %s',str(self._ra))
+                self.logger.debug('read ra')
                 self._dec = fits[dec_hdu][dec_col][s].astype(float)
-                self.logger.debug('read dec = %s',str(self._dec))
+                self.logger.debug('read dec')
                 ntot = len(self._ra)
                 if r_col != '0':
                     r_hdu = treecorr.config.get_from_list(self.config,'r_hdu',num,int,hdu)
                     self._r = fits[r_hdu][r_col][s].astype(float)
-                    self.logger.debug('read r = %s',str(self._r))
+                    self.logger.debug('read r')
             self._apply_units()
 
             # Read patch
             if patch_col != '0':
                 patch_hdu = treecorr.config.get_from_list(self.config,'patch_hdu',num,int,hdu)
                 self._patch = fits[patch_hdu][patch_col][s].astype(int)
-                self.logger.debug('read patch = %s',str(self._patch))
+                self.logger.debug('read patch')
                 self._set_npatch()
 
             # If only reading in a single patch, do it now.
@@ -1458,19 +1458,19 @@ class Catalog(object):
             if w_col != '0':
                 w_hdu = treecorr.config.get_from_list(self.config,'w_hdu',num,int,hdu)
                 self._w = fits[w_hdu][w_col][s].astype(float)
-                self.logger.debug('read w = %s',str(self._w))
+                self.logger.debug('read w')
 
             # Read wpos
             if wpos_col != '0':
                 wpos_hdu = treecorr.config.get_from_list(self.config,'wpos_hdu',num,int,hdu)
                 self._wpos = fits[wpos_hdu][wpos_col][s].astype(float)
-                self.logger.debug('read wpos = %s',str(self._wpos))
+                self.logger.debug('read wpos')
 
             # Read flag
             if flag_col != '0':
                 flag_hdu = treecorr.config.get_from_list(self.config,'flag_hdu',num,int,hdu)
                 self._flag = fits[flag_hdu][flag_col][s].astype(int)
-                self.logger.debug('read flag = %s',str(self._flag))
+                self.logger.debug('read flag')
 
             # Skip g1,g2,k if this file is a random catalog
             if not is_rand:
@@ -1479,15 +1479,15 @@ class Catalog(object):
                 g2_hdu = treecorr.config.get_from_list(self.config,'g2_hdu',num,int,hdu)
                 if g1_col in fits[g1_hdu].get_colnames():
                     self._g1 = fits[g1_hdu][g1_col][s].astype(float)
-                    self.logger.debug('read g1 = %s',str(self._g1))
+                    self.logger.debug('read g1')
                     self._g2 = fits[g2_hdu][g2_col][s].astype(float)
-                    self.logger.debug('read g2 = %s',str(self._g2))
+                    self.logger.debug('read g2')
 
                 # Read k
                 k_hdu = treecorr.config.get_from_list(self.config,'k_hdu',num,int,hdu)
                 if k_col in fits[k_hdu].get_colnames():
                     self._k = fits[k_hdu][k_col][s].astype(float)
-                    self.logger.debug('read k = %s',str(self._k))
+                    self.logger.debug('read k')
 
     @property
     def nfields(self):

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -1936,6 +1936,9 @@ class Catalog(object):
             self._g2 = None
             self._k = None
             self._patch = None
+            if self._patches is not None:
+                for p in self._patches:
+                    p.unload()
         self.clear_cache()
 
     def get_patches(self, unloaded=None):

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -797,6 +797,19 @@ class Catalog(object):
             else:
                 return '3d'
 
+    def _get_center_size(self):
+        if not hasattr(self, '_cen_s'):
+            mx = np.mean(self.x)
+            my = np.mean(self.y)
+            mz = 0
+            dsq = (self.x - mx)**2 + (self.y - my)**2
+            if self.z is not None:
+                mz = np.mean(self.z)
+                dsq += (self.z - mz)**2
+            s = np.max(dsq)**0.5
+            self._cen_s = (mx, my, mz, s)
+        return self._cen_s
+
     def _finish_input(self):
         # Finish processing the data based on given inputs.
 

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -102,23 +102,24 @@ class GGCorrelation(treecorr.BinnedCorr2):
         self.meanlogr = np.zeros_like(self.rnom, dtype=float)
         self.weight = np.zeros_like(self.rnom, dtype=float)
         self.npairs = np.zeros_like(self.rnom, dtype=float)
-        self._build_corr()
         self.logger.debug('Finished building GGCorr')
 
-    def _build_corr(self):
-        from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildCorr2(
-                self._d1, self._d2, self._bintype,
-                self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
-                self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
-                dp(self.xip),dp(self.xip_im),dp(self.xim),dp(self.xim_im),
-                dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs))
+    @property
+    def corr(self):
+        if not hasattr(self, '_corr'):
+            from treecorr.util import double_ptr as dp
+            self._corr = treecorr._lib.BuildCorr2(
+                    self._d1, self._d2, self._bintype,
+                    self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
+                    self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
+                    dp(self.xip),dp(self.xip_im),dp(self.xim),dp(self.xim_im),
+                    dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs))
+        return self._corr
 
     def __del__(self):
         # Using memory allocated from the C layer means we have to explicitly deallocate it
         # rather than being able to rely on the Python memory manager.
-        # In case __init__ failed to get that far
-        if hasattr(self,'corr'):  # pragma: no branch
+        if hasattr(self, '_corr'):
             if not treecorr._ffi._lock.locked(): # pragma: no branch
                 treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
@@ -156,13 +157,12 @@ class GGCorrelation(treecorr.BinnedCorr2):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        del d['corr']
-        del d['logger']  # Oh well.  This is just lost in the copy.  Can't be pickled.
+        d.pop('_corr',None)
+        d.pop('logger',None)  # Oh well.  This is just lost in the copy.  Can't be pickled.
         return d
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self._build_corr()
         self.logger = treecorr.config.setup_logger(
                 treecorr.config.get(self.config,'verbose',int,1),
                 self.config.get('log_file',None))
@@ -506,7 +506,6 @@ class GGCorrelation(treecorr.BinnedCorr2):
         self.metric = params['metric'].strip()
         self.sep_units = params['sep_units'].strip()
         self.bin_type = params['bin_type'].strip()
-        self._build_corr()
 
 
     def calculateMapSq(self, R=None, m2_uform=None):
@@ -748,5 +747,3 @@ class GGCorrelation(treecorr.BinnedCorr2):
               mapsq, mxsq, mapsq_im, -mxsq_im, np.sqrt(varmapsq),
               gamsq, np.sqrt(vargamsq) ],
             precision=precision, file_type=file_type, logger=self.logger)
-
-

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -155,6 +155,16 @@ class GGCorrelation(treecorr.BinnedCorr2):
         import copy
         return copy.deepcopy(self)
 
+    def _copy_for_results(self):
+        # Make a copy of just the things we need to keep in results.
+        ret = GGCorrelation.__new__(GGCorrelation)
+        ret._nbins = self._nbins
+        ret.xip = self.xip.copy()
+        ret.xim = self.xim.copy()
+        ret.weight = self.weight.copy()
+        ret.config = self.config  # not deep copy, so cheap, but makes repr work
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_corr',None)

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -376,7 +376,7 @@ class GGCorrelation(treecorr.BinnedCorr2):
         return self
 
 
-    def process(self, cat1, cat2=None, metric=None, num_threads=None):
+    def process(self, cat1, cat2=None, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.
 
         If only 1 argument is given, then compute an auto-correlation function.
@@ -395,6 +395,8 @@ class GGCorrelation(treecorr.BinnedCorr2):
             num_threads (int):  How many OpenMP threads to use during the calculation.
                                 (default: use the number of cpu cores; this value can also be given
                                 in the constructor in the config dict.)
+            low_mem (bool):     Whether to sacrifice a little speed to try to reduce memory usage.
+                                This only works if using patches. (default: False)
         """
         import math
         self.clear()
@@ -411,13 +413,13 @@ class GGCorrelation(treecorr.BinnedCorr2):
             varg1 = treecorr.calculateVarG(cat1)
             varg2 = varg1
             self.logger.info("varg = %f: sig_sn (per component) = %f",varg1,math.sqrt(varg1))
-            self._process_all_auto(cat1, metric, num_threads)
+            self._process_all_auto(cat1, metric, num_threads, low_mem)
         else:
             varg1 = treecorr.calculateVarG(cat1)
             varg2 = treecorr.calculateVarG(cat2)
             self.logger.info("varg1 = %f: sig_sn (per component) = %f",varg1,math.sqrt(varg1))
             self.logger.info("varg2 = %f: sig_sn (per component) = %f",varg2,math.sqrt(varg2))
-            self._process_all_cross(cat1,cat2, metric, num_threads)
+            self._process_all_cross(cat1, cat2, metric, num_threads, low_mem)
         self.finalize(varg1,varg2)
 
 

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -538,7 +538,7 @@ class GGGCorrelation(treecorr.BinnedCorr3):
             self.logger.info("varg1 = %f: sig_g = %f",varg1,math.sqrt(varg1))
             self.logger.info("varg2 = %f: sig_g = %f",varg2,math.sqrt(varg2))
             self.logger.info("varg3 = %f: sig_g = %f",varg3,math.sqrt(varg3))
-            self._process_all_cross(cat1,cat2,cat3, metric, num_threads)
+            self._process_all_cross(cat1, cat2, cat3, metric, num_threads)
         self.finalize(varg1,varg2,varg3)
 
 

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -141,6 +141,15 @@ class KGCorrelation(treecorr.BinnedCorr2):
         import copy
         return copy.deepcopy(self)
 
+    def _copy_for_results(self):
+        # Make a copy of just the things we need to keep in results.
+        ret = KGCorrelation.__new__(KGCorrelation)
+        ret._nbins = self._nbins
+        ret.xi = self.xi.copy()
+        ret.weight = self.weight.copy()
+        ret.config = self.config  # not deep copy, so cheap, but makes repr work
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_corr',None)

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -308,7 +308,7 @@ class KGCorrelation(treecorr.BinnedCorr2):
         return self
 
 
-    def process(self, cat1, cat2, metric=None, num_threads=None):
+    def process(self, cat1, cat2, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.
 
         Both arguments may be lists, in which case all items in the list are used
@@ -323,6 +323,8 @@ class KGCorrelation(treecorr.BinnedCorr2):
             num_threads (int):  How many OpenMP threads to use during the calculation.
                                 (default: use the number of cpu cores; this value can also be given
                                 in the constructor in the config dict.)
+            low_mem (bool):     Whether to sacrifice a little speed to try to reduce memory usage.
+                                This only works if using patches. (default: False)
         """
         import math
         self.clear()
@@ -338,7 +340,7 @@ class KGCorrelation(treecorr.BinnedCorr2):
         varg = treecorr.calculateVarG(cat2)
         self.logger.info("vark = %f: sig_k = %f",vark,math.sqrt(vark))
         self.logger.info("varg = %f: sig_sn (per component) = %f",varg,math.sqrt(varg))
-        self._process_all_cross(cat1,cat2,metric,num_threads)
+        self._process_all_cross(cat1, cat2, metric, num_threads, low_mem)
         self.finalize(vark,varg)
 
 

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -344,7 +344,7 @@ class KKCorrelation(treecorr.BinnedCorr2):
         return self
 
 
-    def process(self, cat1, cat2=None, metric=None, num_threads=None):
+    def process(self, cat1, cat2=None, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.
 
         If only 1 argument is given, then compute an auto-correlation function.
@@ -363,6 +363,8 @@ class KKCorrelation(treecorr.BinnedCorr2):
             num_threads (int):  How many OpenMP threads to use during the calculation.
                                 (default: use the number of cpu cores; this value can also be given
                                 in the constructor in the config dict.)
+            low_mem (bool):     Whether to sacrifice a little speed to try to reduce memory usage.
+                                This only works if using patches. (default: False)
         """
         import math
         self.clear()
@@ -379,13 +381,13 @@ class KKCorrelation(treecorr.BinnedCorr2):
             vark1 = treecorr.calculateVarK(cat1)
             vark2 = vark1
             self.logger.info("vark = %f: sig_k = %f",vark1,math.sqrt(vark1))
-            self._process_all_auto(cat1,metric,num_threads)
+            self._process_all_auto(cat1, metric, num_threads, low_mem)
         else:
             vark1 = treecorr.calculateVarK(cat1)
             vark2 = treecorr.calculateVarK(cat2)
             self.logger.info("vark1 = %f: sig_k = %f",vark1,math.sqrt(vark1))
             self.logger.info("vark2 = %f: sig_k = %f",vark2,math.sqrt(vark2))
-            self._process_all_cross(cat1,cat2,metric,num_threads)
+            self._process_all_cross(cat1, cat2, metric, num_threads, low_mem)
         self.finalize(vark1,vark2)
 
 

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -143,6 +143,15 @@ class KKCorrelation(treecorr.BinnedCorr2):
         import copy
         return copy.deepcopy(self)
 
+    def _copy_for_results(self):
+        # Make a copy of just the things we need to keep in results.
+        ret = KKCorrelation.__new__(KKCorrelation)
+        ret._nbins = self._nbins
+        ret.xi = self.xi.copy()
+        ret.weight = self.weight.copy()
+        ret.config = self.config  # not deep copy, so cheap, but makes repr work
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_corr',None)

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -94,23 +94,24 @@ class KKCorrelation(treecorr.BinnedCorr2):
         self.meanlogr = np.zeros_like(self.rnom, dtype=float)
         self.weight = np.zeros_like(self.rnom, dtype=float)
         self.npairs = np.zeros_like(self.rnom, dtype=float)
-        self._build_corr()
         self.logger.debug('Finished building KKCorr')
 
-    def _build_corr(self):
-        from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildCorr2(
-                self._d1, self._d2, self._bintype,
-                self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
-                self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
-                dp(self.xi), dp(None), dp(None), dp(None),
-                dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+    @property
+    def corr(self):
+        if not hasattr(self, '_corr'):
+            from treecorr.util import double_ptr as dp
+            self._corr = treecorr._lib.BuildCorr2(
+                    self._d1, self._d2, self._bintype,
+                    self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
+                    self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
+                    dp(self.xi), dp(None), dp(None), dp(None),
+                    dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+        return self._corr
 
     def __del__(self):
         # Using memory allocated from the C layer means we have to explicitly deallocate it
         # rather than being able to rely on the Python memory manager.
-        # In case __init__ failed to get that far
-        if hasattr(self,'corr'):  # pragma: no branch
+        if hasattr(self, 'corr'):
             if not treecorr._ffi._lock.locked(): # pragma: no branch
                 treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
@@ -144,13 +145,12 @@ class KKCorrelation(treecorr.BinnedCorr2):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        del d['corr']
-        del d['logger']  # Oh well.  This is just lost in the copy.  Can't be pickled.
+        d.pop('_corr',None)
+        d.pop('logger',None)  # Oh well.  This is just lost in the copy.  Can't be pickled.
         return d
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self._build_corr()
         self.logger = treecorr.config.setup_logger(
                 treecorr.config.get(self.config,'verbose',int,1),
                 self.config.get('log_file',None))
@@ -458,6 +458,3 @@ class KKCorrelation(treecorr.BinnedCorr2):
         self.metric = params['metric'].strip()
         self.sep_units = params['sep_units'].strip()
         self.bin_type = params['bin_type'].strip()
-        self._build_corr()
-
-

--- a/treecorr/kkkcorrelation.py
+++ b/treecorr/kkkcorrelation.py
@@ -447,7 +447,7 @@ class KKKCorrelation(treecorr.BinnedCorr3):
             self.logger.info("vark1 = %f: sig_k = %f",vark1,math.sqrt(vark1))
             self.logger.info("vark2 = %f: sig_k = %f",vark2,math.sqrt(vark2))
             self.logger.info("vark3 = %f: sig_k = %f",vark3,math.sqrt(vark3))
-            self._process_all_cross(cat1,cat2,cat3, metric, num_threads)
+            self._process_all_cross(cat1, cat2, cat3, metric, num_threads)
         self.finalize(vark1,vark2,vark3)
 
 

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -328,7 +328,7 @@ class NGCorrelation(treecorr.BinnedCorr2):
         return self
 
 
-    def process(self, cat1, cat2, metric=None, num_threads=None):
+    def process(self, cat1, cat2, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.
 
         Both arguments may be lists, in which case all items in the list are used
@@ -343,6 +343,8 @@ class NGCorrelation(treecorr.BinnedCorr2):
             num_threads (int):  How many OpenMP threads to use during the calculation.
                                 (default: use the number of cpu cores; this value can also be given
                                 in the constructor in the config dict.)
+            low_mem (bool):     Whether to sacrifice a little speed to try to reduce memory usage.
+                                This only works if using patches. (default: False)
         """
         import math
         self.clear()
@@ -356,7 +358,7 @@ class NGCorrelation(treecorr.BinnedCorr2):
 
         varg = treecorr.calculateVarG(cat2)
         self.logger.info("varg = %f: sig_sn (per component) = %f",varg,math.sqrt(varg))
-        self._process_all_cross(cat1,cat2,metric,num_threads)
+        self._process_all_cross(cat1, cat2, metric, num_threads, low_mem)
         self.finalize(varg)
 
 

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -150,6 +150,15 @@ class NGCorrelation(treecorr.BinnedCorr2):
         import copy
         return copy.deepcopy(self)
 
+    def _copy_for_results(self):
+        # Make a copy of just the things we need to keep in results.
+        ret = NGCorrelation.__new__(NGCorrelation)
+        ret._nbins = self._nbins
+        ret.xi = self.xi.copy()
+        ret.weight = self.weight.copy()
+        ret.config = self.config  # not deep copy, so cheap, but makes repr work
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_corr',None)
@@ -393,7 +402,6 @@ class NGCorrelation(treecorr.BinnedCorr2):
                     if ij in self.results: continue
                     new_cij = template.copy()
                     new_cij.xi.ravel()[:] = 0
-                    new_cij.xi_im.ravel()[:] = 0
                     new_cij.weight.ravel()[:] = 0
                     self.results[ij] = new_cij
 

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -99,24 +99,25 @@ class NGCorrelation(treecorr.BinnedCorr2):
         self.raw_xi = self.xi
         self.raw_xi_im = self.xi_im
         self.raw_varxi = self.varxi
-        self._build_corr()
         self._rg = None
         self.logger.debug('Finished building NGCorr')
 
-    def _build_corr(self):
-        from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildCorr2(
-                self._d1, self._d2, self._bintype,
-                self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
-                self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
-                dp(self.raw_xi),dp(self.raw_xi_im), dp(None), dp(None),
-                dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+    @property
+    def corr(self):
+        if not hasattr(self, '_corr'):
+            from treecorr.util import double_ptr as dp
+            self._corr = treecorr._lib.BuildCorr2(
+                    self._d1, self._d2, self._bintype,
+                    self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
+                    self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
+                    dp(self.raw_xi),dp(self.raw_xi_im), dp(None), dp(None),
+                    dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+        return self._corr
 
     def __del__(self):
         # Using memory allocated from the C layer means we have to explicitly deallocate it
         # rather than being able to rely on the Python memory manager.
-        # In case __init__ failed to get that far
-        if hasattr(self,'corr'):  # pragma: no branch
+        if hasattr(self, '_corr'):
             if not treecorr._ffi._lock.locked(): # pragma: no branch
                 treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
@@ -151,13 +152,12 @@ class NGCorrelation(treecorr.BinnedCorr2):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        del d['corr']
-        del d['logger']  # Oh well.  This is just lost in the copy.  Can't be pickled.
+        d.pop('_corr',None)
+        d.pop('logger',None)  # Oh well.  This is just lost in the copy.  Can't be pickled.
         return d
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self._build_corr()
         self.logger = treecorr.config.setup_logger(
                 treecorr.config.get(self.config,'verbose',int,1),
                 self.config.get('log_file',None))
@@ -513,8 +513,6 @@ class NGCorrelation(treecorr.BinnedCorr2):
         self.raw_xi = self.xi
         self.raw_xi_im = self.xi_im
         self.raw_varxi = self.varxi
-        self._build_corr()
-
 
     def calculateNMap(self, R=None, rg=None, m2_uform=None):
         """Calculate the aperture mass statistics from the correlation function.
@@ -738,4 +736,3 @@ class NGCorrelation(treecorr.BinnedCorr2):
               nsq, np.sqrt(varnsq), mapsq, np.sqrt(varmapsq),
               nmnorm, np.sqrt(varnmnorm), nnnorm, np.sqrt(varnnnorm) ],
             precision=precision, file_type=file_type, logger=self.logger)
-

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -315,7 +315,7 @@ class NKCorrelation(treecorr.BinnedCorr2):
         return self
 
 
-    def process(self, cat1, cat2, metric=None, num_threads=None):
+    def process(self, cat1, cat2, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.
 
         Both arguments may be lists, in which case all items in the list are used
@@ -330,6 +330,8 @@ class NKCorrelation(treecorr.BinnedCorr2):
             num_threads (int):  How many OpenMP threads to use during the calculation.
                                 (default: use the number of cpu cores; this value can also be given
                                 in the constructor in the config dict.)
+            low_mem (bool):     Whether to sacrifice a little speed to try to reduce memory usage.
+                                This only works if using patches. (default: False)
         """
         import math
         self.clear()
@@ -343,7 +345,7 @@ class NKCorrelation(treecorr.BinnedCorr2):
 
         vark = treecorr.calculateVarK(cat2)
         self.logger.info("vark = %f: sig_k = %f",vark,math.sqrt(vark))
-        self._process_all_cross(cat1,cat2,metric,num_threads)
+        self._process_all_cross(cat1, cat2, metric, num_threads, low_mem)
         self.finalize(vark)
 
 

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -145,6 +145,15 @@ class NKCorrelation(treecorr.BinnedCorr2):
         import copy
         return copy.deepcopy(self)
 
+    def _copy_for_results(self):
+        # Make a copy of just the things we need to keep in results.
+        ret = NKCorrelation.__new__(NKCorrelation)
+        ret._nbins = self._nbins
+        ret.xi = self.xi.copy()
+        ret.weight = self.weight.copy()
+        ret.config = self.config  # not deep copy, so cheap, but makes repr work
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_corr',None)

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -95,24 +95,25 @@ class NKCorrelation(treecorr.BinnedCorr2):
         self.npairs = np.zeros_like(self.rnom, dtype=float)
         self.raw_xi = self.xi
         self.raw_varxi = self.varxi
-        self._build_corr()
         self._rk = None
         self.logger.debug('Finished building NKCorr')
 
-    def _build_corr(self):
-        from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildCorr2(
-                self._d1, self._d2, self._bintype,
-                self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
-                self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
-                dp(self.raw_xi), dp(None), dp(None), dp(None),
-                dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+    @property
+    def corr(self):
+        if not hasattr(self, '_corr'):
+            from treecorr.util import double_ptr as dp
+            self._corr = treecorr._lib.BuildCorr2(
+                    self._d1, self._d2, self._bintype,
+                    self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
+                    self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
+                    dp(self.raw_xi), dp(None), dp(None), dp(None),
+                    dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+        return self._corr
 
     def __del__(self):
         # Using memory allocated from the C layer means we have to explicitly deallocate it
         # rather than being able to rely on the Python memory manager.
-        # In case __init__ failed to get that far
-        if hasattr(self,'corr'):  # pragma: no branch
+        if hasattr(self, '_corr'):
             if not treecorr._ffi._lock.locked(): # pragma: no branch
                 treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
@@ -146,13 +147,12 @@ class NKCorrelation(treecorr.BinnedCorr2):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        del d['corr']
-        del d['logger']  # Oh well.  This is just lost in the copy.  Can't be pickled.
+        d.pop('_corr',None)
+        d.pop('logger',None)  # Oh well.  This is just lost in the copy.  Can't be pickled.
         return d
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self._build_corr()
         self.logger = treecorr.config.setup_logger(
                 treecorr.config.get(self.config,'verbose',int,1),
                 self.config.get('log_file',None))
@@ -494,6 +494,3 @@ class NKCorrelation(treecorr.BinnedCorr2):
         self.bin_type = params['bin_type'].strip()
         self.raw_xi = self.xi
         self.raw_varxi = self.varxi
-        self._build_corr()
-
-

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -339,7 +339,7 @@ class NNCorrelation(treecorr.BinnedCorr2):
         # the resulting weight is zero.
         self.results[(i,j)] = other._copy_for_results()
 
-    def process(self, cat1, cat2=None, metric=None, num_threads=None):
+    def process(self, cat1, cat2=None, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.
 
         If only 1 argument is given, then compute an auto-correlation function.
@@ -358,6 +358,8 @@ class NNCorrelation(treecorr.BinnedCorr2):
             num_threads (int):  How many OpenMP threads to use during the calculation.
                                 (default: use the number of cpu cores; this value can also be given
                                 in the constructor in the config dict.)
+            low_mem (bool):     Whether to sacrifice a little speed to try to reduce memory usage.
+                                This only works if using patches. (default: False)
         """
         self.clear()
 
@@ -370,9 +372,9 @@ class NNCorrelation(treecorr.BinnedCorr2):
             cat2 = cat2.get_patches()
 
         if cat2 is None or len(cat2) == 0:
-            self._process_all_auto(cat1,metric,num_threads)
+            self._process_all_auto(cat1, metric, num_threads, low_mem)
         else:
-            self._process_all_cross(cat1,cat2,metric,num_threads)
+            self._process_all_cross(cat1, cat2, metric, num_threads, low_mem)
         self.finalize()
 
     def _mean_weight(self):

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -329,15 +329,21 @@ class NNCorrelation(treecorr.BinnedCorr2):
         self.tot += other.tot
         return self
 
-    def _add_tot(self, i, j, other):
+    def _add_tot(self, i, j, c1, c2):
         # When storing results from a patch-based run, tot needs to be accumulated even if
         # the total weight being accumulated comes out to be zero.
         # This only applies to NNCorrelation.  For the other ones, this is a no op.
-        self.tot += other.tot
+        tot = c1.sumw * c2.sumw
+        self.tot += tot
         # We also have to keep all pairs in the results dict, otherwise the tot calculation
         # gets messed up.  We need to accumulate the tot value of all pairs, even if
         # the resulting weight is zero.
-        self.results[(i,j)] = other._copy_for_results()
+        res = NNCorrelation.__new__(NNCorrelation)
+        res._nbins = self._nbins
+        res.weight = np.zeros_like(self.weight)
+        res.tot = tot
+        res.config = self.config  # not deep copy, so cheap, but makes repr work
+        self.results[(i,j)] = res
 
     def process(self, cat1, cat2=None, metric=None, num_threads=None, low_mem=False):
         """Compute the correlation function.

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -90,24 +90,25 @@ class NNCorrelation(treecorr.BinnedCorr2):
         self.weight = np.zeros_like(self.rnom, dtype=float)
         self.npairs = np.zeros_like(self.rnom, dtype=float)
         self.tot = 0.
-        self._build_corr()
         self._rr_weight = None  # Marker that calculateXi hasn't been called yet.
         self.logger.debug('Finished building NNCorr')
 
-    def _build_corr(self):
-        from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildCorr2(
-                self._d1, self._d2, self._bintype,
-                self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
-                self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
-                dp(None), dp(None), dp(None), dp(None),
-                dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+    @property
+    def corr(self):
+        if not hasattr(self, '_corr'):
+            from treecorr.util import double_ptr as dp
+            self._corr = treecorr._lib.BuildCorr2(
+                    self._d1, self._d2, self._bintype,
+                    self._min_sep,self._max_sep,self._nbins,self._bin_size,self.b,
+                    self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
+                    dp(None), dp(None), dp(None), dp(None),
+                    dp(self.meanr),dp(self.meanlogr),dp(self.weight),dp(self.npairs));
+        return self._corr
 
     def __del__(self):
         # Using memory allocated from the C layer means we have to explicitly deallocate it
         # rather than being able to rely on the Python memory manager.
-        # In case __init__ failed to get that far
-        if hasattr(self,'corr'):  # pragma: no branch
+        if hasattr(self, '_corr'):
             if not treecorr._ffi._lock.locked(): # pragma: no branch
                 treecorr._lib.DestroyCorr2(self.corr, self._d1, self._d2, self._bintype)
 
@@ -140,13 +141,12 @@ class NNCorrelation(treecorr.BinnedCorr2):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        del d['corr']
-        del d['logger']  # Oh well.  This is just lost in the copy.  Can't be pickled.
+        d.pop('_corr',None)
+        d.pop('logger',None)  # Oh well.  This is just lost in the copy.  Can't be pickled.
         return d
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self._build_corr()
         self.logger = treecorr.config.setup_logger(
                 treecorr.config.get(self.config,'verbose',int,1),
                 self.config.get('log_file',None))
@@ -715,8 +715,6 @@ class NNCorrelation(treecorr.BinnedCorr2):
         if 'xi' in data.dtype.names:
             self.xi = data['xi']
             self.varxi = data['sigma_xi']**2
-        self._build_corr()
-
 
     def calculateNapSq(self, rr, R=None, dr=None, rd=None, m2_uform=None):
         """Calculate the correlary to the aperture mass statistics for counts.
@@ -801,5 +799,3 @@ class NNCorrelation(treecorr.BinnedCorr2):
         varnsq = (Tp**2).dot(varxi) * self.bin_size**2
 
         return nsq, varnsq
-
-

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -139,6 +139,15 @@ class NNCorrelation(treecorr.BinnedCorr2):
         import copy
         return copy.deepcopy(self)
 
+    def _copy_for_results(self):
+        # Make a copy of just the things we need to keep in results.
+        ret = NNCorrelation.__new__(NNCorrelation)
+        ret._nbins = self._nbins
+        ret.weight = self.weight.copy()
+        ret.tot = self.tot
+        ret.config = self.config  # not deep copy, so cheap, but makes repr work
+        return ret
+
     def __getstate__(self):
         d = self.__dict__.copy()
         d.pop('_corr',None)
@@ -328,7 +337,7 @@ class NNCorrelation(treecorr.BinnedCorr2):
         # We also have to keep all pairs in the results dict, otherwise the tot calculation
         # gets messed up.  We need to accumulate the tot value of all pairs, even if
         # the resulting weight is zero.
-        self.results[(i,j)] = other.copy()
+        self.results[(i,j)] = other._copy_for_results()
 
     def process(self, cat1, cat2=None, metric=None, num_threads=None):
         """Compute the correlation function.

--- a/treecorr/nnncorrelation.py
+++ b/treecorr/nnncorrelation.py
@@ -426,7 +426,7 @@ class NNNCorrelation(treecorr.BinnedCorr3):
             raise NotImplementedError("No partial cross NNN yet.")
         else:
             assert cat2 is not None and cat3 is not None
-            self._process_all_cross(cat1,cat2,cat3, metric, num_threads)
+            self._process_all_cross(cat1, cat2, cat3, metric, num_threads)
         self.finalize()
 
     def calculateZeta(self, rrr, drr=None, rdr=None, rrd=None,

--- a/treecorr/nnncorrelation.py
+++ b/treecorr/nnncorrelation.py
@@ -115,28 +115,29 @@ class NNNCorrelation(treecorr.BinnedCorr3):
         self.weight = np.zeros(shape, dtype=float)
         self.ntri = np.zeros(shape, dtype=float)
         self.tot = 0.
-        self._build_corr()
         self.logger.debug('Finished building NNNCorr')
 
-    def _build_corr(self):
-        from treecorr.util import double_ptr as dp
-        self.corr = treecorr._lib.BuildCorr3(
-                self._d1, self._d2, self._d3, self._bintype,
-                self._min_sep,self._max_sep,self.nbins,self._bin_size,self.b,
-                self.min_u,self.max_u,self.nubins,self.ubin_size,self.bu,
-                self.min_v,self.max_v,self.nvbins,self.vbin_size,self.bv,
-                self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
-                dp(None), dp(None), dp(None), dp(None),
-                dp(None), dp(None), dp(None), dp(None),
-                dp(self.meand1), dp(self.meanlogd1), dp(self.meand2), dp(self.meanlogd2),
-                dp(self.meand3), dp(self.meanlogd3), dp(self.meanu), dp(self.meanv),
-                dp(self.weight), dp(self.ntri));
+    @property
+    def corr(self):
+        if not hasattr(self, '_corr'):
+            from treecorr.util import double_ptr as dp
+            self._corr = treecorr._lib.BuildCorr3(
+                    self._d1, self._d2, self._d3, self._bintype,
+                    self._min_sep,self._max_sep,self.nbins,self._bin_size,self.b,
+                    self.min_u,self.max_u,self.nubins,self.ubin_size,self.bu,
+                    self.min_v,self.max_v,self.nvbins,self.vbin_size,self.bv,
+                    self.min_rpar, self.max_rpar, self.xperiod, self.yperiod, self.zperiod,
+                    dp(None), dp(None), dp(None), dp(None),
+                    dp(None), dp(None), dp(None), dp(None),
+                    dp(self.meand1), dp(self.meanlogd1), dp(self.meand2), dp(self.meanlogd2),
+                    dp(self.meand3), dp(self.meanlogd3), dp(self.meanu), dp(self.meanv),
+                    dp(self.weight), dp(self.ntri));
+        return self._corr
 
     def __del__(self):
         # Using memory allocated from the C layer means we have to explicitly deallocate it
         # rather than being able to rely on the Python memory manager.
-        # In case __init__ failed to get that far
-        if hasattr(self,'corr'):  # pragma: no branch
+        if hasattr(self, '_corr'):
             if not treecorr._ffi._lock.locked(): # pragma: no branch
                 treecorr._lib.DestroyCorr3(self.corr, self._d1, self._d2, self._d3, self._bintype)
 
@@ -183,13 +184,12 @@ class NNNCorrelation(treecorr.BinnedCorr3):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        del d['corr']
-        del d['logger']  # Oh well.  This is just lost in the copy.  Can't be pickled.
+        d.pop('_corr',None)
+        d.pop('logger',None)  # Oh well.  This is just lost in the copy.  Can't be pickled.
         return d
 
     def __setstate__(self, d):
         self.__dict__ = d
-        self._build_corr()
         self.logger = treecorr.config.setup_logger(
                 treecorr.config.get(self.config,'verbose',int,1),
                 self.config.get('log_file',None))
@@ -682,6 +682,3 @@ class NNNCorrelation(treecorr.BinnedCorr3):
         self.metric = params['metric'].strip()
         self.sep_units = params['sep_units'].strip()
         self.bin_type = params['bin_type'].strip()
-        self._build_corr()
-
-


### PR DESCRIPTION
One of the desired advantages of using patches is to reduce the memory required to compute the full correlation.  Only one or two patches need to be in memory at a time, so this potentially provides a way to process very large files without crashing the memory.  However, there hadn't been a way to really make that work easily.  So this PR adds some convenience functions to enable it.

Here is the use pattern to minimize the memory footprint by using patches:
```
# Load a smaller version of the full catalog using every_nth to make the patches
partial_cat = treecorr.Catalog(file_name, every_nth=100,
                               ra_col='ra', dec_col='dec', ra_units='rad', dec_units='rad',
                               npatch=npatch)

# Save the patch_centers from this catalog
patch_centers = partial_cat.patch_centers
del partial_cat  # Don't need it anymore.

# Make the full catalog, telling it to use these patch centers.
# Note: this won't trigger an actual read.
# And the way we'll do it, we won't ever read the full file.  Just patches.
# The save_patch_dir is not technically required, but it makes the repeated
# loads and unloads of the patches much more efficient.  So recommended.
full_cat = treecorr.Catalog(file_name,
                            ra_col='ra', dec_col='dec', ra_units='rad', dec_units='rad',
                            patch_centers=patch_centers, save_patch_dir='tmp_dir')

# Make whatever kind of correlation function you want.
dd = treecorr.NNCorrelation(bin_size=0.5, min_sep=1., max_sep=30., sep_units='arcmin')

# Now process with the new low_mem=True option.
# It will load each patch as needed and unload them when it's done with it.
dd.process(full_cat, low_mem=True)
```
In my testing, I was finding it taking about 50% longer than the regular version (without `low_mem`).  But I think this is highly dependent on how big the patches are such.  It wouldn't surprise me if for vv large files, the difference was pretty negligible as the reading steps becomes a much smaller fraction of the total time.

Pinging @chihway @ajamsellem  It would be great if you could try this on your use case and let me know if you notice any issues!