### PR TITLE
Change NaN warning when there are lots of them

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1446,6 +1446,11 @@ def test_nan2():
     np.testing.assert_allclose(cat1.varg, cat2.varg)
     np.testing.assert_allclose(cat1.vark, cat2.vark)
 
+    # Catalog generation with > 200 nans, to test the other pathway
+    # in the warnings code.  No other immediate tests.
+    g1[:1000] = np.nan
+    cat2c = treecorr.Catalog(ra=ra, dec=dec, g1=g1, g2=g2, ra_units='deg', dec_units='deg')
+
 
 @timer
 def test_contiguous():

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -1118,8 +1118,12 @@ class Catalog(object):
         """
         if col is not None and np.any(np.isnan(col)):
             index = np.where(np.isnan(col))[0]
-            self.logger.warning("Warning: NaNs found in %s column.  Skipping rows %s."%(
-                                col_str,str(index.tolist())))
+            if len(index) < 200:
+                self.logger.warning("Warning: %d NaNs found in %s column.  Skipping rows %s."%(
+                                    len(index),col_str,str(index.tolist())))
+            else:
+                self.logger.warning("Warning: %d NaNs found in %s column.  Skipping rows starting %s."%(
+                                    len(index),col_str,str(index[:10].tolist())))
             if self._w is None:
                 self._w = np.ones_like(col, dtype=float)
             self._w[index] = 0

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -1118,11 +1118,11 @@ class Catalog(object):
         """
         if col is not None and np.any(np.isnan(col)):
             index = np.where(np.isnan(col))[0]
-            if len(index) < 200:
+            if len(index) < 10:
                 self.logger.warning("Warning: %d NaNs found in %s column.  Skipping rows %s."%(
                                     len(index),col_str,str(index.tolist())))
             else:
-                self.logger.warning("Warning: %d NaNs found in %s column.  Skipping rows starting %s."%(
+                self.logger.warning("Warning: %d NaNs found in %s column.  Skipping rows starting %s ..."%(
                                     len(index),col_str,str(index[:10].tolist())))
             if self._w is None:
                 self._w = np.ones_like(col, dtype=float)


### PR DESCRIPTION
In a few cases in TXPipe I've run TreeCorr on catalogs with thousands or millions of NaNs.  That's definitely a problem to fix, but I ended up with GB of logs printing out all the indices.

This PR changes the logging so if there are more than 200 NaNs in a column it just lists the first 10.  In either case it also prints out the number of NaNs.