### PR TITLE
Add Parquet as a valid input file_type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
               # They are slow to install on pypy, where some are installed from scratch.
               if: matrix.py > 3.0
               run: |
-                pip install -U matplotlib nbval ipykernel scipy pandas guppy3 h5py
+                pip install -U matplotlib nbval ipykernel scipy pandas guppy3 h5py pyarrow
 
             - name: List all installed packages for reference
               run: pip list

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ New features
 - Added ability to do 3 point cross-correlations properly, rather than the not exactly
   correct version that had been implemented.  Not all combinations are implemented.
   So far just GGG, KKK, and NNN. (#115)
+- Added ability to read from parquet catalogs.  (#117)
 
 Bug fixes
 ---------

--- a/tests/data/.gitignore
+++ b/tests/data/.gitignore
@@ -1,5 +1,6 @@
 Aardvark.fit
 Aardvark.hdf5
+Aardvark.parquet
 *.fits
 *.png
 *.dat

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -483,8 +483,9 @@ def test_hdf5():
 def test_parquet():
     try:
         import pandas  # noqa: F401
+        import pyarrow # noqa: F401
     except ImportError:
-        print('Skipping ParquetReader tests, since pandas not installed.')
+        print('Skipping ParquetReader tests, since pandas or pyarrow not installed.')
         return
     _test_aardvark('Aardvark.parquet', 'Parquet', None)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -468,7 +468,7 @@ def test_ascii():
 
 @timer
 def test_fits():
-    _test_fits_hdf('Aardvark.fit')
+    _test_aardvark('Aardvark.fit', 'FITS', 'AARDWOLF')
 
 @timer
 def test_hdf5():
@@ -477,23 +477,26 @@ def test_hdf5():
     except ImportError:
         print('Skipping HdfReader tests, since h5py not installed.')
         return
-    _test_fits_hdf('Aardvark.hdf5')
+    _test_aardvark('Aardvark.hdf5', 'HDF', '/')
 
+@timer
+def test_parquet():
+    try:
+        import pandas  # noqa: F401
+    except ImportError:
+        print('Skipping ParquetReader tests, since pandas not installed.')
+        return
+    _test_aardvark('Aardvark.parquet', 'Parquet', None)
 
-def _test_fits_hdf(filename):
+def _test_aardvark(filename, file_type, ext):
     get_from_wiki(filename)
     file_name = os.path.join('data',filename)
     config = treecorr.read_config('Aardvark.yaml')
     config['verbose'] = 1
     config['kk_file_name'] = 'kk.out'
     config['gg_file_name'] = 'gg.out'
-
-    if filename.endswith('hdf5'):
-        config['file_name'] = file_name
-        file_type = 'HDF'
-    else:
-        config['ext'] = 'AARDWOLF'
-        file_type = 'FITS'
+    config['file_name'] = file_name
+    config['ext'] = ext
 
     # Just test a few random particular values
     cat1 = treecorr.Catalog(file_name, config)
@@ -1990,9 +1993,10 @@ def test_lru():
 
 
 if __name__ == '__main__':
-    test_hdf5()
     test_ascii()
     test_fits()
+    test_hdf5()
+    test_parquet()
     test_ext()
     test_hdu()
     test_direct()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -184,8 +184,9 @@ def test_hdf_reader():
 def test_parquet_reader():
     try:
         import pandas  # noqa: F401
+        import pyarrow # noqa: F401
     except ImportError:
-        print('Skipping PandasReader tests, since pandas not installed.')
+        print('Skipping PandasReader tests, since pandas or pyarrow not installed.')
         return
 
     get_from_wiki('Aardvark.parquet')

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -160,7 +160,8 @@ def test_hdf_reader():
         assert r.row_count('RA','/') == 390935
         assert r.row_count('GAMMA1') == 390935
         # Unlike the other readers, this needs a column name.
-        assert_raises(TypeError, r.row_count)
+        with assert_raises(TypeError):
+            r.row_count()
         assert set(r.names()) == set("INDEX RA DEC Z EPSILON GAMMA1 GAMMA2 KAPPA MU".split())
         assert set(r.names('/')) == set(r.names())
 
@@ -186,7 +187,7 @@ def test_parquet_reader():
         import pandas  # noqa: F401
         import pyarrow # noqa: F401
     except ImportError:
-        print('Skipping PandasReader tests, since pandas or pyarrow not installed.')
+        print('Skipping ParquetReader tests, since pandas or pyarrow not installed.')
         return
 
     get_from_wiki('Aardvark.parquet')
@@ -201,6 +202,8 @@ def test_parquet_reader():
         r.row_count('DEC', None)
     with assert_raises(RuntimeError):
         r.row_count('DEC')
+    with assert_raises(RuntimeError):
+        r.row_count()
     with assert_raises(RuntimeError):
         r.names(None)
     with assert_raises(RuntimeError):
@@ -230,8 +233,7 @@ def test_parquet_reader():
         assert r.row_count('RA') == 390935
         assert r.row_count('RA',None) == 390935
         assert r.row_count('GAMMA1') == 390935
-        # Unlike the other readers, this needs a column name.
-        assert_raises(TypeError, r.row_count)
+        assert r.row_count() == 390935
         print('names = ',set(r.names()))
         print('names = ',set("INDEX RA DEC Z GAMMA1 GAMMA2 KAPPA MU".split()))
         assert set(r.names()) == set("INDEX RA DEC Z GAMMA1 GAMMA2 KAPPA MU".split())
@@ -246,6 +248,8 @@ def test_parquet_reader():
         r.row_count('DEC', None)
     with assert_raises(RuntimeError):
         r.row_count('DEC')
+    with assert_raises(RuntimeError):
+        r.row_count()
     with assert_raises(RuntimeError):
         r.names(None)
     with assert_raises(RuntimeError):

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -211,6 +211,8 @@ def parse(value, value_type, name):
     try:
         if value_type is bool:
             return parse_bool(value)
+        elif value is None:
+            return None
         else:
             return value_type(value)
     except ValueError:
@@ -342,6 +344,8 @@ def convert(value, value_type, key):
         return parse_unit(value)
     elif value_type == bool:
         return parse_bool(value)
+    elif value is None:
+        return None
     else:
         return value_type(value)
 

--- a/treecorr/reader.py
+++ b/treecorr/reader.py
@@ -346,13 +346,10 @@ class ParquetReader():
     def read(self, cols, s=slice(None), ext=None):
         """Read a slice of a column or list of columns from a specified extension.
 
-        Slices should always be used when reading HDF files - using a sequence of
-        integers is painfully slow.
-
         Parameters:
             cols (str/list):    The name(s) of column(s) to read
             s (slice/array):    A slice object or selection of integers to read (default: all)
-            ext (str):          The HDF (sub-)group to use (default: '/')
+            ext (str):          The extension (ignored)
 
         Returns:
             The data as a recarray or simple numpy array as appropriate
@@ -362,7 +359,7 @@ class ParquetReader():
         else:
             return self.df[cols][s].to_records()
 
-    def row_count(self, col, ext=None):
+    def row_count(self, col=None, ext=None):
         """Count the number of rows in the named extension and column
 
         Unlike in FitsReader, col is required.

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -68,12 +68,12 @@ def get_omp_threads():
     """
     return treecorr._lib.GetOMPThreads()
 
-def parse_file_type(file_type, file_name, hdf=False, logger=None):
+def parse_file_type(file_type, file_name, output=False, logger=None):
     """Parse the file_type from the file_name if necessary
 
     :param file_type:   The input file_type.  If None, then parse from file_name's extension.
     :param file_name:   The filename to use for parsing if necessary.
-    :param hdf:         Include HDF as a possible file_type? (default: False)
+    :param output:      Limit to output file types (FITS/ASCII)? (default: False)
     :param logger:      A logger if desired. (default: None)
 
     :returns: The parsed file_type.
@@ -83,8 +83,10 @@ def parse_file_type(file_type, file_name, hdf=False, logger=None):
         name, ext = os.path.splitext(file_name)
         if ext.lower().startswith('.fit'):
             file_type = 'FITS'
-        elif hdf and ext.lower().startswith('.hdf'):
+        elif not output and ext.lower().startswith('.hdf'):
             file_type = 'HDF'
+        elif not output and ext.lower().startswith('.par'):
+            file_type = 'Parquet'
         else:
             file_type = 'ASCII'
         if logger:
@@ -118,7 +120,7 @@ def gen_write(file_name, col_names, columns, params=None, precision=4, file_type
     ensure_dir(file_name)
 
     # Figure out which file type to use.
-    file_type = parse_file_type(file_type, file_name, logger=logger)
+    file_type = parse_file_type(file_type, file_name, output=True, logger=logger)
 
     if file_type == 'FITS':
         try:
@@ -213,7 +215,7 @@ def gen_multi_write(file_name, col_names, group_names, columns,
     ensure_dir(file_name)
 
     # Figure out which file type to use.
-    file_type = parse_file_type(file_type, file_name, logger=logger)
+    file_type = parse_file_type(file_type, file_name, output=True, logger=logger)
 
     if file_type == 'FITS':
         try:
@@ -252,7 +254,7 @@ def gen_read(file_name, file_type=None, logger=None):
     :returns: (data, params), a numpy ndarray with named columns, and a dict of extra parameters.
     """
     # Figure out which file type to use.
-    file_type = parse_file_type(file_type, file_name, logger=logger)
+    file_type = parse_file_type(file_type, file_name, output=True, logger=logger)
 
     if file_type == 'FITS':
         try:
@@ -319,7 +321,7 @@ def gen_multi_read(file_name, group_names, file_type=None, logger=None):
     :returns: list of (data, params) pairs, one for each group
     """
     # Figure out which file type to use.
-    file_type = parse_file_type(file_type, file_name, logger=logger)
+    file_type = parse_file_type(file_type, file_name, output=True, logger=logger)
 
     if file_type == 'FITS':
         try:


### PR DESCRIPTION
@enourbakhsh wanted to read in from some Parquet files.  Turns out that's pretty easy to add with the new Reader class we are using now.  So this PR adds a ParquetReader.  It is automatically used for file names ending in '.par*', or you can manually specify `file_type='Parquet'`.