### PR TITLE
Hdf5 patches

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -728,6 +728,17 @@ def test_gen_multi_read_write():
     with assert_raises((OSError, IOError)):
         treecorr.util.gen_multi_read(file_name, names, file_type='FITS')
 
+    file_name = 'invalid.hdf5'
+    with assert_raises(NotImplementedError):
+        treecorr.util.gen_multi_write(file_name, col_names, names, data)
+    with assert_raises(NotImplementedError):
+        treecorr.util.gen_multi_read(file_name, names)
+    with assert_raises(NotImplementedError):
+        treecorr.util.gen_multi_write(file_name, col_names, names, data, file_type='HDF')
+    with assert_raises(NotImplementedError):
+        treecorr.util.gen_multi_read(file_name, names, file_type='HDF')
+
+
     # Now some working I/O
     file_name1 = 'output/valid1.out'
     treecorr.util.gen_multi_write(file_name1, col_names, names, data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -609,23 +609,42 @@ def test_gen_read_write():
     assert par['p1'] == 7
     assert par['p2'] == 'hello'
 
-    file_name5 = 'output/valid3.hdf'
-    treecorr.util.gen_write(file_name5, ['a', 'b'], [a,b], params=params)
-    data, par = treecorr.util.gen_read(file_name5)
-    np.testing.assert_array_equal(data['a'], a)
-    np.testing.assert_array_equal(data['b'], b)
-    print('par = ',par)
-    assert par['p1'] == 7
-    assert par['p2'] == 'hello'
+    try:
+        import h5py
+    except ImportError:
+        print('Skipping saving HDF catalogs, since h5py not installed.')
+        h5py = None
 
-    file_name6 = 'output/valid3.hdf5'
-    treecorr.util.gen_write(file_name6, ['a', 'b'], [a,b], params=params)
-    data, par = treecorr.util.gen_read(file_name6)
-    np.testing.assert_array_equal(data['a'], a)
-    np.testing.assert_array_equal(data['b'], b)
-    print('par = ',par)
-    assert par['p1'] == 7
-    assert par['p2'] == 'hello'
+    if h5py is not None:
+        file_name5 = 'output/valid3.hdf'
+        treecorr.util.gen_write(file_name5, ['a', 'b'], [a,b], params=params)
+        data, par = treecorr.util.gen_read(file_name5)
+        np.testing.assert_array_equal(data['a'], a)
+        np.testing.assert_array_equal(data['b'], b)
+        print('par = ',par)
+        assert par['p1'] == 7
+        assert par['p2'] == 'hello'
+
+        file_name6 = 'output/valid3.hdf5'
+        treecorr.util.gen_write(file_name6, ['a', 'b'], [a,b], params=params)
+        data, par = treecorr.util.gen_read(file_name6)
+        np.testing.assert_array_equal(data['a'], a)
+        np.testing.assert_array_equal(data['b'], b)
+        print('par = ',par)
+        assert par['p1'] == 7
+        assert par['p2'] == 'hello'
+
+        file_name7 = 'output/valid4.hdf5'
+        with h5py.File(file_name7, "w") as hdf:
+            treecorr.util.gen_write_hdf(hdf, ['a', 'b'], [a,b], params=params, groupname="my_group")
+        with h5py.File(file_name7, "r") as hdf:
+            data, par = treecorr.util.gen_read_hdf(hdf, groupname="my_group")
+        np.testing.assert_array_equal(data['a'], a)
+        np.testing.assert_array_equal(data['b'], b)
+        print('par = ',par)
+        assert par['p1'] == 7
+        assert par['p2'] == 'hello'
+
 
     # Check with logger
     with CaptureLog() as cl:
@@ -640,6 +659,12 @@ def test_gen_read_write():
     with CaptureLog() as cl:
         treecorr.util.gen_read(file_name4, logger=cl.logger)
     assert 'assumed to be FITS' in cl.output
+
+    if h5py is not None:
+        with CaptureLog() as cl:
+            treecorr.util.gen_write(file_name7, ['a', 'b'], [a,b], params=params, logger=cl.logger)
+        assert 'assumed to be HDF' in cl.output
+
 
     # Check that errors are reasonable if fitsio not installed.
     if sys.version_info < (3,): return  # mock only available on python 3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -728,16 +728,6 @@ def test_gen_multi_read_write():
     with assert_raises((OSError, IOError)):
         treecorr.util.gen_multi_read(file_name, names, file_type='FITS')
 
-    file_name = 'invalid.hdf5'
-    with assert_raises(NotImplementedError):
-        treecorr.util.gen_multi_write(file_name, col_names, names, data)
-    with assert_raises(NotImplementedError):
-        treecorr.util.gen_multi_read(file_name, names)
-    with assert_raises(NotImplementedError):
-        treecorr.util.gen_multi_write(file_name, col_names, names, data, file_type='HDF')
-    with assert_raises(NotImplementedError):
-        treecorr.util.gen_multi_read(file_name, names, file_type='HDF')
-
 
     # Now some working I/O
     file_name1 = 'output/valid1.out'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -609,6 +609,24 @@ def test_gen_read_write():
     assert par['p1'] == 7
     assert par['p2'] == 'hello'
 
+    file_name5 = 'output/valid3.hdf'
+    treecorr.util.gen_write(file_name5, ['a', 'b'], [a,b], params=params)
+    data, par = treecorr.util.gen_read(file_name5)
+    np.testing.assert_array_equal(data['a'], a)
+    np.testing.assert_array_equal(data['b'], b)
+    print('par = ',par)
+    assert par['p1'] == 7
+    assert par['p2'] == 'hello'
+
+    file_name6 = 'output/valid3.hdf5'
+    treecorr.util.gen_write(file_name6, ['a', 'b'], [a,b], params=params)
+    data, par = treecorr.util.gen_read(file_name6)
+    np.testing.assert_array_equal(data['a'], a)
+    np.testing.assert_array_equal(data['b'], b)
+    print('par = ',par)
+    assert par['p1'] == 7
+    assert par['p2'] == 'hello'
+
     # Check with logger
     with CaptureLog() as cl:
         treecorr.util.gen_write(file_name3, ['a', 'b'], [a,b], params=params, logger=cl.logger)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1642,8 +1642,6 @@ def test_save_patches():
     cat0 = treecorr.Catalog(ra=ra, dec=dec, ra_units='rad', dec_units='rad')
     cat0.write(file_name)
 
-    hdf_file_name = os.path.join('output','test_save_patches.hdf5')
-    cat0.write(hdf_file_name)
 
     # When catalog has explicit ra, dec, etc., then file names are patch000.fits, ...
     clear_save('patch%03d.fits', npatch)
@@ -1662,16 +1660,45 @@ def test_save_patches():
 
     # When catalog is a file, then base name off of given file_name.
     # And also try to match the type if HDF
-    for name, ext in zip([file_name, hdf_file_name], ["fits", "hdf5"]):
-        clear_save('test_save_patches_%%03d.%s'%ext, npatch)
-        cat2 = treecorr.Catalog(name, ra_col='ra', dec_col='dec', ra_units='rad', dec_units='rad',
+    file_name = os.path.join('output','test_save_patches.fits')
+    clear_save('test_save_patches_%03d.fits', npatch)
+    cat2 = treecorr.Catalog(file_name, ra_col='ra', dec_col='dec', ra_units='rad', dec_units='rad',
+                            npatch=npatch, save_patch_dir='output')
+    assert not cat2.loaded
+    cat2.get_patches(low_mem=True)
+    assert len(cat2.patches) == npatch
+    assert cat2.loaded  # Making patches triggers load.  Also when write happens.
+    for i in range(npatch):
+        patch_file_name = os.path.join('output','test_save_patches_%03d.fits'%i)
+        assert os.path.exists(patch_file_name)
+        cat_i = treecorr.Catalog(patch_file_name, ra_col='ra', dec_col='dec',
+                                 ra_units='rad', dec_units='rad', patch=i)
+        assert not cat_i.loaded
+        assert not cat2.patches[i].loaded
+        assert cat_i == cat2.patches[i]
+        assert cat_i.loaded
+        assert cat2.patches[i].loaded
+
+    try:
+        import h5py  # noqa: F401
+    except ImportError:
+        print('Skipping saving HDF patches, since h5py not installed.')
+        h5py = None
+
+
+    if h5py is not None:
+        file_name = os.path.join('output','test_save_patches.hdf5')
+        cat0.write(file_name)
+        # And also try to match the type if HDF
+        clear_save('test_save_patches_%03d.hdf5', npatch)
+        cat2 = treecorr.Catalog(file_name, ra_col='ra', dec_col='dec', ra_units='rad', dec_units='rad',
                                 npatch=npatch, save_patch_dir='output')
         assert not cat2.loaded
         cat2.get_patches(low_mem=True)
         assert len(cat2.patches) == npatch
         assert cat2.loaded  # Making patches triggers load.  Also when write happens.
         for i in range(npatch):
-            patch_file_name = os.path.join('output','test_save_patches_%03d.%s'%(i, ext))
+            patch_file_name = os.path.join('output','test_save_patches_%03d.hdf5'%i)
             assert os.path.exists(patch_file_name)
             cat_i = treecorr.Catalog(patch_file_name, ra_col='ra', dec_col='dec',
                                      ra_units='rad', dec_units='rad', patch=i)
@@ -1680,7 +1707,6 @@ def test_save_patches():
             assert cat_i == cat2.patches[i]
             assert cat_i.loaded
             assert cat2.patches[i].loaded
-
 
 
     # Check x,y,z, as well as other possible columns

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1659,8 +1659,6 @@ def test_save_patches():
         assert cat_i.loaded
 
     # When catalog is a file, then base name off of given file_name.
-    # And also try to match the type if HDF
-    file_name = os.path.join('output','test_save_patches.fits')
     clear_save('test_save_patches_%03d.fits', npatch)
     cat2 = treecorr.Catalog(file_name, ra_col='ra', dec_col='dec', ra_units='rad', dec_units='rad',
                             npatch=npatch, save_patch_dir='output')
@@ -1679,6 +1677,7 @@ def test_save_patches():
         assert cat_i.loaded
         assert cat2.patches[i].loaded
 
+    # And also try to match the type if HDF
     try:
         import h5py  # noqa: F401
     except ImportError:

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -1927,8 +1927,13 @@ class Catalog(object):
         """Get the names of the files to use for reading/writing patches in save_patch_dir
         """
         if self.file_name is not None:
-            base = os.path.splitext(os.path.basename(self.file_name))[0]
-            names = [base + '_%03d.fits'%i for i in range(self.npatch)]
+            base, ext = os.path.splitext(os.path.basename(self.file_name))
+            # Default to FITS file if we do not otherwise recognize the file type.
+            # It's not critical to match this, just a convenience for if the user
+            # wants to pre-create their own patch files.
+            if ext.lower() not in [".fits", ".fit", ".hdf5", ".hdf"]:
+                ext = ".fits"
+            names = [base + '_%03d%s'%(i, ext) for i in range(self.npatch)]
         else:
             names = ['patch%03d.fits'%i for i in range(self.npatch)]
         return [os.path.join(save_patch_dir, n) for n in names]

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -261,7 +261,8 @@ def gen_multi_write(file_name, col_names, group_names, columns,
                 fid.write(s.encode())
                 gen_write_ascii(fid, col_names, cols, params, precision=precision)
     elif file_type == "HDF":
-        raise NotImplementedError("Cannot currently write 3-point correlations to HDF files")
+        raise NotImplementedError("Cannot currently write 3-point correlations or "
+                                  "other multi-part data to HDF files")
     else:
         raise ValueError("Invalid file_type %s"%file_type)
 
@@ -299,7 +300,7 @@ def gen_read(file_name, file_type=None, logger=None):
             import h5py
         except ImportError:
             if logger:
-                logger.error("Unable to import fitsio.  Cannot read %s"%file_name)
+                logger.error("Unable to import h5py.  Cannot read %s"%file_name)
             raise
         with h5py.File(file_name, 'r') as hdf:
             return gen_read_hdf(hdf)

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -188,7 +188,7 @@ def gen_write_fits(fits, col_names, columns, params, extname=None):
         data[name] = col
     fits.write(data, header=params, extname=extname)
 
-def gen_write_hdf(hdf, col_names, columns, params, hduname=None):
+def gen_write_hdf(hdf, col_names, columns, params, groupname=None):
     """Write some columns to a new FITS extension with the given column names.
 
     :param hdf:        An open h5py.File handle. E.g. hdf = h5py.File(file_name, 'w')
@@ -197,8 +197,8 @@ def gen_write_hdf(hdf, col_names, columns, params, hduname=None):
     :param params:      A dict of extra parameters to write in the HDF attributes.
     :param extname:     An optional name for the extension to write. (default: None)
     """
-    if hduname is not None:
-        hdf = hdf.create_group(hduname)
+    if groupname is not None:
+        hdf = hdf.create_group(groupname)
     if params is not None:
         hdf.attrs.update(params)
     for (name, col) in zip(col_names, columns):

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -416,6 +416,9 @@ def gen_multi_read(file_name, group_names, file_type=None, logger=None):
                 data, params = gen_read_ascii(fid, max_rows=max_rows)
                 out.append( (data,params) )
         return out
+    elif file_type == "HDF":
+        raise NotImplementedError("Cannot currently read 3-point correlations or "
+                                  "other multi-part data to HDF files")
     else:
         raise ValueError("Invalid file_type %s"%file_type)
 


### PR DESCRIPTION
Adds saving of patch files to HDF.  This is to support a case where I want to make them beforehand, in parallel and using existing HDF tools.

Catalogs originally loaded from HDF files will output their patches to HDF files too.