### PR TITLE
#123 Make things work when almost all patches have no data.

### DIFF
--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -66,7 +66,7 @@ def test_dessv():
     print('rms size = ',np.std(sizes))
     assert np.sum(inertia) < 200.  # This is specific to this particular field and npatch.
     print(np.std(inertia)/np.mean(inertia))
-    assert np.std(inertia) < 0.14 * np.mean(inertia)  # rms is usually < 0.2 * mean
+    assert np.std(inertia) < 0.16 * np.mean(inertia)  # rms is usually < 0.2 * mean
     print(np.std(sizes)/np.mean(sizes))
     assert np.std(sizes) < 0.07 * np.mean(sizes)  # sizes have even less spread usually.
 
@@ -99,7 +99,7 @@ def test_dessv():
     print(np.std(inertia)/np.mean(inertia))
     assert np.std(inertia) < 0.07 * np.mean(inertia)  # rms should be even smaller here.
     print(np.std(sizes)/np.mean(sizes))
-    assert np.std(sizes) < 0.05 * np.mean(sizes)  # This isn't usually much smaller.
+    assert np.std(sizes) < 0.06 * np.mean(sizes)  # This isn't usually much smaller.
 
     # This doesn't keep the counts as equal as the standard algorithm.
     print('mean counts = ',np.mean(counts))
@@ -423,7 +423,7 @@ def test_2d():
     print('rms inertia = ',np.std(inertia))
     assert np.sum(inertia) < 5300.
     print(np.std(inertia)/np.mean(inertia))
-    assert np.std(inertia) < 0.08 * np.mean(inertia)
+    assert np.std(inertia) < 0.09 * np.mean(inertia)
     print('mean counts = ',np.mean(counts))
     print('min counts = ',np.min(counts))
     print('max counts = ',np.max(counts))
@@ -862,7 +862,7 @@ def test_catalog_sphere():
     print('rms inertia = ',np.std(inertia))
     assert np.sum(inertia) < 200.  # Total shouldn't increase much. (And often decreases.)
     print(np.std(inertia)/np.mean(inertia))
-    assert np.std(inertia) < 0.09 * np.mean(inertia)  # rms should be even smaller here.
+    assert np.std(inertia) < 0.10 * np.mean(inertia)  # rms should be even smaller here.
     print('mean counts = ',np.mean(counts))
     print('min counts = ',np.min(counts))
     print('max counts = ',np.max(counts))
@@ -954,7 +954,7 @@ def test_catalog_3d():
     print('rms inertia = ',np.std(inertia))
     assert np.sum(inertia) < 200.  # Total shouldn't increase much. (And often decreases.)
     print(np.std(inertia)/np.mean(inertia))
-    assert np.std(inertia) < 0.09 * np.mean(inertia)  # rms should be even smaller here.
+    assert np.std(inertia) < 0.10 * np.mean(inertia)  # rms should be even smaller here.
     print('mean counts = ',np.mean(counts))
     print('min counts = ',np.min(counts))
     print('max counts = ',np.max(counts))

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2750,8 +2750,8 @@ def test_empty_patches():
 
     # Put all the lenses in a tight patch, but the sources in a much larger patch.
     # This seems like the least implausible scenario where this could happen.
-    lens_x = rng.uniform(-5,5,nlens)
-    lens_y = rng.uniform(-5,5,nlens)
+    lens_x = rng.uniform(-1,1,nlens)
+    lens_y = rng.uniform(-1,1,nlens)
     source_x = rng.uniform(-100,100,nsource)
     source_y = rng.uniform(-100,100,nsource)
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2819,6 +2819,18 @@ def test_empty_patches():
     with assert_raises(RuntimeError):
         cov3 = ng3.estimate_cov('sample')
 
+    # Finally, if all the patch pairs have no counts, then this used to fail in a different way.
+    # The easiest way to achieve this is to have the separation range be wrong.
+    ng4 = treecorr.NGCorrelation(bin_size=0.1, bin_slop=0.1, min_sep=1000., max_sep=5000.)
+    ng4.process(cat1p, cat2p)
+    ng4.estimate_cov('jackknife')
+    np.testing.assert_array_equal(ng4.xi, 0.)
+    np.testing.assert_array_equal(ng4.varxi, 0.)
+    np.testing.assert_array_equal(ng4.cov, 0.)
+
+    with assert_raises(RuntimeError):
+        ng4.estimate_cov('sample')
+
     # With even more patches, there was also a different problem with the 1-2p correlation,
     # because some (0,k) pairs don't have any data, so don't end up in results dict.
     npatch = 100

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2831,6 +2831,21 @@ def test_empty_patches():
     with assert_raises(RuntimeError):
         ng4.estimate_cov('sample')
 
+    # With NN and NNN the check happens in a different place.
+    nn = treecorr.NNCorrelation(bin_size=0.1, bin_slop=0.1, min_sep=10., max_sep=100.)
+    nn.process(cat1p)
+    cov = nn.estimate_cov('jackknife', func=lambda c: c.weight)
+    np.testing.assert_array_equal(cov, 0.)
+    with assert_raises(RuntimeError):
+        cov = nn.estimate_cov('sample', func=lambda c: c.weight)
+
+    nnn = treecorr.NNNCorrelation(bin_size=0.1, bin_slop=0.1, min_sep=10., max_sep=100.)
+    nnn.process(cat1p)
+    cov = nnn.estimate_cov('jackknife', func=lambda c: c.weight.ravel())
+    np.testing.assert_array_equal(cov, 0.)
+    with assert_raises(RuntimeError):
+        cov = nnn.estimate_cov('sample', func=lambda c: c.weight.ravel())
+
     # With even more patches, there was also a different problem with the 1-2p correlation,
     # because some (0,k) pairs don't have any data, so don't end up in results dict.
     npatch = 100

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2819,6 +2819,24 @@ def test_empty_patches():
     with assert_raises(RuntimeError):
         cov3 = ng3.estimate_cov('sample')
 
+    # With even more patches, there was also a different problem with the 1-2p correlation,
+    # because some (0,k) pairs don't have any data, so don't end up in results dict.
+    npatch = 100
+    cat2p = treecorr.Catalog(x=source_x, y=source_y, g1=source_g1, g2=source_g2, k=source_k,
+                             npatch=npatch, rng=rng)
+    ng2.process(cat1, cat2p)
+    np.testing.assert_allclose(ng2.weight, ng1.weight, rtol=0.05)
+    np.testing.assert_allclose(ng2.xi, ng1.xi, rtol=0.05, atol=1.e-3)
+    # The test here is really that the following all compute something.
+    # They used to all fail with an error about some (0,k) pair not being in results dict.
+    cov2j = ng2.estimate_cov('jackknife')
+    with assert_raises(RuntimeError):
+        # This one still gives a runtime error, but not the KeyError it used to raise.
+        cov2s = ng2.estimate_cov('sample')
+    cov2m = ng2.estimate_cov('marked_bootstrap')
+    cov2b = ng2.estimate_cov('bootstrap')
+
+
 if __name__ == '__main__':
     test_cat_patches()
     test_cat_centers()

--- a/tests/test_patch3pt.py
+++ b/tests/test_patch3pt.py
@@ -163,7 +163,7 @@ def test_kkk_jk():
 
     np.testing.assert_allclose(kkkp.ntri, kkk.ntri, rtol=0.05 * tol_factor)
     np.testing.assert_allclose(kkkp.zeta, kkk.zeta, rtol=0.1 * tol_factor, atol=1e-3 * tol_factor)
-    np.testing.assert_allclose(kkkp.varzeta, kkk.varzeta, rtol=0.05 * tol_factor)
+    np.testing.assert_allclose(kkkp.varzeta, kkk.varzeta, rtol=0.05 * tol_factor, atol=3.e-6)
 
     print('jackknife:')
     cov = kkkp.estimate_cov('jackknife')
@@ -422,7 +422,7 @@ def test_kkk_jk():
 
         np.testing.assert_allclose(k1.ntri, kkk.ntri, rtol=0.05 * tol_factor)
         np.testing.assert_allclose(k1.zeta, kkk.zeta, rtol=0.1 * tol_factor, atol=1e-3 * tol_factor)
-        np.testing.assert_allclose(k1.varzeta, kkk.varzeta, rtol=0.05 * tol_factor)
+        np.testing.assert_allclose(k1.varzeta, kkk.varzeta, rtol=0.05 * tol_factor, atol=3.e-6)
 
     print('jackknife:')
     cov = kkkc.estimate_cov('jackknife')

--- a/tests/test_patch3pt.py
+++ b/tests/test_patch3pt.py
@@ -1261,13 +1261,11 @@ def test_nnn_jk():
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.9*tol_factor)
 
-    # In the nosetests version of this, there are zero weight samples, which causes problems
-    # Wait until #123 is fixed to enable this.
-    #print('sample:')
-    #cov = treecorr.estimate_multi_cov([dddc,rrrc], 'sample', cc_zeta)
-    #print(np.diagonal(cov))
-    #print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    #np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.7*tol_factor)
+    print('sample:')
+    cov = treecorr.estimate_multi_cov([dddc,rrrc], 'sample', cc_zeta)
+    print(np.diagonal(cov))
+    print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.7*tol_factor)
 
     print('marked:')
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'marked_bootstrap', cc_zeta)

--- a/tests/test_patch3pt.py
+++ b/tests/test_patch3pt.py
@@ -871,7 +871,7 @@ def test_nnn_jk():
     # Test jackknife and other covariance estimates for nnn correlations.
 
     if __name__ == '__main__':
-        # This setup takes about 2200 sec to run.
+        # This setup takes about 1200 sec to run.
         nhalo = 300
         nsource = 2000
         npatch = 16
@@ -879,7 +879,7 @@ def test_nnn_jk():
         rand_factor = 3
         tol_factor = 1
     elif False:
-        # This setup takes about 1671 sec to run.
+        # This setup takes about 250 sec to run.
         nhalo = 200
         nsource = 1000
         npatch = 16
@@ -887,7 +887,7 @@ def test_nnn_jk():
         rand_factor = 2
         tol_factor = 2
     else:
-        # This setup takes about 147 sec to run.
+        # This setup takes about 44 sec to run.
         nhalo = 100
         nsource = 500
         npatch = 8
@@ -1002,7 +1002,7 @@ def test_nnn_jk():
     # Make the patches with a large random catalog to make sure the patches are uniform area.
     big_rx = rng.uniform(0,1000, 100*nsource)
     big_ry = rng.uniform(0,1000, 100*nsource)
-    big_catp = treecorr.Catalog(x=big_rx, y=big_ry, npatch=npatch)
+    big_catp = treecorr.Catalog(x=big_rx, y=big_ry, npatch=npatch, rng=rng)
     patch_centers = big_catp.patch_centers
 
     # Do the same thing with patches on D, but not yet on R.
@@ -1063,7 +1063,7 @@ def test_nnn_jk():
     cov = dddp.estimate_cov('marked_bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.2*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.3*tol_factor)
 
     print('bootstrap:')
     cov = dddp.estimate_cov('bootstrap')
@@ -1098,7 +1098,7 @@ def test_nnn_jk():
     cov = dddp.estimate_cov('marked_bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnnc))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnnc), atol=2.2*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnnc), atol=2.3*tol_factor)
 
     print('bootstrap:')
     cov = dddp.estimate_cov('bootstrap')
@@ -1130,29 +1130,42 @@ def test_nnn_jk():
     ddd1._calculate_xi_from_pairs(dddp.results.keys())
     np.testing.assert_allclose(ddd1.zeta, dddp.zeta)
 
+    t0 = time.time()
     print('jackknife:')
     cov = dddp.estimate_cov('jackknife')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.9*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('sample:')
     cov = dddp.estimate_cov('sample')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.7*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('marked:')
     cov = dddp.estimate_cov('marked_bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.8*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('bootstrap:')
     cov = dddp.estimate_cov('bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.0*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('compensated: ')
     zeta_c2, var_zeta_c2 = dddp.calculateZeta(rrrp, drrp, rddp)
@@ -1165,29 +1178,42 @@ def test_nnn_jk():
     np.testing.assert_allclose(zeta_c2, zeta_c1, rtol=0.05 * tol_factor, atol=1.e-3 * tol_factor)
     np.testing.assert_allclose(var_zeta_c2, var_zeta_c1, rtol=0.05 * tol_factor)
 
+    t0 = time.time()
     print('jackknife:')
     cov = dddp.estimate_cov('jackknife')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnnc))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnnc), atol=0.8*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('sample:')
     cov = dddp.estimate_cov('sample')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnnc))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnnc), atol=0.8*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('marked:')
     cov = dddp.estimate_cov('marked_bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnnc))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnnc), atol=0.8*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     print('bootstrap:')
     cov = dddp.estimate_cov('bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnnc))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnnc), atol=0.8*tol_factor)
+    t1 = time.time()
+    print('t = ',t1-t0)
+    t0 = time.time()
 
     # I haven't implemented calculateZeta for the NNNCrossCorrelation class, because I'm not
     # actually sure what the right thing to do here is for calculating a single zeta vectors.
@@ -1202,7 +1228,7 @@ def test_nnn_jk():
                                         min_v=0.0, max_v=0.2, nvbins=1, rng=rng)
     rrrc = treecorr.NNNCrossCorrelation(nbins=3, min_sep=50., max_sep=100., bin_slop=0.2,
                                         min_u=0.8, max_u=1.0, nubins=1,
-                                        min_v=0.0, max_v=0.2, nvbins=1, rng=rng)
+                                        min_v=0.0, max_v=0.2, nvbins=1)
     print('CrossCorrelation:')
     dddc.process(catp, catp, catp)
     rrrc.process(rand_catp, rand_catp, rand_catp)
@@ -1231,19 +1257,19 @@ def test_nnn_jk():
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'sample', cc_zeta)
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.7*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.2*tol_factor)
 
     print('marked:')
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'marked_bootstrap', cc_zeta)
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.8*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.5*tol_factor)
 
     print('bootstrap:')
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'bootstrap', cc_zeta)
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.0*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.6*tol_factor)
 
     # Repeat with a 1-2 cross-correlation
     print('CrossCorrelation 1-2:')
@@ -1265,19 +1291,19 @@ def test_nnn_jk():
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'sample', cc_zeta)
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.7*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.1*tol_factor)
 
     print('marked:')
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'marked_bootstrap', cc_zeta)
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.8*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.5*tol_factor)
 
     print('bootstrap:')
     cov = treecorr.estimate_multi_cov([dddc,rrrc], 'bootstrap', cc_zeta)
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_nnns))))
-    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=1.0*tol_factor)
+    np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_nnns), atol=0.6*tol_factor)
 
 
 @timer

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -1072,9 +1072,13 @@ class BinnedCorr2(object):
 
     def _jackknife_pairs(self):
         if self.npatch2 == 1:
-            return [ [(j,0) for j in range(self.npatch1) if j!=i] for i in range(self.npatch1) ]
+            # k=0 here.
+            return [ [(j,k) for j,k in self.results.keys() if j!=i]
+                     for i in range(self.npatch1) ]
         elif self.npatch1 == 1:
-            return [ [(0,j) for j in range(self.npatch2) if j!=i] for i in range(self.npatch2) ]
+            # j=0 here.
+            return [ [(j,k) for j,k in self.results.keys() if k!=i]
+                     for i in range(self.npatch1) ]
         else:
             assert self.npatch1 == self.npatch2
             # For each i:
@@ -1084,9 +1088,11 @@ class BinnedCorr2(object):
 
     def _sample_pairs(self):
         if self.npatch2 == 1:
-            return [ [(i,0)] for i in range(self.npatch1) ]
+            # k=0 here.
+            return [ [(j,k) for j,k in self.results.keys() if j==i] for i in range(self.npatch1) ]
         elif self.npatch1 == 1:
-            return [ [(0,i)] for i in range(self.npatch2) ]
+            # j=0 here.
+            return [ [(j,k) for j,k in self.results.keys() if k==i] for i in range(self.npatch1) ]
         else:
             assert self.npatch1 == self.npatch2
             # Note: It's not obvious to me a priori which of these should be the right choice.
@@ -1110,9 +1116,9 @@ class BinnedCorr2(object):
 
     def _marked_pairs(self, indx):
         if self.npatch2 == 1:
-            return [ (i,0) for i in indx ]
+            return [ (i,0) for i in indx if self._ok[i,0] ]
         elif self.npatch1 == 1:
-            return [ (0,i) for i in indx ]
+            return [ (0,i) for i in indx if self._ok[0,i] ]
         else:
             assert self.npatch1 == self.npatch2
             # Select all pairs where first point is in indx (repeating i as appropriate)
@@ -1120,9 +1126,9 @@ class BinnedCorr2(object):
 
     def _bootstrap_pairs(self, indx):
         if self.npatch2 == 1:
-            return [ (i,0) for i in indx ]
+            return [ (i,0) for i in indx if self._ok[i,0] ]
         elif self.npatch1 == 1:
-            return [ (0,i) for i in indx ]
+            return [ (0,i) for i in indx if self._ok[0,i] ]
         else:
             assert self.npatch1 == self.npatch2
             # Include all represented auto-correlations once, repeating as appropriate.

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -575,6 +575,12 @@ class BinnedCorr2(object):
         self.npatch1 = self.npatch2 = 1
         self.__dict__.pop('_ok',None)
 
+    @property
+    def nonzero(self):
+        """Return if there are any values accumulated yet.  (i.e. npairs > 0)
+        """
+        return np.any(self.npairs)
+
     def _add_tot(self, i, j, c1, c2):
         # No op for all but NNCorrelation, which needs to add the tot value
         pass
@@ -668,7 +674,7 @@ class BinnedCorr2(object):
                         else:
                             self.logger.info('Skipping %d,%d pair, which are too far apart ' +
                                              'for this set of separations',i,j)
-                        if np.sum(temp.npairs) > 0:
+                        if temp.nonzero:
                             if (i,j) not in self.results:
                                 self.results[(i,j)] = temp.copy()
                             else:
@@ -765,7 +771,7 @@ class BinnedCorr2(object):
                         else:
                             self.logger.info('Skipping %d,%d pair, which are too far apart ' +
                                              'for this set of separations',i,j)
-                        if np.sum(temp.npairs) > 0 or i==j or n1==1 or n2==1:
+                        if temp.nonzero or i==j or n1==1 or n2==1:
                             if (i,j) not in self.results:
                                 self.results[(i,j)] = temp.copy()
                             else:

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -765,7 +765,7 @@ class BinnedCorr2(object):
                         else:
                             self.logger.info('Skipping %d,%d pair, which are too far apart ' +
                                              'for this set of separations',i,j)
-                        if np.sum(temp.npairs) > 0:
+                        if np.sum(temp.npairs) > 0 or i==j or n1==1 or n2==1:
                             if (i,j) not in self.results:
                                 self.results[(i,j)] = temp.copy()
                             else:
@@ -1338,14 +1338,15 @@ def _cov_sample(corrs, func):
     npatch = _check_patch_nums(corrs, 'sample')
 
     plist = [c._sample_pairs() for c in corrs]
-    for vpairs in plist:
-        if any([len(v) == 0 for v in vpairs]):
-            raise RuntimeError("Cannot compute sample variance when some patches have no data.")
     # Swap order of plist.  Right now it's a list for each corr of a list for each row.
     # We want a list by row with a list for each corr.
     plist = list(zip(*plist))
 
     v,w = _make_cov_design_matrix(corrs, plist, func, 'sample')
+
+    if np.any(w == 0):
+        raise RuntimeError("Cannot compute sample variance when some patches have no data.")
+
     w /= np.sum(w)  # Now w is the fractional weight for each patch
 
     vmean = np.mean(v, axis=0)

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -1156,26 +1156,32 @@ class BinnedCorr3(object):
     def _jackknife_pairs(self):
         if self.npatch3 == 1:
             if self.npatch2 == 1:
-                return [ [(j,0,0) for j in range(self.npatch1) if j!=i]
+                # k=m=0
+                return [ [(j,k,m) for j,k,m in self.results.keys() if j!=i]
                          for i in range(self.npatch1) ]
             elif self.npatch1 == 1:
-                return [ [(0,j,0) for j in range(self.npatch2) if j!=i]
+                # j=m=0
+                return [ [(j,k,m) for j,k,m in self.results.keys() if k!=i]
                          for i in range(self.npatch2) ]
             else:
+                # m=0
                 assert self.npatch1 == self.npatch2
-                return [ [(j,k,0) for j,k,_ in self.results.keys() if j!=i and k!=i]
-                            for i in range(self.npatch1) ]
+                return [ [(j,k,m) for j,k,m in self.results.keys() if j!=i and k!=i]
+                         for i in range(self.npatch1) ]
         elif self.npatch2 == 1:
             if self.npatch1 == 1:
-                return [ [(0,0,j) for j in range(self.npatch3) if j!=i]
+                # j=k=0
+                return [ [(j,k,m) for j,k,m in self.results.keys() if m!=i]
                          for i in range(self.npatch3) ]
             else:
+                # k=0
                 assert self.npatch1 == self.npatch3
-                return [ [(j,0,k) for j,_,k in self.results.keys() if j!=i and k!=i]
-                            for i in range(self.npatch1) ]
+                return [ [(j,k,m) for j,k,m in self.results.keys() if j!=i and m!=i]
+                         for i in range(self.npatch1) ]
         elif self.npatch1 == 1:
+            # j=0
             assert self.npatch2 == self.npatch3
-            return [ [(0,j,k) for _,j,k in self.results.keys() if j!=i and k!=i]
+            return [ [(j,k,m) for j,k,m in self.results.keys() if k!=i and m!=i]
                      for i in range(self.npatch2) ]
         else:
             assert self.npatch1 == self.npatch2 == self.npatch3
@@ -1185,23 +1191,32 @@ class BinnedCorr3(object):
     def _sample_pairs(self):
         if self.npatch3 == 1:
             if self.npatch2 == 1:
-                return [ [(i,0,0)] for i in range(self.npatch1) ]
+                # k=m=0
+                return [ [(j,k,m) for j,k,m in self.results.keys() if j==i]
+                         for i in range(self.npatch1) ]
             elif self.npatch1 == 1:
-                return [ [(0,i,0)] for i in range(self.npatch2) ]
+                # j=m=0
+                return [ [(j,k,m) for j,k,m in self.results.keys() if k==i]
+                         for i in range(self.npatch2) ]
             else:
+                # m=0
                 assert self.npatch1 == self.npatch2
-                return [ [(j,k,0) for j,k,_ in self.results.keys() if j==i]
+                return [ [(j,k,m) for j,k,m in self.results.keys() if j==i]
                          for i in range(self.npatch1) ]
         elif self.npatch2 == 1:
             if self.npatch1 == 1:
-                return [ [(0,0,i)] for i in range(self.npatch3) ]
+                # j=k=0
+                return [ [(j,k,m) for j,k,m in self.results.keys() if m==i]
+                         for i in range(self.npatch3) ]
             else:
+                # k=0
                 assert self.npatch1 == self.npatch3
-                return [ [(j,0,k) for j,_,k in self.results.keys() if j==i]
+                return [ [(j,k,m) for j,k,m in self.results.keys() if j==i]
                          for i in range(self.npatch1) ]
         elif self.npatch1 == 1:
+            # j=0
             assert self.npatch2 == self.npatch3
-            return [ [(0,j,k) for _,j,k in self.results.keys() if j==i]
+            return [ [(j,k,m) for j,k,m in self.results.keys() if k==i]
                      for i in range(self.npatch2) ]
         else:
             assert self.npatch1 == self.npatch2 == self.npatch3
@@ -1218,16 +1233,16 @@ class BinnedCorr3(object):
     def _marked_pairs(self, indx):
         if self.npatch3 == 1:
             if self.npatch2 == 1:
-                return [ (i,0,0) for i in indx ]
+                return [ (i,0,0) for i in indx if self._ok[i,0,0] ]
             elif self.npatch1 == 1:
-                return [ (0,i,0) for i in indx ]
+                return [ (0,i,0) for i in indx if self._ok[0,i,0] ]
             else:
                 assert self.npatch1 == self.npatch2
                 # Select all pairs where first point is in indx (repeating i as appropriate)
                 return [ (i,j,0) for i in indx for j in range(self.npatch2) if self._ok[i,j,0] ]
         elif self.npatch2 == 1:
             if self.npatch1 == 1:
-                return [ (0,0,i) for i in indx ]
+                return [ (0,0,i) for i in indx if self._ok[0,0,i] ]
             else:
                 assert self.npatch1 == self.npatch3
                 # Select all pairs where first point is in indx (repeating i as appropriate)
@@ -1245,16 +1260,16 @@ class BinnedCorr3(object):
     def _bootstrap_pairs(self, indx):
         if self.npatch3 == 1:
             if self.npatch2 == 1:
-                return [ (i,0,0) for i in indx ]
+                return [ (i,0,0) for i in indx if self._ok[i,0,0] ]
             elif self.npatch1 == 1:
-                return [ (0,i,0) for i in indx ]
+                return [ (0,i,0) for i in indx if self._ok[0,i,0] ]
             else:
                 assert self.npatch1 == self.npatch2
                 return ([ (i,i,0) for i in indx if self._ok[i,i,0] ] +
                         [ (i,j,0) for i in indx for j in indx if self._ok[i,j,0] and i!=j ])
         elif self.npatch2 == 1:
             if self.npatch1 == 1:
-                return [ (0,0,i) for i in indx ]
+                return [ (0,0,i) for i in indx if self._ok[0,0,i] ]
             else:
                 assert self.npatch1 == self.npatch3
                 return ([ (i,0,i) for i in indx if self._ok[i,0,i] ] +

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -856,7 +856,6 @@ class BinnedCorr3(object):
                             else:
                                 self.results[(i,j,j)] += temp
                             self += temp
-                            temp.clear()
                         else:
                             # NNNCorrelation needs to add the tot value
                             self._add_tot(i, j, j, c1, c2, c2)

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -850,7 +850,7 @@ class BinnedCorr3(object):
                         else:
                             self.logger.info('Skipping %d,%d pair, which are too far apart ' +
                                              'for this set of separations',i,j)
-                        if temp.nonempty():
+                        if temp.nonempty() or i==j or n1==1 or n2==1:
                             if (i,j,j) not in self.results:
                                 self.results[(i,j,j)] = temp.copy()
                             else:
@@ -971,7 +971,9 @@ class BinnedCorr3(object):
                             else:
                                 self.logger.info('Skipping %d,%d,%d, which are too far apart ' +
                                                  'for this set of separations',i,j,k)
-                            if temp.nonempty():
+                            if (temp.nonempty() or (i==j==k)
+                                    or (i==j and n3==1) or (i==k and n2==1) or (j==k and n1==1)
+                                    or (n1==n2==1) or (n1==n3==1) or (n2==n3==1)):
                                 if (i,j,k) not in self.results:
                                     self.results[(i,j,k)] = temp.copy()
                                 else:

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -616,6 +616,12 @@ class BinnedCorr3(object):
         self.npatch1 = self.npatch2 = self.npatch3 = 1
         self.__dict__.pop('_ok',None)
 
+    @property
+    def nonzero(self):
+        """Return if there are any values accumulated yet.  (i.e. ntri > 0)
+        """
+        return np.any(self.ntri)
+
     def _add_tot(self, i, j, k, c1, c2, c3):
         # No op for all but NNCorrelation, which needs to add the tot value
         pass
@@ -692,10 +698,10 @@ class BinnedCorr3(object):
                     temp.clear()
                     self.logger.info('Process patch %d auto',i)
                     temp.process_auto(c1,metric,num_threads)
-                    if (i,i,i) not in self.results:
-                        self.results[(i,i,i)] = temp.copy()
-                    else:
+                    if (i,i,i) in self.results and self.results[(i,i,i)].nonzero:
                         self.results[(i,i,i)] += temp
+                    else:
+                        self.results[(i,i,i)] = temp.copy()
                     self += temp
 
                 for jj,c2 in list(enumerate(cat1))[::-1]:
@@ -710,11 +716,11 @@ class BinnedCorr3(object):
                             else:
                                 self.logger.info('Skipping %d,%d pair, which are too far apart ' +
                                                  'for this set of separations',i,j)
-                            if temp.nonempty():
-                                if (i,j,j) not in self.results:
-                                    self.results[(i,j,j)] = temp.copy()
-                                else:
+                            if temp.nonzero:
+                                if (i,j,j) in self.results and self.results[(i,j,j)].nonzero:
                                     self.results[(i,j,j)] += temp
+                                else:
+                                    self.results[(i,j,j)] = temp.copy()
                                 self += temp
                             else:
                                 # NNNCorrelation needs to add the tot value
@@ -725,11 +731,11 @@ class BinnedCorr3(object):
                             if not self._trivially_zero(c1,c1,c2,metric):
                                 self.logger.info('Process patches %d,%d cross12',j,i)
                                 temp.process_cross12(c2,c1, metric, num_threads)
-                            if temp.nonempty():
-                                if (i,i,j) not in self.results:
-                                    self.results[(i,i,j)] = temp.copy()
-                                else:
+                            if temp.nonzero:
+                                if (i,i,j) in self.results and self.results[(i,i,j)].nonzero:
                                     self.results[(i,i,j)] += temp
+                                else:
+                                    self.results[(i,i,j)] = temp.copy()
                                 self += temp
                             else:
                                 # NNNCorrelation needs to add the tot value
@@ -747,11 +753,11 @@ class BinnedCorr3(object):
                                 else:
                                     self.logger.info('Skipping %d,%d,%d, which are too far apart ' +
                                                      'for this set of separations',i,j,k)
-                                if temp.nonempty():
-                                    if (i,j,k) not in self.results:
-                                        self.results[(i,j,k)] = temp.copy()
-                                    else:
+                                if temp.nonzero:
+                                    if (i,j,k) in self.results and self.results[(i,j,k)].nonzero:
                                         self.results[(i,j,k)] += temp
+                                    else:
+                                        self.results[(i,j,k)] = temp.copy()
                                     self += temp
                                 else:
                                     # NNNCorrelation needs to add the tot value
@@ -850,11 +856,11 @@ class BinnedCorr3(object):
                         else:
                             self.logger.info('Skipping %d,%d pair, which are too far apart ' +
                                              'for this set of separations',i,j)
-                        if temp.nonempty() or i==j or n1==1 or n2==1:
-                            if (i,j,j) not in self.results:
-                                self.results[(i,j,j)] = temp.copy()
-                            else:
+                        if temp.nonzero or i==j or n1==1 or n2==1:
+                            if (i,j,j) in self.results and self.results[(i,j,j)].nonzero:
                                 self.results[(i,j,j)] += temp
+                            else:
+                                self.results[(i,j,j)] = temp.copy()
                             self += temp
                         else:
                             # NNNCorrelation needs to add the tot value
@@ -872,11 +878,11 @@ class BinnedCorr3(object):
                             else:
                                 self.logger.info('Skipping %d,%d,%d, which are too far apart ' +
                                                  'for this set of separations',i,j,k)
-                            if temp.nonempty():
-                                if (i,j,k) not in self.results:
-                                    self.results[(i,j,k)] = temp.copy()
-                                else:
+                            if temp.nonzero:
+                                if (i,j,k) in self.results and self.results[(i,j,k)].nonzero:
                                     self.results[(i,j,k)] += temp
+                                else:
+                                    self.results[(i,j,k)] = temp.copy()
                                 self += temp
                             else:
                                 # NNNCorrelation needs to add the tot value
@@ -970,13 +976,13 @@ class BinnedCorr3(object):
                             else:
                                 self.logger.info('Skipping %d,%d,%d, which are too far apart ' +
                                                  'for this set of separations',i,j,k)
-                            if (temp.nonempty() or (i==j==k)
+                            if (temp.nonzero or (i==j==k)
                                     or (i==j and n3==1) or (i==k and n2==1) or (j==k and n1==1)
                                     or (n1==n2==1) or (n1==n3==1) or (n2==n3==1)):
-                                if (i,j,k) not in self.results:
-                                    self.results[(i,j,k)] = temp.copy()
-                                else:
+                                if (i,j,k) in self.results and self.results[(i,j,k)].nonzero:
                                     self.results[(i,j,k)] += temp
+                                else:
+                                    self.results[(i,j,k)] = temp.copy()
                                 self += temp
                             else:
                                 # NNNCorrelation needs to add the tot value

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -457,11 +457,6 @@ class GGGCorrelation(BinnedCorr3):
         self.vargam2.ravel()[:] = self.cov.diagonal()[2*self._nbins:3*self._nbins].real
         self.vargam3.ravel()[:] = self.cov.diagonal()[3*self._nbins:4*self._nbins].real
 
-    def nonempty(self):
-        """Return if there are any values accumulated yet.  (i.e. ntri > 0)
-        """
-        return np.sum(self.ntri) > 0
-
     def _clear(self):
         """Clear the data vectors
         """
@@ -509,7 +504,7 @@ class GGGCorrelation(BinnedCorr3):
                 self.max_v == other.max_v):
             raise ValueError("GGGCorrelation to be added is not compatible with this one.")
 
-        if not other.nonempty(): return self
+        if not other.nonzero: return self
         self._set_metric(other.metric, other.coords)
         self.gam0r[:] += other.gam0r[:]
         self.gam0i[:] += other.gam0i[:]
@@ -1398,10 +1393,11 @@ class GGGCrossCorrelation(BinnedCorr3):
         self.g3g1g2.finalize(varg3,varg1,varg2)
         self.g3g2g1.finalize(varg3,varg2,varg1)
 
-    def nonempty(self):
+    @property
+    def nonzero(self):
         """Return if there are any values accumulated yet.  (i.e. ntri > 0)
         """
-        return any([ggg.nonempty() for ggg in self._all])
+        return any([ggg.nonzero for ggg in self._all])
 
     def _clear(self):
         """Clear the data vectors

--- a/treecorr/kkkcorrelation.py
+++ b/treecorr/kkkcorrelation.py
@@ -371,11 +371,6 @@ class KKKCorrelation(BinnedCorr3):
         self.cov = self.estimate_cov(self.var_method)
         self.varzeta.ravel()[:] = self.cov.diagonal()
 
-    def nonempty(self):
-        """Return if there are any values accumulated yet.  (i.e. ntri > 0)
-        """
-        return np.sum(self.ntri) > 0
-
     def _clear(self):
         """Clear the data vectors
         """
@@ -413,7 +408,7 @@ class KKKCorrelation(BinnedCorr3):
                 self.max_v == other.max_v):
             raise ValueError("KKKCorrelation to be added is not compatible with this one.")
 
-        if not other.nonempty(): return self
+        if not other.nonzero: return self
         self._set_metric(other.metric, other.coords)
         self.zeta[:] += other.zeta[:]
         self.meand1[:] += other.meand1[:]
@@ -911,10 +906,11 @@ class KKKCrossCorrelation(BinnedCorr3):
         self.k3k1k2.finalize(vark3,vark1,vark2)
         self.k3k2k1.finalize(vark3,vark2,vark1)
 
-    def nonempty(self):
+    @property
+    def nonzero(self):
         """Return if there are any values accumulated yet.  (i.e. ntri > 0)
         """
-        return any([kkk.nonempty() for kkk in self._all])
+        return any([kkk.nonzero for kkk in self._all])
 
     def _clear(self):
         """Clear the data vectors


### PR DESCRIPTION
@joezuntz ran into a couple cases where things fail catastrophically when doing patch-based calculations.

1. If only one patch has any data in it for one of the catalogs being correlated.  This kind of a fundamental problem for jackknife, but now it gracefully gives a warning and does the best it can for the case where that patch is left out.
2. If all the counts in a run are zero.  Then things like jackknife should just give zero for the variance estimate, rather than an error, which is what used to happen.

Both of these would normally only be the result of user error, but now they at least don't crash, and instead do something sensible.