### PR TITLE
Fix a bug when running with Rlens metric using patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     pull_request:
         branches:
             - main
+            - releases/*
 
 jobs:
     build:

--- a/include/BinnedCorr2.h
+++ b/include/BinnedCorr2.h
@@ -84,6 +84,8 @@ public:
                 _maxrpar != std::numeric_limits<double>::max());
     }
 
+    template <int M, int C>
+    bool triviallyZero(Position<C> p1, Position<C> p2, double s1, double s2);
 
 protected:
 

--- a/include/BinnedCorr2.h
+++ b/include/BinnedCorr2.h
@@ -67,10 +67,10 @@ public:
     void operator+=(const BinnedCorr2<D1,D2,B>& rhs);
 
     // Sample a random subset of pairs in a given range
-    template <int C, int M, int P>
+    template <int M, int P, int C>
     long samplePairs(const Field<D1, C>& field1, const Field<D2, C>& field2,
                      double min_sep, double max_sep, long* i1, long* i2, double* sep, int n);
-    template <int C, int M, int P>
+    template <int M, int P, int C>
     void samplePairs(const Cell<D1, C>& c1, const Cell<D2, C>& c2, const MetricHelper<M,P>& m,
                      double min_sep, double min_sepsq, double max_sep, double max_sepsq,
                      long* i1, long* i2, double* sep, int n, long& k);

--- a/include/BinnedCorr2_C.h
+++ b/include/BinnedCorr2_C.h
@@ -35,3 +35,7 @@ extern int GetOMPThreads();
 extern long SamplePairs(void* corr, void* field1, void* field2, double min_sep, double max_sep,
                         int d1, int d2, int coords, int bin_type, int metric,
                         long* i1, long* i2, double* sep, int n);
+
+extern int TriviallyZero(void* corr, int d1, int d2, int bin_type, int metric, int coords,
+                         double x1, double y1, double z1, double s1,
+                         double x2, double y2, double z2, double s2);

--- a/src/BinnedCorr2.cpp
+++ b/src/BinnedCorr2.cpp
@@ -606,7 +606,7 @@ void BinnedCorr2<D1,D2,B>::operator+=(const BinnedCorr2<D1,D2,B>& rhs)
     for (int i=0; i<_nbins; ++i) _npairs[i] += rhs._npairs[i];
 }
 
-template <int D1, int D2, int B> template <int C, int M, int P>
+template <int D1, int D2, int B> template <int M, int P, int C>
 long BinnedCorr2<D1,D2,B>::samplePairs(
     const Field<D1, C>& field1, const Field<D2, C>& field2,
     double minsep, double maxsep, long* i1, long* i2, double* sep, int n)
@@ -636,7 +636,7 @@ long BinnedCorr2<D1,D2,B>::samplePairs(
     return k;
 }
 
-template <int D1, int D2, int B> template <int C, int M, int P>
+template <int D1, int D2, int B> template <int M, int P, int C>
 void BinnedCorr2<D1,D2,B>::samplePairs(
     const Cell<D1, C>& c1, const Cell<D2, C>& c2, const MetricHelper<M,P>& metric,
     double minsep, double minsepsq, double maxsep, double maxsepsq,
@@ -704,29 +704,29 @@ void BinnedCorr2<D1,D2,B>::samplePairs(
             Assert(c1.getRight());
             Assert(c2.getLeft());
             Assert(c2.getRight());
-            samplePairs<C,M,P>(*c1.getLeft(), *c2.getLeft(), metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
-            samplePairs<C,M,P>(*c1.getLeft(), *c2.getRight(), metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
-            samplePairs<C,M,P>(*c1.getRight(), *c2.getLeft(), metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
-            samplePairs<C,M,P>(*c1.getRight(), *c2.getRight(), metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(*c1.getLeft(), *c2.getLeft(), metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(*c1.getLeft(), *c2.getRight(), metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(*c1.getRight(), *c2.getLeft(), metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(*c1.getRight(), *c2.getRight(), metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
         } else if (split1) {
             Assert(c1.getLeft());
             Assert(c1.getRight());
-            samplePairs<C,M,P>(*c1.getLeft(), c2, metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
-            samplePairs<C,M,P>(*c1.getRight(), c2, metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(*c1.getLeft(), c2, metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(*c1.getRight(), c2, metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
         } else {
             Assert(split2);
             Assert(c2.getLeft());
             Assert(c2.getRight());
-            samplePairs<C,M,P>(c1, *c2.getLeft(), metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
-            samplePairs<C,M,P>(c1, *c2.getRight(), metric,
-                               minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(c1, *c2.getLeft(), metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
+            samplePairs(c1, *c2.getRight(), metric,
+                        minsep, minsepsq, maxsep, maxsepsq, i1, i2, sep, n, k);
         }
     }
 }
@@ -1514,7 +1514,7 @@ long SamplePairs2d(BinnedCorr2<D1,D2,B>* corr, void* field1, void* field2,
       case Flat:
            Assert((MetricHelper<M,0>::_Flat == int(Flat)));
            Assert(!P);
-           return corr->template samplePairs<MetricHelper<M,0>::_Flat, M, false>(
+           return corr->template samplePairs<M, false>(
                *static_cast<Field<D1,MetricHelper<M,0>::_Flat>*>(field1),
                *static_cast<Field<D2,MetricHelper<M,0>::_Flat>*>(field2),
                minsep, maxsep, i1, i2, sep, n);
@@ -1522,7 +1522,7 @@ long SamplePairs2d(BinnedCorr2<D1,D2,B>* corr, void* field1, void* field2,
       case Sphere:
            Assert((MetricHelper<M,0>::_Sphere == int(Sphere)));
            Assert(!P);
-           return corr->template samplePairs<MetricHelper<M,0>::_Sphere, M, false>(
+           return corr->template samplePairs<M, false>(
                *static_cast<Field<D1,MetricHelper<M,0>::_Sphere>*>(field1),
                *static_cast<Field<D2,MetricHelper<M,0>::_Sphere>*>(field2),
                minsep, maxsep, i1, i2, sep, n);
@@ -1530,12 +1530,12 @@ long SamplePairs2d(BinnedCorr2<D1,D2,B>* corr, void* field1, void* field2,
       case ThreeD:
            Assert((MetricHelper<M,0>::_ThreeD == int(ThreeD)));
            if (P)
-               return corr->template samplePairs<MetricHelper<M,1>::_ThreeD, M, true>(
+               return corr->template samplePairs<M, true>(
                    *static_cast<Field<D1,MetricHelper<M,1>::_ThreeD>*>(field1),
                    *static_cast<Field<D2,MetricHelper<M,1>::_ThreeD>*>(field2),
                    minsep, maxsep, i1, i2, sep, n);
            else
-               return corr->template samplePairs<MetricHelper<M,0>::_ThreeD, M, false>(
+               return corr->template samplePairs<M, false>(
                    *static_cast<Field<D1,MetricHelper<M,0>::_ThreeD>*>(field1),
                    *static_cast<Field<D2,MetricHelper<M,0>::_ThreeD>*>(field2),
                    minsep, maxsep, i1, i2, sep, n);

--- a/tests/test_rperp.py
+++ b/tests/test_rperp.py
@@ -214,6 +214,79 @@ def test_nn_direct_rlens():
 
 
 @timer
+def test_nk_patch_rlens():
+    # This is based on a bug report by Marina Ricci that Rlens with patches failed when
+    # one catalog used ra, dec, r, and the other used just ra, dec.
+
+    ngal = 200
+    s = 10.
+    rng = np.random.RandomState(8675309)
+    x1 = rng.normal(312, s, (ngal,) )
+    y1 = rng.normal(728, s, (ngal,) )
+    z1 = rng.normal(-932, s, (ngal,) )
+    r1 = np.sqrt( x1*x1 + y1*y1 + z1*z1 )
+    dec1 = np.arcsin(z1/r1)
+    ra1 = np.arctan2(y1,x1)
+    cat1 = treecorr.Catalog(ra=ra1, dec=dec1, r=r1, ra_units='rad', dec_units='rad')
+
+    x2 = rng.normal(312, s, (ngal,) )
+    y2 = rng.normal(728, s, (ngal,) )
+    z2 = rng.normal(-932, s, (ngal,) )
+    r2 = np.sqrt( x2*x2 + y2*y2 + z2*z2 )
+    k2 = rng.uniform(0.98, 1.03, (ngal,) )
+    dec2 = np.arcsin(z2/r2)
+    ra2 = np.arctan2(y2,x2)
+    cat2 = treecorr.Catalog(ra=ra2, dec=dec2, k=k2, ra_units='rad', dec_units='rad')
+
+    min_sep = 1.
+    max_sep = 50.
+    nbins = 50
+    nk = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, brute=True)
+    nk.process(cat1, cat2, metric='Rlens')
+    print('nk.npairs = ',nk.npairs)
+
+    log_min_sep = np.log(min_sep)
+    log_max_sep = np.log(max_sep)
+    true_npairs = np.zeros(nbins)
+    true_kappa = np.zeros(nbins)
+    bin_size = (log_max_sep - log_min_sep) / nbins
+    for i in range(ngal):
+        for j in range(ngal):
+            # L = |r1| sin(theta)
+            #   = |r1 x r2| / |r2|
+            xcross = y1[i] * z2[j] - z1[i] * y2[j]
+            ycross = z1[i] * x2[j] - x1[i] * z2[j]
+            zcross = x1[i] * y2[j] - y1[i] * x2[j]
+            Rlens = np.sqrt(xcross**2 + ycross**2 + zcross**2) / r2[j]
+            logr = np.log(Rlens)
+            k = int(np.floor( (logr-log_min_sep) / bin_size ))
+            if k < 0: continue
+            if k >= nbins: continue
+            true_npairs[k] += 1
+            true_kappa[k] += k2[j]
+    true_kappa /= true_npairs
+
+    print('true_npairs = ',true_npairs)
+    print('diff = ',nk.npairs - true_npairs)
+    np.testing.assert_array_equal(nk.npairs, true_npairs)
+    print('nk.xi = ',nk.xi)
+    print('true_kappa = ',true_kappa)
+    print('diff = ',nk.xi - true_kappa)
+    np.testing.assert_allclose(nk.xi, true_kappa)
+
+    # This version failed on v4.2.3.
+    cat1p = treecorr.Catalog(ra=ra1, dec=dec1, r=r1, ra_units='rad', dec_units='rad', npatch=4)
+    cat2p = treecorr.Catalog(ra=ra2, dec=dec2, k=k2, ra_units='rad', dec_units='rad',
+                             patch_centers=cat1p.patch_centers)
+    nk2 = treecorr.NKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0)
+    nk2.process(cat1p, cat2p, metric='Rlens')
+    print('nk2.npairs = ',nk2.npairs)
+    print('nk2.xi = ',nk2.xi)
+    np.testing.assert_array_equal(nk2.npairs, true_npairs)
+    np.testing.assert_allclose(nk2.xi, true_kappa)
+
+
+@timer
 def test_rperp_minmax():
     """This test is based on a bug report from Erika Wagoner where the lowest bins were
     getting spuriously high w(rp) values.  It stemmed from a subtlety about how large

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -589,8 +589,9 @@ class BinnedCorr2(object):
         # For now, ignore the metric.  Just be conservative about how much space we need.
         x1,y1,z1,s1 = c1._get_center_size()
         x2,y2,z2,s2 = c2._get_center_size()
-        d = ((x1-x2)**2 + (y1-y2)**2 + (z1-z2)**2)**0.5
-        return (d > s1 + s2 + 2*self._max_sep)  # The 2* is where we are being conservative.
+        return _lib.TriviallyZero(self.corr, self._d1, self._d2, self._bintype,
+                                  self._metric, self._coords,
+                                  x1, y1, z1, s1, x2, y2, z2, s2)
 
     def _process_all_auto(self, cat1, metric, num_threads, comm, low_mem):
 
@@ -651,6 +652,7 @@ class BinnedCorr2(object):
             else:
                 my_indices = None
 
+            self._set_metric(metric, cat1[0].coords)
             temp = self.copy()
             temp.results = {}  # Don't mess up the original results
             for ii,c1 in enumerate(cat1):
@@ -757,6 +759,7 @@ class BinnedCorr2(object):
             else:
                 my_indices = None
 
+            self._set_metric(metric, cat1[0].coords, cat2[0].coords)
             temp = self.copy()
             temp.results = {}  # Don't mess up the original results
             for ii,c1 in enumerate(cat1):

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -376,7 +376,7 @@ class GGCorrelation(BinnedCorr2):
                 self.max_sep == other.max_sep):
             raise ValueError("GGCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords)
         self.xip.ravel()[:] += other.xip.ravel()[:]
         self.xim.ravel()[:] += other.xim.ravel()[:]
         self.xip_im.ravel()[:] += other.xip_im.ravel()[:]

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -505,7 +505,7 @@ class GGGCorrelation(BinnedCorr3):
             raise ValueError("GGGCorrelation to be added is not compatible with this one.")
 
         if not other.nonzero: return self
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords, other.coords)
         self.gam0r[:] += other.gam0r[:]
         self.gam0i[:] += other.gam0i[:]
         self.gam1r[:] += other.gam1r[:]

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -317,7 +317,7 @@ class KGCorrelation(BinnedCorr2):
                 self.max_sep == other.max_sep):
             raise ValueError("KGCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords)
         self.xi.ravel()[:] += other.xi.ravel()[:]
         self.xi_im.ravel()[:] += other.xi_im.ravel()[:]
         self.meanr.ravel()[:] += other.meanr.ravel()[:]

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -345,7 +345,7 @@ class KKCorrelation(BinnedCorr2):
                 self.max_sep == other.max_sep):
             raise ValueError("KKCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords)
         self.xi.ravel()[:] += other.xi.ravel()[:]
         self.meanr.ravel()[:] += other.meanr.ravel()[:]
         self.meanlogr.ravel()[:] += other.meanlogr.ravel()[:]

--- a/treecorr/kkkcorrelation.py
+++ b/treecorr/kkkcorrelation.py
@@ -409,7 +409,7 @@ class KKKCorrelation(BinnedCorr3):
             raise ValueError("KKKCorrelation to be added is not compatible with this one.")
 
         if not other.nonzero: return self
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords, other.coords)
         self.zeta[:] += other.zeta[:]
         self.meand1[:] += other.meand1[:]
         self.meanlogd1[:] += other.meanlogd1[:]

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -336,7 +336,7 @@ class NGCorrelation(BinnedCorr2):
                 self.max_sep == other.max_sep):
             raise ValueError("NGCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords)
         self.raw_xi.ravel()[:] += other.raw_xi.ravel()[:]
         self.raw_xi_im.ravel()[:] += other.raw_xi_im.ravel()[:]
         self.meanr.ravel()[:] += other.meanr.ravel()[:]

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -328,7 +328,7 @@ class NKCorrelation(BinnedCorr2):
                 self.max_sep == other.max_sep):
             raise ValueError("NKCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords)
         self.raw_xi.ravel()[:] += other.raw_xi.ravel()[:]
         self.meanr.ravel()[:] += other.meanr.ravel()[:]
         self.meanlogr.ravel()[:] += other.meanlogr.ravel()[:]

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -364,7 +364,7 @@ class NNCorrelation(BinnedCorr2):
                 self.max_sep == other.max_sep):
             raise ValueError("NNCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords)
         self.meanr.ravel()[:] += other.meanr.ravel()[:]
         self.meanlogr.ravel()[:] += other.meanlogr.ravel()[:]
         self.weight.ravel()[:] += other.weight.ravel()[:]

--- a/treecorr/nnncorrelation.py
+++ b/treecorr/nnncorrelation.py
@@ -467,7 +467,7 @@ class NNNCorrelation(BinnedCorr3):
                 self.max_v == other.max_v):
             raise ValueError("NNNCorrelation to be added is not compatible with this one.")
 
-        self._set_metric(other.metric, other.coords)
+        self._set_metric(other.metric, other.coords, other.coords, other.coords)
         self.tot += other.tot
 
         # If other is empty, then we're done now.


### PR DESCRIPTION
@marina_ricci ran into a bug when using the Rlens metric with patches when one of the catalogs used distances and the other one didn't (i.e. just ra, dec, which is allowed for Rlens).

It turns out there was an error in some of the logic about how the metric is checked, so I fixed that.  

But then when writing the unit test to confirm the fix, I also discovered another issue with this use case where it would erroneously think patch pairs had no overlap because the one with only ra, dec are placed on the unit sphere, and that was considered too far away from the objects in the other catalog to have any overlap.  So I fixed that error too.

Anyway, I think this use case should now work correctly.  But Marina, please do let me know if you run into any more problems, as this use case apparently has some subtleties that don't apply to most uses, so it's possible I've still overlooked something.