### PR TITLE
Parallel estimation of covariance matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
             - name: Run unit tests
               run: |
                 cd tests
-                nosetests --with-coverage --cover-package=treecorr
+                nosetests --with-coverage --cover-package=treecorr -v
                 cd ..  # N.B. This seems to happen automatically if omitted.
                        # Less confusing to include it explicitly.
 

--- a/tests/mpi_test.py
+++ b/tests/mpi_test.py
@@ -197,6 +197,7 @@ def do_mpi_kk(comm, output=True):
 
 
 def do_mpi_cov(comm, method):
+    # Test covariance estimation under MPI
     from test_patch import generate_shear_field
     nside = 200
     npatch = 16

--- a/tests/mpi_test.py
+++ b/tests/mpi_test.py
@@ -195,6 +195,84 @@ def do_mpi_kg(comm, output=True):
 def do_mpi_kk(comm, output=True):
     do_mpi_corr(comm, treecorr.KKCorrelation, True, ['xi', 'npairs'], output)
 
+
+def do_mpi_cov(comm):
+    os.environ['TREECORR_MOCK_MPI_MODE'] = "1"
+    from test_patch import generate_shear_field
+    nside = 200
+    npatch = 16
+    tol_factor = 8
+
+    # Generate a random catalog to use. Because all the processes
+    # have the same random seed they will get the same catalogs,
+    # so everything should work.
+    rng = np.random.RandomState(1234)
+    x, y, g1, g2, _ = generate_shear_field(nside, rng)
+    cat = treecorr.Catalog(x=x, y=y, g1=g1, g2=g2, npatch=npatch)
+    xr, yr, _, _, _ = generate_shear_field(nside, rng)
+    ran_cat = treecorr.Catalog(x=x, y=y, npatch=npatch)
+
+    # Generate the three sets of correlations we will use
+    gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    rr = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    gg.process(cat, comm=comm)
+    ng.process(cat, cat, comm=comm)
+    nn.process(cat, comm=comm)
+    rr.process(ran_cat, comm=comm)
+
+    # Only the root process gets the complete version
+    # when you call the above with comm
+    gg = comm.bcast(gg)
+    ng = comm.bcast(ng)
+    nn = comm.bcast(nn)
+    rr = comm.bcast(rr)
+
+
+    ng.calculateXi()
+    nn.calculateXi(rr=rr)
+
+
+    corrs = [gg, ng, nn]
+
+    # Get the baseline single process covariance
+    if comm.rank == 0:
+        cov1 = treecorr.estimate_multi_cov(corrs, 'jackknife')
+    else:
+        cov1 = None
+    cov1 = comm.bcast(cov1)
+
+    print("\nCOV 1 \n", cov1[0:3,0:3], " for ", comm.rank)
+
+    gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    rr = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    gg.process(cat, comm=comm)
+    ng.process(cat, cat, comm=comm)
+    nn.process(cat, comm=comm)
+    rr.process(ran_cat, comm=comm)
+    # Only the root process gets the complete version
+    # when you call the above with comm
+    gg = comm.bcast(gg)
+    ng = comm.bcast(ng)
+    nn = comm.bcast(nn)
+    rr = comm.bcast(rr)
+
+    ng.calculateXi()
+    nn.calculateXi(rr=rr)
+    corrs = [gg, ng, nn]
+
+    # Compare to the SMP covariance
+    cov2 = treecorr.estimate_multi_cov(corrs, 'jackknife', comm=comm)
+    print("\nCOV 2\n", cov2[0:3,0:3], " for ", comm.rank, "\n")
+
+    np.testing.assert_allclose(cov1, cov2)
+
+
+
+
 if __name__ == '__main__':
     from mpi4py import MPI
     from mpi_helper import NiceComm
@@ -209,3 +287,4 @@ if __name__ == '__main__':
     do_mpi_nn(comm)
     do_mpi_kg(comm)
     do_mpi_kk(comm)
+    do_mpi_cov(comm)

--- a/tests/mpi_test.py
+++ b/tests/mpi_test.py
@@ -202,7 +202,7 @@ def do_mpi_cov(comm, method):
     npatch = 16
 
     if "bootstrap" in method:
-        tol = 1.0e-5
+        tol = 2.0e-5
     else:
         tol = 1.0e-8
 
@@ -290,4 +290,7 @@ if __name__ == '__main__':
     do_mpi_nn(comm)
     do_mpi_kg(comm)
     do_mpi_kk(comm)
-    do_mpi_cov(comm)
+    do_mpi_cov(comm, "jackknife")
+    do_mpi_cov(comm, "bootstrap")
+    do_mpi_cov(comm, "marked_bootstrap")
+    do_mpi_cov(comm, "sample")

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -17,7 +17,7 @@ import sys
 from mockmpi import mock_mpiexec
 
 from test_helper import timer
-from mpi_test import setup, do_mpi_gg, do_mpi_ng, do_mpi_nk, do_mpi_nn, do_mpi_kk, do_mpi_kg
+from mpi_test import setup, do_mpi_gg, do_mpi_ng, do_mpi_nk, do_mpi_nn, do_mpi_kk, do_mpi_kg, do_mpi_cov
 
 @timer
 def test_mpi_gg():
@@ -54,6 +54,14 @@ def test_mpi_kk():
     output = __name__ == '__main__'
     mock_mpiexec(4, do_mpi_kk, output)
     mock_mpiexec(1, do_mpi_kk, output)
+
+
+@unittest.skipIf(sys.version_info < (3, 0), "mock_mpiexec doesn't support python 2")
+@timer
+def test_mpi_cov():
+    mock_mpiexec(1, do_mpi_cov)
+    mock_mpiexec(2, do_mpi_cov)
+
 
 if __name__ == '__main__':
     setup()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -58,9 +58,31 @@ def test_mpi_kk():
 
 @unittest.skipIf(sys.version_info < (3, 0), "mock_mpiexec doesn't support python 2")
 @timer
-def test_mpi_cov():
-    mock_mpiexec(1, do_mpi_cov)
-    mock_mpiexec(2, do_mpi_cov)
+def test_mpi_cov_jackknife():
+    mock_mpiexec(1, do_mpi_cov, "jackknife")
+    mock_mpiexec(2, do_mpi_cov, "jackknife")
+    mock_mpiexec(4, do_mpi_cov, "jackknife")
+
+@unittest.skipIf(sys.version_info < (3, 0), "mock_mpiexec doesn't support python 2")
+@timer
+def test_mpi_cov_bootstrap():
+    mock_mpiexec(1, do_mpi_cov, "bootstrap")
+    mock_mpiexec(2, do_mpi_cov, "bootstrap")
+    mock_mpiexec(4, do_mpi_cov, "bootstrap")
+
+@unittest.skipIf(sys.version_info < (3, 0), "mock_mpiexec doesn't support python 2")
+@timer
+def test_mpi_cov_marked_bootstrap():
+    mock_mpiexec(1, do_mpi_cov, "marked_bootstrap")
+    mock_mpiexec(2, do_mpi_cov, "marked_bootstrap")
+    mock_mpiexec(4, do_mpi_cov, "marked_bootstrap")
+
+@unittest.skipIf(sys.version_info < (3, 0), "mock_mpiexec doesn't support python 2")
+@timer
+def test_mpi_cov_sample():
+    mock_mpiexec(1, do_mpi_cov, "sample")
+    mock_mpiexec(2, do_mpi_cov, "sample")
+    mock_mpiexec(4, do_mpi_cov, "sample")
 
 
 if __name__ == '__main__':

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -18,7 +18,7 @@ import coord
 import time
 import fitsio
 import treecorr
-
+import multiprocessing
 from test_helper import assert_raises, do_pickle, timer, get_from_wiki, CaptureLog, clear_save
 
 @timer

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2939,9 +2939,6 @@ def test_huge_npatch():
     print('Time to calculate marked_bootstrap covariance = ',t1-t0)
     print('varxi = ',cov.diagonal())
 
-def test_bad_multicov_name():
-    with assert_raises(ValueError):
-        treecorr.binnedcorr2._make_cov_design_matrix_core([], 0, None, "fake name")
 
 if __name__ == '__main__':
     test_cat_patches()

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2942,6 +2942,7 @@ def test_huge_npatch():
 
 
 def smp_cov_core(method):
+    print("Running test of", method, "with SMP")
     # Test covariance estimation under multiprocessing
     nside = 200
     npatch = 16
@@ -2963,6 +2964,7 @@ def smp_cov_core(method):
     ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
     nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
     rr = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    print("Processing catalogs")
     gg.process(cat)
     ng.process(cat, cat)
     nn.process(cat)
@@ -2972,6 +2974,7 @@ def smp_cov_core(method):
     corrs = [gg, ng, nn]
 
     # Get the baseline single process covariance
+    print("Running single-process cov")
     cov1 = treecorr.estimate_multi_cov(corrs, method)
     print("\nCOV 1\n", cov1[0:3,0:3])
 
@@ -2979,6 +2982,7 @@ def smp_cov_core(method):
     ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
     nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
     rr = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    print("Processing catalogs again")
     gg.process(cat)
     ng.process(cat, cat)
     nn.process(cat)
@@ -2988,6 +2992,7 @@ def smp_cov_core(method):
     corrs = [gg, ng, nn]
 
 
+    print("Running 2-core cov")
     cov2 = treecorr.estimate_multi_cov(corrs, method, smp=2)
     print("\nCOV 2\n", cov2[0:3,0:3])
     np.testing.assert_allclose(cov1.diagonal(), cov2.diagonal(), atol=tol)
@@ -2998,6 +3003,7 @@ def smp_cov_core(method):
     ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
     nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
     rr = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    print("Processing catalogs yet again")
     gg.process(cat)
     ng.process(cat, cat)
     nn.process(cat)
@@ -3007,6 +3013,7 @@ def smp_cov_core(method):
     corrs = [gg, ng, nn]
 
     # Test with six processes
+    print("Running 3-core cov")
     cov3 = treecorr.estimate_multi_cov(corrs, method, smp=6)
     print("\nCOV 3\n", cov3[0:3,0:3])
     np.testing.assert_allclose(cov1.diagonal(), cov3.diagonal(), atol=tol)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2942,6 +2942,7 @@ def test_huge_npatch():
 
 
 def smp_cov_core(method):
+    # Test covariance estimation under multiprocessing
     nside = 200
     npatch = 16
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -3012,9 +3012,9 @@ def smp_cov_core(method):
     nn.calculateXi(rr=rr)
     corrs = [gg, ng, nn]
 
-    # Test with six processes
+    # Test with three processes
     print("Running 3-core cov")
-    cov3 = treecorr.estimate_multi_cov(corrs, method, smp=6)
+    cov3 = treecorr.estimate_multi_cov(corrs, method, smp=3)
     print("\nCOV 3\n", cov3[0:3,0:3])
     np.testing.assert_allclose(cov1.diagonal(), cov3.diagonal(), atol=tol)
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2939,6 +2939,9 @@ def test_huge_npatch():
     print('Time to calculate marked_bootstrap covariance = ',t1-t0)
     print('varxi = ',cov.diagonal())
 
+def test_bad_multicov_name():
+    with assert_raises(ValueError):
+        treecorr.binnedcorr2._make_cov_design_matrix_core([], 0, None, "fake name")
 
 if __name__ == '__main__':
     test_cat_patches()

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -2941,12 +2941,12 @@ def test_huge_npatch():
     print('varxi = ',cov.diagonal())
 
 
-def core_test_smp_cov(method):
+def smp_cov_core(method):
     nside = 200
     npatch = 16
 
     if "bootstrap" in method:
-        tol = 1.0e-5
+        tol = 2.0e-5
     else:
         tol = 1.0e-8
 
@@ -3012,19 +3012,19 @@ def core_test_smp_cov(method):
 
 @timer
 def test_smp_jackknife():
-    core_test_smp_cov("jackknife")
+    smp_cov_core("jackknife")
 
 @timer
 def test_smp_bootstrap():
-    core_test_smp_cov("bootstrap")
+    smp_cov_core("bootstrap")
 
 @timer
 def test_smp_marked_bootstrap():
-    core_test_smp_cov("marked_bootstrap")
+    smp_cov_core("marked_bootstrap")
 
 @timer
 def test_smp_sample():
-    core_test_smp_cov("sample")
+    smp_cov_core("sample")
 
 
 if __name__ == '__main__':

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -20,6 +20,7 @@ import numpy as np
 import sys
 import coord
 import itertools
+import multiprocessing
 
 from . import _lib
 from .config import merge_config, setup_logger, get
@@ -1380,7 +1381,6 @@ def _make_cov_design_matrix(corrs, npatch, func, name, smp=None, comm=None):
     # The SMP version. In this one we create a pool and make a different matrix
     # on each process, and then sum them together
     elif smp is not None:
-        import multiprocessing
         with multiprocessing.Pool(smp) as pool:
             tasks = [(corrs, npatch, func, name, rank, smp) for rank in range(smp)]
             results = pool.starmap(_make_cov_design_matrix_core, tasks)

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -1334,8 +1334,8 @@ def _make_cov_design_matrix_core(corrs, npatch, func, name, rank=0, size=1):
             indx = corrs[0].rng.randint(npatch, size=npatch)
             vpairs = [c._bootstrap_pairs(indx) for c in corrs]
             plist.append(vpairs)
-    else:
-        assert False, "Invalid name %s in _make_cov_design_matrix_core" % name # pragma: no cover
+    else: # pragma: no cover
+        assert False, "Invalid name %s in _make_cov_design_matrix_core" % name 
 
     # Figure out the shape of the design matrix.
     v1 = func(corrs)

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -1312,7 +1312,7 @@ def _make_cov_design_matrix_core(corrs, npatch, func, name, rank=0, size=1):
         func = lambda corrs: np.concatenate([c.getStat() for c in corrs])
 
     # We also can't send generators using SMP or MPI, so instead we need
-    # to create them here. 
+    # to create them here.
     if name == "jackknife":
         plist = [c._jackknife_pairs() for c in corrs]
         # Swap order of plist.  Right now it's a list for each corr of a list for each row.


### PR DESCRIPTION
For the CosmoDC2 analysis estimate_multi_cov was taking two hours, being single threaded.

This adds two options for parallel calculations, SMP or MPI. The user can pass in either a number of processes or a communicator.  The difference processes each generate different rows of the design matrix, and the total is then summed together.

This involves moving the pair generation inside the design matrix calculation, because the generators can't be pickled.

In the associated tests the tolerances for the bootstrap calculation have to be low because there is a random component to the test. There doesn't seem to be a way to reset the RNG to produce the same indices for different processes, at least in the SMP case.