### PR TITLE
Handle None as defaults in configs and kwargs

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -213,6 +213,12 @@ def test_ascii():
     np.testing.assert_almost_equal(cat5.x, x * (pi/180.))
     np.testing.assert_almost_equal(cat5.y, y * (pi/180.))
 
+    config['x_units'] = None  # Default is radians
+    config['y_units'] = None  # Default is radians
+    cat5 = treecorr.Catalog(file_name, config)
+    np.testing.assert_almost_equal(cat5.x, x)
+    np.testing.assert_almost_equal(cat5.y, y)
+
     del config['x_units']  # Default is radians
     del config['y_units']
     cat5 = treecorr.Catalog(file_name, config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -444,9 +444,10 @@ def test_merge():
     kwargs = {'bin_size': 0.06, 'nbins': None}
     config2 = treecorr.config.merge_config(config1, kwargs, treecorr.BinnedCorr2._valid_params)
     assert config2['bin_size'] == 0.06
-    assert config2['nbins'] == config1['nbins']
-    assert kwargs['nbins'] == config2['nbins']
+    assert config2['min_sep'] == config1['min_sep']
+    assert config2['max_sep'] == config1['max_sep']
     assert kwargs['nbins'] is None
+    assert config2['nbins'] is None
 
     # If kwargs has invalid parameters, exception is raised
     kwargs = { 'cat_prec' : 10 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -389,20 +389,25 @@ def test_get():
     assert treecorr.config.get_from_list(config1, 'ra_col', 1, int, 2) == 2
     assert treecorr.config.get_from_list(config1, 'ra_col', 1, int) is None
 
-    config1['flip_g1'] = [True, False]
+    config1['flip_g1'] = [True, False, None]
     assert treecorr.config.get_from_list(config1, 'flip_g1', 0, bool) is True
     assert treecorr.config.get_from_list(config1, 'flip_g1', 1, bool) is False
+    assert treecorr.config.get_from_list(config1, 'flip_g1', 2, bool) is None
     assert treecorr.config.get_from_list(config1, 'flip_g1', 0, bool, False) is True
+    assert treecorr.config.get_from_list(config1, 'flip_g1', 1, bool, True) is False
+    assert treecorr.config.get_from_list(config1, 'flip_g1', 2, bool, True) is True
+    assert treecorr.config.get_from_list(config1, 'flip_g1', 2, bool, False) is False
     assert treecorr.config.get_from_list(config1, 'flip_g2', 1, bool) is None
     assert treecorr.config.get_from_list(config1, 'flip_g2', 1, bool, False) is False
     assert treecorr.config.get_from_list(config1, 'flip_g2', 2, bool, False) is False
+    assert treecorr.config.get_from_list(config1, 'flip_g2', 3, bool, True) is True
 
     with assert_raises(IndexError):
         treecorr.config.get_from_list(config1, 'k_col', 2, int)
     with assert_raises(IndexError):
-        treecorr.config.get_from_list(config1, 'flip_g1', 2, bool)
+        treecorr.config.get_from_list(config1, 'flip_g1', 3, bool)
     with assert_raises(IndexError):
-        treecorr.config.get_from_list(config1, 'flip_g1', 2, bool, False)
+        treecorr.config.get_from_list(config1, 'flip_g1', 3, bool, False)
 
 
 @timer

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -374,6 +374,12 @@ def test_get():
     assert treecorr.config.get(config1, 'flip_g2', bool, False) is False
     assert treecorr.config.get(config1, 'flip_g2', bool) is None
 
+    config1['flip_g2'] = None
+    assert treecorr.config.get(config1, 'flip_g1', bool) is True
+    assert treecorr.config.get(config1, 'flip_g2', bool) is None
+    assert treecorr.config.get(config1, 'flip_g2', bool, True) is True
+    assert treecorr.config.get(config1, 'flip_g2', bool, False) is False
+
     assert treecorr.config.get_from_list(config1, 'k_col', 0, int) == 3
     assert treecorr.config.get_from_list(config1, 'k_col', 0, str) == '3'
     assert treecorr.config.get_from_list(config1, 'k_col', 0) == '3'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -440,14 +440,13 @@ def test_merge():
     config2 = treecorr.config.merge_config(config1, kwargs, treecorr.Catalog._valid_params)
     assert config2['ra_col'] == 'alpha2000'
 
-    # ... except when the value in kwargs is None.
+    # ... even when when the value in kwargs is None.
     kwargs = {'bin_size': 0.06, 'nbins': None}
     config2 = treecorr.config.merge_config(config1, kwargs, treecorr.BinnedCorr2._valid_params)
     assert config2['bin_size'] == 0.06
     assert config2['nbins'] == config1['nbins']
     assert kwargs['nbins'] == config2['nbins']
-    assert kwargs['nbins'] is not None
-    # Note: config2 is not in a valid state to be used to initialize BinnedCorr2.
+    assert kwargs['nbins'] is None
 
     # If kwargs has invalid parameters, exception is raised
     kwargs = { 'cat_prec' : 10 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -435,10 +435,19 @@ def test_merge():
         else:
             assert config2[key] == valid_params[key][2]
 
-    # If conflicts, kwargs takes precedence
+    # If conflicts, kwargs takes precedence ...
     kwargs['ra_col'] = 'alpha2000'
     config2 = treecorr.config.merge_config(config1, kwargs, treecorr.Catalog._valid_params)
     assert config2['ra_col'] == 'alpha2000'
+
+    # ... except when the value in kwargs is None.
+    kwargs = {'bin_size': 0.06, 'nbins': None}
+    config2 = treecorr.config.merge_config(config1, kwargs, treecorr.BinnedCorr2._valid_params)
+    assert config2['bin_size'] == 0.06
+    assert config2['nbins'] == config1['nbins']
+    assert kwargs['nbins'] == config2['nbins']
+    assert kwargs['nbins'] is not None
+    # Note: config2 is not in a valid state to be used to initialize BinnedCorr2.
 
     # If kwargs has invalid parameters, exception is raised
     kwargs = { 'cat_prec' : 10 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -447,6 +447,17 @@ def test_merge():
 
 
 @timer
+def test_convert():
+    """Test converting a value to a given type.
+    """
+    assert treecorr.config.convert('10', int, 'n_bins') == 10
+    assert treecorr.config.convert('yes', bool, 'flip_g1') is True
+    assert treecorr.config.convert('0.9', float, 'bin_slop') == 0.9
+    assert treecorr.config.convert(None, str, 'x_units') is None
+    assert np.isclose(treecorr.config.convert('deg', float, 'ra_units'), np.pi / 180.)
+
+
+@timer
 def test_omp():
     """Test setting the number of omp threads.
     """
@@ -874,6 +885,7 @@ if __name__ == '__main__':
     test_print()
     test_get()
     test_merge()
+    test_convert()
     test_omp()
     test_util()
     test_gen_read_write()

--- a/tests/test_gg.py
+++ b/tests/test_gg.py
@@ -435,6 +435,12 @@ def test_gg():
                                 verbose=1)
     gg.process(cat)
 
+    # Using nbins=None rather than omiting nbins is equivalent.
+    gg2 = treecorr.GGCorrelation(bin_size=0.1, min_sep=1., max_sep=100., nbins=None, sep_units='arcmin')
+    gg2.process(cat, num_threads=1)
+    gg.process(cat, num_threads=1)
+    assert gg2 == gg
+
     # log(<R>) != <logR>, but it should be close:
     print('meanlogr - log(meanr) = ',gg.meanlogr - np.log(gg.meanr))
     np.testing.assert_allclose(gg.meanlogr, np.log(gg.meanr), atol=1.e-3)

--- a/tests/test_ggg.py
+++ b/tests/test_ggg.py
@@ -1338,6 +1338,15 @@ def test_ggg():
                                   sep_units='arcmin', verbose=1)
     ggg.process(cat)
 
+    # Using bin_size=None rather than omiting bin_size is equivalent.
+    ggg2 = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_size=None,
+                                  min_u=min_u, max_u=max_u, min_v=min_v, max_v=max_v,
+                                  nubins=nubins, nvbins=nvbins,
+                                  sep_units='arcmin', verbose=1)
+    ggg2.process(cat, num_threads=1)
+    ggg.process(cat, num_threads=1)
+    assert ggg2 == ggg
+
     # log(<d>) != <logd>, but it should be close:
     print('meanlogd1 - log(meand1) = ',ggg.meanlogd1 - np.log(ggg.meand1))
     print('meanlogd2 - log(meand2) = ',ggg.meanlogd2 - np.log(ggg.meand2))

--- a/tests/test_kg.py
+++ b/tests/test_kg.py
@@ -495,6 +495,12 @@ def test_kg():
                                 verbose=1)
     kg.process(lens_cat, source_cat)
 
+    # Using nbins=None rather than omiting nbins is equivalent.
+    kg2 = treecorr.KGCorrelation(bin_size=0.1, min_sep=1., max_sep=20., nbins=None, sep_units='arcmin')
+    kg2.process(lens_cat, source_cat, num_threads=1)
+    kg.process(lens_cat, source_cat, num_threads=1)
+    assert kg2 == kg
+
     r = kg.meanr
     true_gt = gamma0 * np.exp(-0.5*r**2/r0**2)
 

--- a/tests/test_kk.py
+++ b/tests/test_kk.py
@@ -372,6 +372,13 @@ def test_kk():
                                 verbose=1)
     kk.process(cat)
 
+    # Using nbins=None rather than omiting nbins is equivalent.
+    kk2 = treecorr.KKCorrelation(bin_size=0.1, min_sep=1., max_sep=20., nbins=None,
+                                 sep_units='arcmin')
+    kk2.process(cat, num_threads=1)
+    kk.process(cat, num_threads=1)
+    assert kk2 == kk
+
     # log(<R>) != <logR>, but it should be close:
     print('meanlogr - log(meanr) = ',kk.meanlogr - np.log(kk.meanr))
     np.testing.assert_allclose(kk.meanlogr, np.log(kk.meanr), atol=1.e-3)

--- a/tests/test_kkk.py
+++ b/tests/test_kkk.py
@@ -1149,6 +1149,15 @@ def test_kkk():
                                   sep_units='arcmin', verbose=1)
     kkk.process(cat)
 
+    # Using bin_size=None rather than omiting bin_size is equivalent.
+    kkk2 = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_size=None,
+                                   min_u=min_u, max_u=max_u, min_v=min_v, max_v=max_v,
+                                   nubins=nubins, nvbins=nvbins,
+                                   sep_units='arcmin', verbose=1)
+    kkk2.process(cat, num_threads=1)
+    kkk.process(cat, num_threads=1)
+    assert kkk2 == kkk
+
     # log(<d>) != <logd>, but it should be close:
     print('meanlogd1 - log(meand1) = ',kkk.meanlogd1 - np.log(kkk.meand1))
     print('meanlogd2 - log(meand2) = ',kkk.meanlogd2 - np.log(kkk.meand2))

--- a/tests/test_ng.py
+++ b/tests/test_ng.py
@@ -656,6 +656,12 @@ def test_ng():
                                 verbose=1)
     ng.process(lens_cat, source_cat)
 
+    # Using nbins=None rather than omitting nbins is equivalent.
+    ng2 = treecorr.NGCorrelation(bin_size=0.1, min_sep=1., max_sep=20., nbins=None, sep_units='arcmin')
+    ng2.process(lens_cat, source_cat, num_threads=1)
+    ng.process(lens_cat, source_cat, num_threads=1)
+    assert ng2 == ng
+
     r = ng.meanr
     true_gt = gamma0 * np.exp(-0.5*r**2/r0**2)
 

--- a/tests/test_nk.py
+++ b/tests/test_nk.py
@@ -404,6 +404,12 @@ def test_nk():
                                 verbose=1)
     nk.process(lens_cat, source_cat)
 
+    # Using nbins=None rather than omitting nbins is equivalent.
+    nk2 = treecorr.NKCorrelation(bin_size=0.1, min_sep=1., max_sep=20., nbins=None, sep_units='arcmin')
+    nk2.process(lens_cat, source_cat, num_threads=1)
+    nk.process(lens_cat, source_cat, num_threads=1)
+    assert nk2 == nk
+
     # log(<R>) != <logR>, but it should be close:
     print('meanlogr - log(meanr) = ',nk.meanlogr - np.log(nk.meanr))
     np.testing.assert_allclose(nk.meanlogr, np.log(nk.meanr), atol=1.e-3)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1224,6 +1224,12 @@ def test_nn():
     dd.process(cat)
     print('dd.npairs = ',dd.npairs)
 
+    # Using nbins=None rather than omitting nbins is equivalent.
+    dd2 = treecorr.NNCorrelation(bin_size=0.1, min_sep=1., max_sep=25., nbins=None, sep_units='arcmin')
+    dd2.process(cat, num_threads=1)
+    dd.process(cat, num_threads=1)
+    assert dd2 == dd
+
     # log(<R>) != <logR>, but it should be close:
     print('meanlogr - log(meanr) = ',dd.meanlogr - np.log(dd.meanr))
     np.testing.assert_allclose(dd.meanlogr, np.log(dd.meanr), atol=1.e-3)

--- a/tests/test_nnn.py
+++ b/tests/test_nnn.py
@@ -2093,6 +2093,15 @@ def test_nnn():
     ddd.process(cat)
     #print('ddd.ntri = ',ddd.ntri)
 
+    # Using bin_size=None rather than omitting bin_size is equivalent.
+    ddd2 = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_size=None,
+                                   min_u=min_u, max_u=max_u, min_v=min_v, max_v=max_v,
+                                   nubins=nubins, nvbins=nvbins,
+                                   sep_units='arcmin', verbose=1)
+    ddd2.process(cat, num_threads=1)
+    ddd.process(cat, num_threads=1)
+    assert ddd2 == ddd
+
     # log(<d>) != <logd>, but it should be close:
     print('meanlogd1 - log(meand1) = ',ddd.meanlogd1 - np.log(ddd.meand1))
     print('meanlogd2 - log(meand2) = ',ddd.meanlogd2 - np.log(ddd.meand2))

--- a/treecorr/binnedcorr2.py
+++ b/treecorr/binnedcorr2.py
@@ -98,19 +98,21 @@ class BinnedCorr2(object):
     Keyword Arguments:
 
         nbins (int):        How many bins to use. (Exactly three of nbins, bin_size, min_sep,
-                            max_sep are required. If nbins is not given, it will be calculated from
-                            the values of the other three, rounding up to the next highest integer.
-                            In this case, bin_size will be readjusted to account for this rounding
-                            up.)
+                            max_sep are required. If nbins is not given or set to None, it will be
+                            calculated from the values of the other three, rounding up to the next
+                            highest integer. In this case, bin_size will be readjusted to account
+                            for this rounding up.)
         bin_size (float):   The width of the bins in log(separation). (Exactly three of nbins,
-                            bin_size, min_sep, max_sep are required.  If bin_size is not given, it
-                            will be calculated from the values of the other three.)
+                            bin_size, min_sep, max_sep are required.  If bin_size is not given or
+                            set to None, it will be calculated from the values of the other three.)
         min_sep (float):    The minimum separation in units of sep_units, if relevant. (Exactly
                             three of nbins, bin_size, min_sep, max_sep are required.  If min_sep is
-                            not given, it will be calculated from the values of the other three.)
+                            not given or set to None, it will be calculated from the values of the
+                            other three.)
         max_sep (float):    The maximum separation in units of sep_units, if relevant. (Exactly
                             three of nbins, bin_size, min_sep, max_sep are required.  If max_sep is
-                            not given, it will be calculated from the values of the other three.
+                            not given or set to None, it will be calculated from the values of the
+                            other three.)
 
         sep_units (str):    The units to use for the separation values, given as a string.  This
                             includes both min_sep and max_sep above, as well as the units of the
@@ -302,12 +304,12 @@ class BinnedCorr2(object):
         self._ro.sep_units = self.config.get('sep_units','')
         self._ro._sep_units = get(self.config,'sep_units',str,'radians')
         self._ro._log_sep_units = math.log(self._sep_units)
-        if 'nbins' not in self.config:
-            if 'max_sep' not in self.config:
+        if self.config.get('nbins', None) is None:
+            if self.config.get('max_sep', None) is None:
                 raise TypeError("Missing required parameter max_sep")
-            if 'min_sep' not in self.config and self.bin_type != 'TwoD':
+            if self.config.get('min_sep', None) is None and self.bin_type != 'TwoD':
                 raise TypeError("Missing required parameter min_sep")
-            if 'bin_size' not in self.config:
+            if self.config.get('bin_size', None) is None:
                 raise TypeError("Missing required parameter bin_size")
             self._ro.min_sep = float(self.config.get('min_sep',0))
             self._ro.max_sep = float(self.config['max_sep'])
@@ -315,10 +317,10 @@ class BinnedCorr2(object):
                 raise ValueError("max_sep must be larger than min_sep")
             self._ro.bin_size = float(self.config['bin_size'])
             self._ro.nbins = None
-        elif 'bin_size' not in self.config:
-            if 'max_sep' not in self.config:
+        elif self.config.get('bin_size', None) is None:
+            if self.config.get('max_sep', None) is None:
                 raise TypeError("Missing required parameter max_sep")
-            if 'min_sep' not in self.config and self.bin_type != 'TwoD':
+            if self.config.get('min_sep', None) is None and self.bin_type != 'TwoD':
                 raise TypeError("Missing required parameter min_sep")
             self._ro.min_sep = float(self.config.get('min_sep',0))
             self._ro.max_sep = float(self.config['max_sep'])
@@ -326,8 +328,8 @@ class BinnedCorr2(object):
                 raise ValueError("max_sep must be larger than min_sep")
             self._ro.nbins = int(self.config['nbins'])
             self._ro.bin_size = None
-        elif 'max_sep' not in self.config:
-            if 'min_sep' not in self.config and self.bin_type != 'TwoD':
+        elif self.config.get('max_sep', None) is None:
+            if self.config.get('min_sep', None) is None and self.bin_type != 'TwoD':
                 raise TypeError("Missing required parameter min_sep")
             self._ro.min_sep = float(self.config.get('min_sep',0))
             self._ro.nbins = int(self.config['nbins'])
@@ -337,7 +339,7 @@ class BinnedCorr2(object):
             if self.bin_type == 'TwoD':
                 raise TypeError("Only 2 of max_sep, bin_size, nbins are allowed "
                                 "for bin_type='TwoD'.")
-            if 'min_sep' in self.config:
+            if self.config.get('min_sep', None) is not None:
                 raise TypeError("Only 3 of min_sep, max_sep, bin_size, nbins are allowed.")
             self._ro.max_sep = float(self.config['max_sep'])
             self._ro.nbins = int(self.config['nbins'])

--- a/treecorr/binnedcorr3.py
+++ b/treecorr/binnedcorr3.py
@@ -97,19 +97,21 @@ class BinnedCorr3(object):
     Keyword Arguments:
 
         nbins (int):        How many bins to use. (Exactly three of nbins, bin_size, min_sep,
-                            max_sep are required. If nbins is not given, it will be calculated from
-                            the values of the other three, rounding up to the next highest integer.
-                            In this case, bin_size will be readjusted to account for this rounding
-                            up.)
+                            max_sep are required. If nbins is not given or set to None, it will be
+                            calculated from the values of the other three, rounding up to the next
+                            highest integer. In this case, bin_size will be readjusted to account
+                            for this rounding up.)
         bin_size (float):   The width of the bins in log(separation). (Exactly three of nbins,
-                            bin_size, min_sep, max_sep are required.  If bin_size is not given, it
-                            will be calculated from the values of the other three.)
+                            bin_size, min_sep, max_sep are required.  If bin_size is not given or
+                            set to None, it will be calculated from the values of the other three.)
         min_sep (float):    The minimum separation in units of sep_units, if relevant. (Exactly
                             three of nbins, bin_size, min_sep, max_sep are required.  If min_sep is
-                            not given, it will be calculated from the values of the other three.)
+                            not given or set to None, it will be calculated from the values of the
+                            other three.)
         max_sep (float):    The maximum separation in units of sep_units, if relevant. (Exactly
                             three of nbins, bin_size, min_sep, max_sep are required.  If max_sep is
-                            not given, it will be calculated from the values of the other three.
+                            not given or set to None, it will be calculated from the values of the
+                            other three.)
 
         sep_units (str):    The units to use for the separation values, given as a string.  This
                             includes both min_sep and max_sep above, as well as the units of the
@@ -315,12 +317,12 @@ class BinnedCorr3(object):
         self._ro.sep_units = self.config.get('sep_units','')
         self._ro._sep_units = get(self.config,'sep_units',str,'radians')
         self._ro._log_sep_units = math.log(self._sep_units)
-        if 'nbins' not in self.config:
-            if 'max_sep' not in self.config:
+        if self.config.get('nbins', None) is None:
+            if self.config.get('max_sep', None) is None:
                 raise TypeError("Missing required parameter max_sep")
-            if 'min_sep' not in self.config:
+            if self.config.get('min_sep', None) is None:
                 raise TypeError("Missing required parameter min_sep")
-            if 'bin_size' not in self.config:
+            if self.config.get('bin_size', None) is None:
                 raise TypeError("Missing required parameter bin_size")
             self._ro.min_sep = float(self.config['min_sep'])
             self._ro.max_sep = float(self.config['max_sep'])
@@ -333,10 +335,10 @@ class BinnedCorr3(object):
             # Note in this case, bin_size is saved as the nominal bin_size from the config
             # file, and self.bin_size is the one for the radial bins.  We'll use the nominal
             # bin_size as the default bin_size for u and v below.
-        elif 'bin_size' not in self.config:
-            if 'max_sep' not in self.config:
+        elif self.config.get('bin_size', None) is None:
+            if self.config.get('max_sep', None) is None:
                 raise TypeError("Missing required parameter max_sep")
-            if 'min_sep' not in self.config:
+            if self.config.get('min_sep', None) is None:
                 raise TypeError("Missing required parameter min_sep")
             self._ro.min_sep = float(self.config['min_sep'])
             self._ro.max_sep = float(self.config['max_sep'])
@@ -344,15 +346,15 @@ class BinnedCorr3(object):
                 raise ValueError("max_sep must be larger than min_sep")
             self._ro.nbins = int(self.config['nbins'])
             bin_size = self._ro.bin_size = math.log(self.max_sep/self.min_sep)/self.nbins
-        elif 'max_sep' not in self.config:
-            if 'min_sep' not in self.config:
+        elif self.config.get('max_sep', None) is None:
+            if self.config.get('min_sep', None) is None:
                 raise TypeError("Missing required parameter min_sep")
             self._ro.min_sep = float(self.config['min_sep'])
             self._ro.nbins = int(self.config['nbins'])
             bin_size = self._ro.bin_size = float(self.config['bin_size'])
             self._ro.max_sep = math.exp(self.nbins*bin_size)*self.min_sep
         else:
-            if 'min_sep' in self.config:
+            if self.config.get('min_sep', None) is not None:
                 raise TypeError("Only 3 of min_sep, max_sep, bin_size, nbins are allowed.")
             self._ro.max_sep = float(self.config['max_sep'])
             self._ro.nbins = int(self.config['nbins'])

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -259,9 +259,11 @@ def check_config(config, params, aliases=None, logger=None):
             value = [parse(v, value_type, key) for v in config[key] ]
         else:
             value = parse(config[key], value_type, key)
+            if value is None:
+                continue
 
         # If limited allowed value, check that this is one of them.
-        if valid_values is not None:
+        if valid_values is not None and value is not None:
             if value_type is str:
                 matches = [ v for v in valid_values if value == v ]
                 if len(matches) == 0:

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -333,12 +333,12 @@ def convert(value, value_type, key):
 
     :returns:           The converted value.
     """
-    if 'unit' in key:
+    if value is None:
+        return None
+    elif 'unit' in key:
         return parse_unit(value)
     elif value_type == bool:
         return parse_bool(value)
-    elif value is None:
-        return None
     else:
         return value_type(value)
 

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -379,18 +379,17 @@ def get(config, key, value_type=str, default=None):
     :param config:      The configuration dict from which to get the key value.
     :param key:         Which key to get from config.
     :param value_type:  Which type should the value be converted to. (default: str)
-    :param default:     What value should be used if the key is not in the config dict.
+    :param default:     What value should be used if the key is not in the config dict,
+                        or the value corresponding to the key is None.
                         (default: None)
 
     :returns:           The specified value, converted as needed.
     """
-    if key in config:
-        value = config[key]
+    value = config.get(key, default)
+    if value is not None:
         return convert(value, value_type, key)
     elif default is not None:
-        return convert(default,value_type,key)
-    else:
-        return default
+        return convert(default, value_type, key)
 
 def merge_config(config, kwargs, valid_params, aliases=None):
     """Merge in the values from kwargs into config.

--- a/treecorr/config.py
+++ b/treecorr/config.py
@@ -355,23 +355,28 @@ def get_from_list(config, key, num, value_type=str, default=None):
     :param key:         What key to get from config.
     :param num:         Which number element to use if the item is a list.
     :param value_type:  What type should the value be converted to. (default: str)
-    :param default:     What value should be used if the key is not in the config dict.
+    :param default:     What value should be used if the key is not in the config dict,
+                        or the value corresponding to the key is None.
                         (default: None)
 
     :returns:           The specified value, converted as needed.
     """
-    if key in config:
-        values = config[key]
-        if isinstance(values, list):
-            if num >= len(values):
-                raise IndexError("num=%d is out of range of list for %s"%(num,key))
-            return convert(values[num],value_type,key)
-        else:
-            return convert(values,value_type,key)
+    values = config.get(key, None)
+    if isinstance(values, list):
+        try:
+            value = values[num]
+        except IndexError:
+            raise IndexError("num=%d is out of range of list for %s"%(num,key))
+
+        if value is not None:
+            return convert(value, value_type, key)
+        elif default is not None:
+            return convert(default, value_type, key)
+    elif values is not None:
+        return convert(values, value_type, key)
     elif default is not None:
-        return convert(default,value_type,key)
-    else:
-        return default
+        return convert(default, value_type, key)
+
 
 def get(config, key, value_type=str, default=None):
     """A helper function to get a key from config converting to a particular type


### PR DESCRIPTION
Hi Mike, the main intention of this PR is to be able to generate a `BinnedCorr2` object by passing all four of `nbins`, `min_sep`, `max_sep`, `bin_size` but with exactly one of them set `None`. I've made the changes for `BinnedCorr3` as well and modified some helper functions to not check if a `key` exists in a config/kwarg dict but instead check if it has been explicitly set. I'm assuming that nowhere in `treecorr` `None` has a special meaning.