### PR TITLE
Add build_cov_design_matrix and build_multi_cov_design_matrix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,7 @@ New features
   (#141)
 - Allow None as a configuration parameter to be equivalent to not specifying a parameter.
   E.g. ``bin_size=0.1, min_sep=1., max_sep=100., nbins=None`` is allowed now. (#142)
+- Add `BinnedCorr2.build_cov_design_matrix` and `build_multi_cov_design_matrix` functions (#132)
 
 Bug fixes
 ---------

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -671,6 +671,8 @@ def test_gg_jk():
 
     with assert_raises(ValueError):
         gg2.build_cov_design_matrix('shot')
+    with assert_raises(ValueError):
+        gg2.build_cov_design_matrix('invalid')
 
     # Now run with jackknife variance estimate.  Should be much better.
     gg3 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., var_method='jackknife',

--- a/tests/test_patch3pt.py
+++ b/tests/test_patch3pt.py
@@ -182,6 +182,8 @@ def test_kkk_jk():
 
     with assert_raises(ValueError):
         kkkp.build_cov_design_matrix('shot')
+    with assert_raises(ValueError):
+        kkkp.build_cov_design_matrix('invalid')
 
     print('sample:')
     cov = kkkp.estimate_cov('sample')

--- a/tests/test_patch3pt.py
+++ b/tests/test_patch3pt.py
@@ -674,6 +674,12 @@ def test_ggg_jk():
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_ggg))))
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_ggg), atol=0.4*tol_factor)
 
+    # Test design matrix
+    A, w = gggp.build_cov_design_matrix('jackknife', func=f)
+    A -= np.mean(A, axis=0)
+    C = (1-1/npatch) * A.conj().T.dot(A)
+    np.testing.assert_allclose(C, cov)
+
     print('sample:')
     cov = gggp.estimate_cov('sample', func=f)
     print(np.diagonal(cov).real)

--- a/treecorr/__init__.py
+++ b/treecorr/__init__.py
@@ -50,7 +50,7 @@ Rperp_alias = 'FisherRperp'
 from .config import read_config
 from .util import set_omp_threads, get_omp_threads
 from .catalog import Catalog, read_catalogs, calculateVarG, calculateVarK
-from .binnedcorr2 import BinnedCorr2, estimate_multi_cov
+from .binnedcorr2 import BinnedCorr2, estimate_multi_cov, build_multi_cov_design_matrix
 from .ggcorrelation import GGCorrelation
 from .nncorrelation import NNCorrelation
 from .kkcorrelation import KKCorrelation


### PR DESCRIPTION
Add functions that allow direct access of the design matrix used to compute covariance matrices.

For single correlation functions, the methods are `build_cov_design_matrix`.  For multiple correlation functions (a la `estimate_multi_cov`), one can use `treecorr.build_multi_cov_design_matrix`.