### PR TITLE
Require npatch when patch is an integer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ whose issue numbers are listed below for the relevant items.
 API Changes
 -----------
 
+- When making a `Catalog`, if ``patch`` is an integer, ``npatch`` is now required.  This used to
+  be usually required implicitly in how TreeCorr expected things to be set up downstream, but
+  there were some use cases where a user could get away with not providing ``npatch`` and things
+  would nonetheless still work.  But now we explicitly check for it, so those use cases do
+  require passing ``npatch`` now.  (#150)
 
 
 Performance improvements
@@ -20,6 +25,7 @@ Performance improvements
 New features
 ------------
 
+- Give a better error message when patch is given as an integer, but npatch is not provided. (#150)
 
 
 Bug fixes

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -510,6 +510,9 @@ def test_omp():
     assert treecorr.set_omp_threads(2) <= 2
     assert treecorr.set_omp_threads(20) >= 1
     assert treecorr.set_omp_threads(20) <= 3
+    with CaptureLog() as cl:
+        treecorr.set_omp_threads(20, logger=cl.logger)
+    assert "max_omp_threads = 3" in cl.output
     treecorr.set_max_omp_threads(None)
 
     # Repeat and check that appropriate messages are emitted

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -215,7 +215,7 @@ def test_cat_patches():
             assert catb.get_patches(low_mem=True) == [catb]
 
     # 7. Set a single patch number
-    cat7 = treecorr.Catalog(ra=ra, dec=dec, ra_units='rad', dec_units='rad', patch=3)
+    cat7 = treecorr.Catalog(ra=ra, dec=dec, ra_units='rad', dec_units='rad', patch=3, npatch=npatch)
     np.testing.assert_array_equal(cat7.patch, 3)
     cat8 = treecorr.Catalog(file_name5, ra_col=1, dec_col=2, ra_units='rad', dec_units='rad',
                              patch_col=3, patch=3)
@@ -244,6 +244,9 @@ def test_cat_patches():
     # Note: npatch larger than what is in patch is ok.
     #       It indicates that this is part of a larger group with more patches.
     treecorr.Catalog(ra=ra, dec=dec, ra_units='rad', dec_units='rad', npatch=300, patch=p2)
+    # npatch required if patch is an integer
+    with assert_raises(ValueError):
+        treecorr.Catalog(ra=ra, dec=dec, ra_units='rad', dec_units='rad', patch=3)
     # patch has to have same number of entries
     with assert_raises(ValueError):
         treecorr.Catalog(ra=ra, dec=dec, ra_units='rad', dec_units='rad', patch=p2[:17])
@@ -1998,7 +2001,7 @@ def test_save_patches():
         patch_file_name = os.path.join('output','patch%03d.fits'%i)
         assert os.path.exists(patch_file_name)
         cat_i = treecorr.Catalog(patch_file_name, ra_col='ra', dec_col='dec',
-                                 ra_units='rad', dec_units='rad', patch=i)
+                                 ra_units='rad', dec_units='rad', patch=i, npatch=npatch)
         assert not cat_i.loaded
         assert cat1.patches[i].loaded
         assert cat_i == cat1.patches[i]
@@ -2016,7 +2019,7 @@ def test_save_patches():
         patch_file_name = os.path.join('output','test_save_patches_%03d.fits'%i)
         assert os.path.exists(patch_file_name)
         cat_i = treecorr.Catalog(patch_file_name, ra_col='ra', dec_col='dec',
-                                 ra_units='rad', dec_units='rad', patch=i)
+                                 ra_units='rad', dec_units='rad', patch=i, npatch=npatch)
         assert not cat_i.loaded
         assert not cat2.patches[i].loaded
         assert cat_i == cat2.patches[i]
@@ -2043,7 +2046,7 @@ def test_save_patches():
             patch_file_name = os.path.join('output','test_save_patches_%03d.hdf5'%i)
             assert os.path.exists(patch_file_name)
             cat_i = treecorr.Catalog(patch_file_name, ra_col='ra', dec_col='dec',
-                                     ra_units='rad', dec_units='rad', patch=i)
+                                     ra_units='rad', dec_units='rad', patch=i, npatch=npatch)
             assert not cat_i.loaded
             assert not cat2.patches[i].loaded
             assert cat_i == cat2.patches[i]
@@ -2072,7 +2075,7 @@ def test_save_patches():
     for i in range(npatch):
         patch_file_name = os.path.join('output','test_save_patches2_%03d.fits'%i)
         assert os.path.exists(patch_file_name)
-        cat_i = treecorr.Catalog(patch_file_name, patch=i,
+        cat_i = treecorr.Catalog(patch_file_name, patch=i, npatch=npatch,
                                  x_col='x', y_col='y', z_col='z', w_col='w',
                                  g1_col='g1', g2_col='g2', k_col='k')
         assert not cat_i.loaded
@@ -2103,7 +2106,7 @@ def test_save_patches():
         patch_file_name = cat5.patches[i].file_name
         assert patch_file_name == os.path.join('output','test_save_patches2_%03d.fits'%i)
         assert os.path.exists(patch_file_name)
-        cat_i = treecorr.Catalog(patch_file_name, patch=i,
+        cat_i = treecorr.Catalog(patch_file_name, patch=i, npatch=npatch,
                                  x_col='x', y_col='y', wpos_col='wpos', k_col='k')
         assert not cat_i.loaded
         assert not cat5.patches[i].loaded


### PR DESCRIPTION
@myamamoto26 ran into an error, which was my fault because I failed to tell him the right syntax for setting a catalog to have a single patch number.  (I.e. one of 200 files, each of which represents a different patch.)  The problem is that for this to work correctly, TreeCorr (usually) needs to know the total number of patches that the given file is a part of.  So you need to include `npatch=200`, which I had neglected.

This error mostly just adds a better error message for whenever users try to set `patch=i` without including `npatch`, rather than the fairly cryptic error that Masa got.  However, it is officially an API change, since there were use cases where TreeCorr could figure out npatch without it being provided explicitly.  So now those uses require setting npatch, when they didn't used to require it.  

That seems worth it to me, since it's a very small burden on the user in those cases.  (They would necessarily know what npatch is in those use cases, so it would be easy to add to the Catalog construction.)  But it means that this can't be considered a bugfix.  It will have to wait until the next minor release series, 4.3.