### PR TITLE
More refactoring to reduce compiled library size.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
               continue-on-error: true
               run: |
                 echo ${{ matrix.os }}
-                brew update
+                brew update-reset
                 brew install openmpi
 
             - name: Install basic dependencies

--- a/devel/run_dessv.py
+++ b/devel/run_dessv.py
@@ -52,7 +52,8 @@ def download():
         print('number to use = ',np.sum(use))
         cols = [col[use] for col in cols]
         print('writing merged file: ',source_file)
-        treecorr.util.gen_write(source_file, col_names, cols, file_type='FITS')
+        with treecorr.util.make_writer(source_file) as writer:
+            writer.write(col_names, cols)
 
     return source_file, lens_file
 
@@ -65,6 +66,7 @@ def run_dessv(source_file, lens_file, use_patches):
         # source catalog to run KMeans.
         print('Read 1/10 of source catalog for kmeans patches')
         npatch = 128
+        t0 = time.time()
         small_cat = treecorr.Catalog(source_file, ra_col='RA', dec_col='DEC', file_type='FITS',
                                      ra_units='deg', dec_units='deg', every_nth=10, npatch=npatch,
                                      verbose=2)
@@ -72,7 +74,9 @@ def run_dessv(source_file, lens_file, use_patches):
         # Write the patch centers
         patch_file = os.path.join('output','test_dessv_patches.fits')
         small_cat.write_patch_centers(patch_file)
+        t1 = time.time()
         print('wrote patch centers file ',patch_file)
+        print('Time to make patches = ',t1-t0)
         #print('centers = ',small_cat.patch_centers)
 
         patch_kwargs = dict(patch_centers=patch_file, save_patch_dir='output')
@@ -155,8 +159,8 @@ if __name__ == '__main__':
     run_dessv(source_file, lens_file, use_patches=False)
     t1 = time.time()
     print('Run with patches:')
-    with profile():
-        run_dessv(source_file, lens_file, use_patches=True)
+    #with profile():
+    run_dessv(source_file, lens_file, use_patches=True)
     t2 = time.time()
     print('Time for normal non-patch run = ',t1-t0)
     print('Time for patch run with jackknife covariance = ',t2-t1)

--- a/include/BinType.h
+++ b/include/BinType.h
@@ -31,7 +31,7 @@ struct BinTypeHelper;
 template <>
 struct BinTypeHelper<Log>
 {
-    static bool doReverse() { return false; }
+    enum { do_reverse = false };
 
     // For Log binning, the test for when to stop splitting is s1+s2 < b*d.
     // This b*d is the "effective" b used by CalcSplit.
@@ -143,7 +143,7 @@ struct BinTypeHelper<Log>
 template <>
 struct BinTypeHelper<Linear>
 {
-    static bool doReverse() { return false; }
+    enum { do_reverse = false };
 
     // For Linear binning, the test for when to stop splitting is s1+s2 < b.
     // So the effective b is just b itself.
@@ -232,7 +232,7 @@ struct BinTypeHelper<Linear>
 template <>
 struct BinTypeHelper<TwoD>
 {
-    static bool doReverse() { return true; }
+    enum { do_reverse = true };
 
     // Like Linear binning, the effective b is just b itself.
     static double getEffectiveB(double r, double b)

--- a/include/Cell.h
+++ b/include/Cell.h
@@ -69,35 +69,53 @@ template <int D, int C>
 class CellData;
 
 template <int C>
-class CellData<NData,C>
+class BaseCellData
 {
 public:
-    CellData() {}
+    BaseCellData() {}
 
-    CellData(const Position<C>& pos, double w) :
-        _pos(pos), _w(w), _n(1) {}
+    virtual ~BaseCellData() {}
 
-    template <int C2>
-    CellData(const Position<C2>& pos, double w) :
-        _pos(pos), _w(w), _n(1) {}
+    BaseCellData(const Position<C>& pos, double w) :
+        _pos(pos), _w(w), _n(1)
+    {}
 
-    CellData(const std::vector<std::pair<CellData<NData,C>*,WPosLeafInfo> >& vdata,
-             size_t start, size_t end);
-
-    // This doesn't do anything, but is provided for consistency with the other
-    // kinds of CellData.
-    void finishAverages(const std::vector<std::pair<CellData<NData,C>*,WPosLeafInfo> >&,
-                        size_t , size_t ) {}
+    BaseCellData(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
+                 size_t start, size_t end);
 
     const Position<C>& getPos() const { return _pos; }
     double getW() const { return _w; }
     long getN() const { return _n; }
 
-private:
+protected:
 
     Position<C> _pos;
     float _w;
     long _n;
+};
+
+
+template <int C>
+class CellData<NData,C> : public BaseCellData<C>
+{
+public:
+    CellData() {}
+
+    CellData(const Position<C>& pos, double w) :
+        BaseCellData<C>(pos, w) {}
+
+    template <int C2>
+    CellData(const Position<C2>& pos, double w) :
+        BaseCellData<C>(pos, w) {}
+
+    CellData(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
+             size_t start, size_t end) :
+        BaseCellData<C>(vdata, start, end) {}
+
+    // This doesn't do anything, but is provided for consistency with the other
+    // kinds of CellData.
+    void finishAverages(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >&,
+                        size_t , size_t ) {}
 };
 
 template <int C>
@@ -105,39 +123,34 @@ std::ostream& operator<<(std::ostream& os, const CellData<NData,C>& c)
 { return os << c.getPos() << " " << c.getN(); }
 
 template <int C>
-class CellData<KData,C>
+class CellData<KData,C> : public BaseCellData<C>
 {
 public:
     CellData() {}
 
     CellData(const Position<C>& pos, double k, double w) :
-        _pos(pos), _wk(w*k), _w(w), _n(1)
+        BaseCellData<C>(pos, w), _wk(w*k)
     {}
 
     template <int C2>
     CellData(const Position<C2>& pos, double k, double w) :
-        _pos(pos), _wk(w*k), _w(w), _n(1)
+        BaseCellData<C>(pos, w), _wk(w*k)
     {}
 
-    CellData(const std::vector<std::pair<CellData<KData,C>*,WPosLeafInfo> >& vdata,
-             size_t start, size_t end);
+    CellData(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
+             size_t start, size_t end) :
+        BaseCellData<C>(vdata, start, end) {}
 
     // The above constructor just computes the mean pos, since sometimes that's all we
     // need.  So this function will finish the rest of the construction when desired.
-    void finishAverages(const std::vector<std::pair<CellData<KData,C>*,WPosLeafInfo> >&,
+    void finishAverages(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >&,
                         size_t start, size_t end);
 
-    const Position<C>& getPos() const { return _pos; }
     double getWK() const { return _wk; }
-    double getW() const { return _w; }
-    long getN() const { return _n; }
 
-private:
+protected:
 
-    Position<C> _pos;
     float _wk;
-    float _w;
-    long _n;
 };
 
 template <int C>
@@ -145,69 +158,55 @@ std::ostream& operator<<(std::ostream& os, const CellData<KData,C>& c)
 { return os << c.getPos() << " " << c.getWK() << " " << c.getW() << " " << c.getN(); }
 
 template <int C>
-class CellData<GData,C>
+class CellData<GData,C> : public BaseCellData<C>
 {
 public:
     CellData() {}
 
     CellData(const Position<C>& pos, const std::complex<double>& g, double w) :
-        _pos(pos), _wg(w*g), _w(w), _n(1)
+        BaseCellData<C>(pos, w), _wg(w*g)
     {}
 
     template <int C2>
     CellData(const Position<C2>& pos, const std::complex<double>& g, double w) :
-        _pos(pos), _wg(w*g), _w(w), _n(1)
+        BaseCellData<C>(pos, w), _wg(w*g)
     {}
 
-    CellData(const std::vector<std::pair<CellData<GData,C>*,WPosLeafInfo> >& vdata,
-             size_t start, size_t end);
+    CellData(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
+             size_t start, size_t end) :
+        BaseCellData<C>(vdata, start, end) {}
 
     // The above constructor just computes the mean pos, since sometimes that's all we
     // need.  So this function will finish the rest of the construction when desired.
-    void finishAverages(const std::vector<std::pair<CellData<GData,C>*,WPosLeafInfo> >&,
+    void finishAverages(const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >&,
                         size_t start, size_t end);
 
-    const Position<C>& getPos() const { return _pos; }
     std::complex<double> getWG() const { return _wg; }
-    double getW() const { return _w; }
-    long getN() const { return _n; }
 
-private:
+protected:
 
-    Position<C> _pos;
     std::complex<float> _wg;
-    float _w;
-    long _n;
 };
 
 template <int C>
 std::ostream& operator<<(std::ostream& os, const CellData<GData,C>& c)
 { return os << c.getPos() << " " << c.getWG() << " " << c.getW() << " " << c.getN(); }
 
-template <int D, int C>
-class Cell
+template <int C>
+class BaseCell
 {
 public:
 
-    // A Cell contains the accumulated data for a bunch of galaxies.
-    // It is characterized primarily by a centroid and a size.
-    // The centroid is simply the weighted centroid of all the galaxy positions.
-    // The size is the maximum deviation of any one of these galaxies
-    // from the centroid.  That is, all galaxies fall within a radius
-    // size from the centroid.
-    // The structure also keeps track of some averages and sums about
-    // the galaxies which are used in the correlation function calculations.
-
-    Cell(CellData<D,C>* data, const LeafInfo& info) :
+    BaseCell(BaseCellData<C>* data, const LeafInfo& info) :
         _data(data), _size(0.), _left(0), _info(info) {}
 
-    Cell(CellData<D,C>* data, const ListLeafInfo& listinfo) :
+    BaseCell(BaseCellData<C>* data, const ListLeafInfo& listinfo) :
         _data(data), _size(0.), _left(0), _listinfo(listinfo) {}
 
-    Cell(CellData<D,C>* data, double size, Cell<D,C>* l, Cell<D,C>* r) :
+    BaseCell(BaseCellData<C>* data, double size, BaseCell<C>* l, BaseCell<C>* r) :
         _data(data), _size(size), _left(l), _right(r) {}
 
-    ~Cell()
+    virtual ~BaseCell()
     {
         if (_left) {
             Assert(_right);
@@ -221,7 +220,7 @@ public:
         }
     }
 
-    const CellData<D,C>& getData() const { return *_data; }
+    const BaseCellData<C>& getData() const { return *_data; }
     const Position<C>& getPos() const { return _data->getPos(); }
     double getW() const { return _data->getW(); }
     long getN() const { return _data->getN(); }
@@ -229,51 +228,84 @@ public:
     double getSize() const { return _size; }
     double calculateInertia() const;
 
-    const Cell<D,C>* getLeft() const { return _left; }
-    const Cell<D,C>* getRight() const { return _left ? _right : 0; }
+    const BaseCell<C>* getLeft() const { return _left; }
+    const BaseCell<C>* getRight() const { return _left ? _right : 0; }
     const LeafInfo& getInfo() const { Assert(!_left && getN()==1); return _info; }
     const ListLeafInfo& getListInfo() const { Assert(!_left && getN()!=1); return _listinfo; }
 
     // These are mostly used for debugging purposes.
     long countLeaves() const;
-    std::vector<const Cell<D,C>*> getAllLeaves() const;
+    std::vector<const BaseCell<C>*> getAllLeaves() const;
     bool includesIndex(long index) const;
     std::vector<long> getAllIndices() const;
-    const Cell<D,C>* getLeafNumber(long i) const;
+    const BaseCell<C>* getLeafNumber(long i) const;
 
     void Write(std::ostream& os) const;
     void WriteTree(std::ostream& os, int indent=0) const;
 
 protected:
 
-    CellData<D,C>* _data;
+    BaseCellData<C>* _data;
     float _size;
 
-    Cell<D,C>* _left;
+    BaseCell<C>* _left;
     union {
-        Cell<D,C>* _right;      // Use this when _left != 0
+        BaseCell<C>* _right;    // Use this when _left != 0
         LeafInfo _info;         // Use this when _left == 0 and N == 1
         ListLeafInfo _listinfo; // Use this when _left == 0 and N > 1
     };
 };
 
 template <int D, int C>
+class Cell : public BaseCell<C>
+{
+public:
+
+    // A Cell contains the accumulated data for a bunch of galaxies.
+    // It is characterized primarily by a centroid and a size.
+    // The centroid is simply the weighted centroid of all the galaxy positions.
+    // The size is the maximum deviation of any one of these galaxies
+    // from the centroid.  That is, all galaxies fall within a radius
+    // size from the centroid.
+    // The structure also keeps track of some averages and sums about
+    // the galaxies which are used in the correlation function calculations.
+
+    Cell(CellData<D,C>* data, const LeafInfo& info) :
+        BaseCell<C>(data, info) {}
+
+    Cell(CellData<D,C>* data, const ListLeafInfo& listinfo) :
+        BaseCell<C>(data, listinfo) {}
+
+    Cell(CellData<D,C>* data, double size, Cell<D,C>* l, Cell<D,C>* r) :
+        BaseCell<C>(data, size, l, r) {}
+
+    const CellData<D,C>& getData() const
+    { return static_cast<const CellData<D,C>&>(BaseCell<C>::getData()); }
+
+    const Cell<D,C>* getLeft() const
+    { return static_cast<const Cell<D,C>*>(BaseCell<C>::getLeft()); }
+
+    const Cell<D,C>* getRight() const
+    { return static_cast<const Cell<D,C>*>(BaseCell<C>::getRight()); }
+};
+
+template <int C>
 double CalculateSizeSq(
-    const Position<C>& cen, const std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
+    const Position<C>& cen, const std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
     size_t start, size_t end);
 
-template <int D, int C, int SM>
+template <int C, int SM>
 size_t SplitData(
-    std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
+    std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
     size_t start, size_t end, const Position<C>& meanpos);
 
 template <int D, int C, int SM>
-Cell<D,C>* BuildCell(std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& vdata,
+Cell<D,C>* BuildCell(std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& vdata,
                      double minsizesq, bool brute, size_t start, size_t end,
                      CellData<D,C>* ave=0, double sizesq=0.);
 
-template <int D, int C>
-inline std::ostream& operator<<(std::ostream& os, const Cell<D,C>& c)
+template <int C>
+inline std::ostream& operator<<(std::ostream& os, const BaseCell<C>& c)
 { c.Write(os); return os; }
 
 #endif

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -40,12 +40,12 @@ public:
     template <int B, int M, int P, int D1, int D2, int C>
     long samplePairs(const Field<D1, C>& field1, const Field<D2, C>& field2,
                      double min_sep, double max_sep, long* i1, long* i2, double* sep, int n);
-    template <int B, int M, int P, int D1, int D2, int C>
-    void samplePairs(const Cell<D1, C>& c1, const Cell<D2, C>& c2, const MetricHelper<M,P>& m,
+    template <int B, int M, int P, int C>
+    void samplePairs(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& m,
                      double min_sep, double min_sepsq, double max_sep, double max_sepsq,
                      long* i1, long* i2, double* sep, int n, long& k);
-    template <int B, int D1, int D2, int C>
-    void sampleFrom(const Cell<D1,C>& c1, const Cell<D2,C>& c2, double rsq, double r,
+    template <int B, int C>
+    void sampleFrom(const BaseCell<C>& c1, const BaseCell<C>& c2, double rsq, double r,
                     long* i1, long* i2, double* sep, int n, long& k);
 
     bool nontrivialRPar() const
@@ -99,14 +99,14 @@ public:
 
     // Main worker functions for calculating the result
     template <int B, int M, int P, int C>
-    void process2(const Cell<D1,C>& c12, const MetricHelper<M,P>& m);
+    void process2(const BaseCell<C>& c12, const MetricHelper<M,P>& m);
 
     template <int B, int M, int P, int C>
-    void process11(const Cell<D1,C>& c1, const Cell<D2,C>& c2, const MetricHelper<M,P>& m,
+    void process11(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& m,
                    bool do_reverse);
 
     template <int B, int C>
-    void directProcess11(const Cell<D1,C>& c1, const Cell<D2,C>& c2, const double dsq,
+    void directProcess11(const BaseCell<C>& c1, const BaseCell<C>& c2, const double dsq,
                          bool do_reverse, int k=-1, double r=0., double logr=0.);
 
     // Note: op= only copies _data.  Not all the params.

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -37,8 +37,8 @@ public:
     ~BaseCorr2() {}
 
     // Sample a random subset of pairs in a given range
-    template <int B, int M, int P, int D1, int D2, int C>
-    long samplePairs(const Field<D1, C>& field1, const Field<D2, C>& field2,
+    template <int B, int M, int P, int C>
+    long samplePairs(const BaseField<C>& field1, const BaseField<C>& field2,
                      double min_sep, double max_sep, long* i1, long* i2, double* sep, int n);
     template <int B, int M, int P, int C>
     void samplePairs(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& m,

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -101,6 +101,7 @@ protected:
     virtual void doFinishProcess(const BaseCell<ThreeD>& c1, const BaseCell<ThreeD>& c2,
                                  double rsq, double r, double logr, int k, int k2, R1<0>)=0;
 
+    BinType _bin_type;
     double _minsep;
     double _maxsep;
     int _nbins;
@@ -306,5 +307,56 @@ struct XiData<NData, NData>
     void write(std::ostream& os) const {}
 };
 
+
+class Sampler : public BaseCorr2
+{
+
+public:
+
+    Sampler(const BaseCorr2& base_corr2, double minsep, double maxsep,
+            long* i1, long* i2, double* sep, int n);
+    // Use default copy/destr/op=
+
+    std::shared_ptr<BaseCorr2> duplicate()
+    { return std::make_shared<Sampler>(*this); }
+
+    // We only use this with a single sampler, so addData just needs to
+    // copy things back to the original sampler.
+    void addData(const BaseCorr2& rhs)
+    { *this = static_cast<const Sampler&>(rhs); }
+
+    template <int R, int C>
+    void finishProcess(const BaseCell<C>& c1, const BaseCell<C>& c2,
+                       double rsq, double r, double logr, int k, int k2);
+
+    long getK() const { return _k; }
+
+protected:
+
+    void doFinishProcess(const BaseCell<Flat>& c1, const BaseCell<Flat>& c2,
+                         double rsq, double r, double logr, int k, int k2, R1<1>)
+    { finishProcess<1>(c1, c2, rsq, r, logr, k, k2); }
+    void doFinishProcess(const BaseCell<Sphere>& c1, const BaseCell<Sphere>& c2,
+                         double rsq, double r, double logr, int k, int k2, R1<1>)
+    { finishProcess<1>(c1, c2, rsq, r, logr, k, k2); }
+    void doFinishProcess(const BaseCell<ThreeD>& c1, const BaseCell<ThreeD>& c2,
+                         double rsq, double r, double logr, int k, int k2, R1<1>)
+    { finishProcess<1>(c1, c2, rsq, r, logr, k, k2); }
+    void doFinishProcess(const BaseCell<Flat>& c1, const BaseCell<Flat>& c2,
+                         double rsq, double r, double logr, int k, int k2, R1<0>)
+    { finishProcess<0>(c1, c2, rsq, r, logr, k, k2); }
+    void doFinishProcess(const BaseCell<Sphere>& c1, const BaseCell<Sphere>& c2,
+                         double rsq, double r, double logr, int k, int k2, R1<0>)
+    { finishProcess<0>(c1, c2, rsq, r, logr, k, k2); }
+    void doFinishProcess(const BaseCell<ThreeD>& c1, const BaseCell<ThreeD>& c2,
+                         double rsq, double r, double logr, int k, int k2, R1<0>)
+    { finishProcess<0>(c1, c2, rsq, r, logr, k, k2); }
+
+    long* _i1;
+    long* _i2;
+    double* _sep;
+    int _n;
+    long _k;
+};
 
 #endif

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -36,6 +36,10 @@ public:
     BaseCorr2(const BaseCorr2& rhs);
     virtual ~BaseCorr2() {}
 
+    virtual std::shared_ptr<BaseCorr2> duplicate() =0;
+
+    virtual void addData(const BaseCorr2& rhs) =0;
+
     // Sample a random subset of pairs in a given range
     template <int B, int M, int P, int C>
     long samplePairs(const BaseField<C>& field1, const BaseField<C>& field2,
@@ -56,6 +60,12 @@ public:
 
     template <int B, int M, int C>
     bool triviallyZero(Position<C> p1, Position<C> p2, double s1, double s2);
+
+    template <int B, int M, int P, int C>
+    void process(const BaseField<C>& field, bool dots);
+
+    template <int B, int M, int P, int C>
+    void process(const BaseField<C>& field1, const BaseField<C>& field2, bool dots);
 
     // Main worker functions for calculating the result
     template <int B, int M, int P, int C>
@@ -122,13 +132,13 @@ public:
     Corr2(const Corr2& rhs, bool copy_data=true);
     ~Corr2();
 
+    std::shared_ptr<BaseCorr2> duplicate()
+    { return std::make_shared<Corr2<D1,D2> >(*this, false); }
+
+    void addData(const BaseCorr2& rhs)
+    { *this += static_cast<const Corr2<D1,D2>&>(rhs); }
+
     void clear();  // Set all data to 0.
-
-    template <int B, int M, int P, int C>
-    void process(const Field<D1,C>& field, bool dots);
-
-    template <int B, int M, int P, int C>
-    void process(const Field<D1,C>& field1, const Field<D2,C>& field2, bool dots);
 
     template <int R, int C>
     void finishProcess(const BaseCell<C>& c1, const BaseCell<C>& c2,

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -101,13 +101,12 @@ public:
     template <int B, int M, int P, int C>
     void process2(const BaseCell<C>& c12, const MetricHelper<M,P>& m);
 
-    template <int B, int M, int P, int C>
-    void process11(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& m,
-                   bool do_reverse);
+    template <int B, int M, int P, int R, int C>
+    void process11(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& m);
 
-    template <int B, int C>
+    template <int B, int R, int C>
     void directProcess11(const BaseCell<C>& c1, const BaseCell<C>& c2, const double dsq,
-                         bool do_reverse, int k=-1, double r=0., double logr=0.);
+                         int k=-1, double r=0., double logr=0.);
 
     // Note: op= only copies _data.  Not all the params.
     void operator=(const Corr2<D1,D2>& rhs);

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -45,7 +45,7 @@ public:
                      double min_sep, double min_sepsq, double max_sep, double max_sepsq,
                      long* i1, long* i2, double* sep, int n, long& k);
     template <int B, int D1, int D2, int C>
-    void sampleFrom(const Cell<D1, C>& c1, const Cell<D2, C>& c2, double rsq, double r,
+    void sampleFrom(const Cell<D1,C>& c1, const Cell<D2,C>& c2, double rsq, double r,
                     long* i1, long* i2, double* sep, int n, long& k);
 
     bool nontrivialRPar() const

--- a/include/Corr3.h
+++ b/include/Corr3.h
@@ -112,17 +112,17 @@ public:
 
     // Main worker functions for calculating the result
     template <int B, int M, int C>
-    void process3(const Cell<D1,C>* c1, const MetricHelper<M,0>& metric);
+    void process3(const BaseCell<C>* c1, const MetricHelper<M,0>& metric);
 
     template <int B, int M, int C>
     void process12(Corr3<D2,D1,D2>& bc212, Corr3<D2,D2,D1>& bc221,
-                   const Cell<D1,C>* c1, const Cell<D2,C>* c2, const MetricHelper<M,0>& metric);
+                   const BaseCell<C>* c1, const BaseCell<C>* c2, const MetricHelper<M,0>& metric);
 
     template <int B, int M, int C>
     void process111(Corr3<D1,D3,D2>& bc132,
                     Corr3<D2,D1,D3>& bc213, Corr3<D2,D3,D1>& bc231,
                     Corr3<D3,D1,D2>& bc312, Corr3<D3,D2,D1>& bc321,
-                    const Cell<D1,C>* c1, const Cell<D2,C>* c2, const Cell<D3,C>* c3,
+                    const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
                     const MetricHelper<M,0>& metric,
                     double d1sq=0., double d2sq=0., double d3sq=0.);
 
@@ -130,12 +130,12 @@ public:
     void process111Sorted(Corr3<D1,D3,D2>& bc132,
                           Corr3<D2,D1,D3>& bc213, Corr3<D2,D3,D1>& bc231,
                           Corr3<D3,D1,D2>& bc312, Corr3<D3,D2,D1>& bc321,
-                          const Cell<D1,C>* c1, const Cell<D2,C>* c2, const Cell<D3,C>* c3,
+                          const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
                           const MetricHelper<M,0>& metric,
                           double d1sq=0., double d2sq=0., double d3sq=0.);
 
     template <int B, int C>
-    void directProcess111(const Cell<D1,C>& c1, const Cell<D2,C>& c2, const Cell<D3,C>& c3,
+    void directProcess111(const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
                           const double d1, const double d2, const double d3,
                           const double logr, const double u, const double v, const int index);
 

--- a/include/Corr3.h
+++ b/include/Corr3.h
@@ -47,33 +47,33 @@ public:
     template <int B, int M, int C>
     void process(const BaseField<C>& field, bool dots);
     template <int B, int M, int C>
-    void process(BaseCorr3* corr212, BaseCorr3* corr221,
+    void process(BaseCorr3& corr212, BaseCorr3& corr221,
                  const BaseField<C>& field1, const BaseField<C>& field2, bool dots);
     template <int B, int M, int C>
-    void process(BaseCorr3* corr132, BaseCorr3* corr213, BaseCorr3* corr231,
-                 BaseCorr3* corr312, BaseCorr3* corr321,
+    void process(BaseCorr3& corr132, BaseCorr3& corr213, BaseCorr3& corr231,
+                 BaseCorr3& corr312, BaseCorr3& corr321,
                  const BaseField<C>& field1, const BaseField<C>& field2,
                  const BaseField<C>& field3, bool dots);
 
     // Main worker functions for calculating the result
     template <int B, int M, int C>
-    void process3(const BaseCell<C>* c1, const MetricHelper<M,0>& metric);
+    void process3(const BaseCell<C>& c1, const MetricHelper<M,0>& metric);
 
     template <int B, int M, int C>
     void process12(BaseCorr3& bc212, BaseCorr3& bc221,
-                   const BaseCell<C>* c1, const BaseCell<C>* c2, const MetricHelper<M,0>& metric);
+                   const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,0>& metric);
 
     template <int B, int M, int C>
     void process111(BaseCorr3& bc132, BaseCorr3& bc213, BaseCorr3& bc231,
                     BaseCorr3& bc312, BaseCorr3& bc321,
-                    const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
+                    const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
                     const MetricHelper<M,0>& metric,
                     double d1sq=0., double d2sq=0., double d3sq=0.);
 
     template <int B, int M, int C>
     void process111Sorted(BaseCorr3& bc132, BaseCorr3& bc213, BaseCorr3& bc231,
                           BaseCorr3& bc312, BaseCorr3& bc321,
-                          const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
+                          const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
                           const MetricHelper<M,0>& metric,
                           double d1sq=0., double d2sq=0., double d3sq=0.);
 

--- a/include/Corr3.h
+++ b/include/Corr3.h
@@ -40,6 +40,21 @@ public:
     BaseCorr3(const BaseCorr3& rhs);
     virtual ~BaseCorr3() {}
 
+    virtual std::shared_ptr<BaseCorr3> duplicate() =0;
+
+    virtual void addData(const BaseCorr3& rhs) =0;
+
+    template <int B, int M, int C>
+    void process(const BaseField<C>& field, bool dots);
+    template <int B, int M, int C>
+    void process(BaseCorr3* corr212, BaseCorr3* corr221,
+                 const BaseField<C>& field1, const BaseField<C>& field2, bool dots);
+    template <int B, int M, int C>
+    void process(BaseCorr3* corr132, BaseCorr3* corr213, BaseCorr3* corr231,
+                 BaseCorr3* corr312, BaseCorr3* corr321,
+                 const BaseField<C>& field1, const BaseField<C>& field2,
+                 const BaseField<C>& field3, bool dots);
+
     // Main worker functions for calculating the result
     template <int B, int M, int C>
     void process3(const BaseCell<C>* c1, const MetricHelper<M,0>& metric);
@@ -146,20 +161,13 @@ public:
     Corr3(const Corr3& rhs, bool copy_data=true);
     ~Corr3();
 
+    std::shared_ptr<BaseCorr3> duplicate()
+    { return std::make_shared<Corr3<D1,D2,D3> >(*this, false); }
+
+    void addData(const BaseCorr3& rhs)
+    { *this += static_cast<const Corr3<D1,D2,D3>&>(rhs); }
+
     void clear();  // Set all data to 0.
-
-    template <int B, int M, int C>
-    void process(const Field<D1,C>& field, bool dots);
-    template <int B, int M, int C>
-    void process(Corr3<D2,D1,D2>* corr212, Corr3<D2,D2,D1>* corr221,
-                 const Field<D1,C>& field1, const Field<D2,C>& field2, bool dots);
-    template <int B, int M, int C>
-    void process(Corr3<D1,D3,D2>* corr132,
-                 Corr3<D2,D1,D3>* corr213, Corr3<D2,D3,D1>* corr231,
-                 Corr3<D3,D1,D2>* corr312, Corr3<D3,D2,D1>* corr321,
-                 const Field<D1,C>& field1, const Field<D2,C>& field2,
-                 const Field<D3,C>& field3, bool dots);
-
 
     template <int C>
     void finishProcess(

--- a/include/Field.h
+++ b/include/Field.h
@@ -35,29 +35,13 @@
 //     Rlens for the perpendicular component at the location of the "lens" (c1)
 //     Arc for great circle distances on the sphere
 
+template <int C>
 class BaseField
 {
 public:
-    virtual ~BaseField() {}
-
-    virtual long getNObj() const = 0;
-    virtual double getSizeSq() const = 0;
-    virtual double getSize() const = 0;
-    virtual long countNear(double x, double y, double z, double sep) const = 0;
-    virtual void getNear(double x, double y, double z, double sep, long* indices, long n) const = 0;
-    virtual long getNTopLevel() const = 0;
-};
-
-template <int D, int C>
-class Field : public BaseField
-{
-public:
-    Field(const double* x, const double* y, const double* z,
-          const double* g1, const double* g2, const double* k,
-          const double* w, const double* wpos, long nobj,
-          double minsize, double maxsize,
-          SplitMethod sm, long long seed, bool brute, int mintop, int maxtop);
-    ~Field();
+    BaseField(long nobj, double minsize, double maxsize,
+              SplitMethod sm, long long seed, bool brute, int mintop, int maxtop);
+    virtual ~BaseField();
 
     long getNObj() const { return _nobj; }
     double getSizeSq() const { return _sizesq; }
@@ -67,8 +51,6 @@ public:
     const std::vector<BaseCell<C>*>& getCells() const { BuildCells(); return _cells; }
     long countNear(double x, double y, double z, double sep) const;
     void getNear(double x, double y, double z, double sep, long* indices, long n) const;
-
-private:
 
     long _nobj;
     double _minsize;
@@ -84,10 +66,28 @@ private:
     // This is set at the start, but once we finish making all the cells, we don't need it anymore.
     mutable std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> > _celldata;
 
+protected:
+    virtual void BuildCells() const = 0;
+};
+
+template <int D, int C>
+class Field : public BaseField<C>
+{
+public:
+    Field(const double* x, const double* y, const double* z,
+          const double* g1, const double* g2, const double* k,
+          const double* w, const double* wpos, long nobj,
+          double minsize, double maxsize,
+          SplitMethod sm, long long seed, bool brute, int mintop, int maxtop);
+
+protected:
     // This finishes the work of the Field constructor.
     void BuildCells() const;
-    template <int SM> void DoBuildCells() const;
 
+private:
+
+    template <int SM>
+    void DoBuildCells() const;
 };
 
 #endif

--- a/include/Field.h
+++ b/include/Field.h
@@ -35,7 +35,6 @@
 //     Rlens for the perpendicular component at the location of the "lens" (c1)
 //     Arc for great circle distances on the sphere
 
-template <int D>
 class BaseField
 {
 public:
@@ -50,7 +49,7 @@ public:
 };
 
 template <int D, int C>
-class Field : public BaseField<D>
+class Field : public BaseField
 {
 public:
     Field(const double* x, const double* y, const double* z,

--- a/include/Field.h
+++ b/include/Field.h
@@ -64,7 +64,7 @@ public:
     Position<C> getCenter() const { return _center; }
     double getSize() const { return std::sqrt(_sizesq); }
     long getNTopLevel() const { BuildCells(); return long(_cells.size()); }
-    const std::vector<Cell<D,C>*>& getCells() const { BuildCells(); return _cells; }
+    const std::vector<BaseCell<C>*>& getCells() const { BuildCells(); return _cells; }
     long countNear(double x, double y, double z, double sep) const;
     void getNear(double x, double y, double z, double sep, long* indices, long n) const;
 
@@ -79,10 +79,10 @@ private:
     int _maxtop;
     Position<C> _center;
     double _sizesq;
-    mutable std::vector<Cell<D,C>*> _cells;
+    mutable std::vector<BaseCell<C>*> _cells;
 
     // This is set at the start, but once we finish making all the cells, we don't need it anymore.
-    mutable std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> > _celldata;
+    mutable std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> > _celldata;
 
     // This finishes the work of the Field constructor.
     void BuildCells() const;

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -784,5 +784,21 @@ struct MetricHelper<Periodic, P>
 
 };
 
+// A quick helper struct so we only instantiate valid combinations of M, C
+template <int M, int C>
+struct ValidMC;
+
+template <int M>
+struct ValidMC<M,Flat>
+{ enum { _M = MetricHelper<M,0>::_Flat == Flat ? M : Euclidean }; };
+
+template <int M>
+struct ValidMC<M,Sphere>
+{ enum { _M = MetricHelper<M,0>::_Sphere == Sphere ? M : Euclidean }; };
+
+template <int M>
+struct ValidMC<M,ThreeD>
+{ enum { _M = MetricHelper<M,0>::_ThreeD == ThreeD ? M : Euclidean }; };
+
 #endif
 

--- a/src/Corr2.cpp
+++ b/src/Corr2.cpp
@@ -535,7 +535,7 @@ void Corr2<D1,D2>::directProcess11(
     if (do_reverse) {
         k2 = BinTypeHelper<B>::calculateBinK(p2, p1, r, logr, _binsize,
                                              _minsep, _maxsep, _logminsep);
-        if (k == _nbins) --k;  // As before, this can (rarely) happen.
+        if (k2 == _nbins) --k2;  // As before, this can (rarely) happen.
         Assert(k2 >= 0);
         Assert(k2 < _nbins);
         _npairs[k2] += nn;

--- a/src/Corr2.cpp
+++ b/src/Corr2.cpp
@@ -852,7 +852,7 @@ Corr2<D1,D2>* BuildCorr2(
 }
 
 template <int B, int M, int C>
-void ProcessAuto2d(BaseCorr2* corr, BaseField<C>* field, bool dots)
+void ProcessAuto2(BaseCorr2* corr, BaseField<C>* field, bool dots)
 {
     const bool P = corr->nontrivialRPar();
     dbg<<"ProcessAuto: coords = "<<C<<", metric = "<<M<<", P = "<<P<<std::endl;
@@ -872,26 +872,26 @@ void ProcessAuto2d(BaseCorr2* corr, BaseField<C>* field, bool dots)
 }
 
 template <int B, int C>
-void ProcessAuto2c(BaseCorr2* corr, BaseField<C>* field, bool dots, Metric metric)
+void ProcessAuto1(BaseCorr2* corr, BaseField<C>* field, bool dots, Metric metric)
 {
     switch(metric) {
       case Euclidean:
-           ProcessAuto2d<B,Euclidean>(corr, field, dots);
+           ProcessAuto2<B,Euclidean>(corr, field, dots);
            break;
       case Rperp:
-           ProcessAuto2d<B,Rperp>(corr, field, dots);
+           ProcessAuto2<B,Rperp>(corr, field, dots);
            break;
       case OldRperp:
-           ProcessAuto2d<B,OldRperp>(corr, field, dots);
+           ProcessAuto2<B,OldRperp>(corr, field, dots);
            break;
       case Rlens:
-           ProcessAuto2d<B,Rlens>(corr, field, dots);
+           ProcessAuto2<B,Rlens>(corr, field, dots);
            break;
       case Arc:
-           ProcessAuto2d<B,Arc>(corr, field, dots);
+           ProcessAuto2<B,Arc>(corr, field, dots);
            break;
       case Periodic:
-           ProcessAuto2d<B,Periodic>(corr, field, dots);
+           ProcessAuto2<B,Periodic>(corr, field, dots);
            break;
       default:
            Assert(false);
@@ -903,13 +903,13 @@ void ProcessAuto(BaseCorr2* corr, BaseField<C>* field, bool dots, BinType bin_ty
 {
     switch(bin_type) {
       case Log:
-           ProcessAuto2c<Log>(corr, field, dots, metric);
+           ProcessAuto1<Log>(corr, field, dots, metric);
            break;
       case Linear:
-           ProcessAuto2c<Linear>(corr, field, dots, metric);
+           ProcessAuto1<Linear>(corr, field, dots, metric);
            break;
       case TwoD:
-           ProcessAuto2c<TwoD>(corr, field, dots, metric);
+           ProcessAuto1<TwoD>(corr, field, dots, metric);
            break;
       default:
            Assert(false);
@@ -917,7 +917,7 @@ void ProcessAuto(BaseCorr2* corr, BaseField<C>* field, bool dots, BinType bin_ty
 }
 
 template <int B, int M, int C>
-void ProcessCross2d(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2, bool dots)
+void ProcessCross2(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2, bool dots)
 {
     const bool P = corr->nontrivialRPar();
     dbg<<"ProcessCross: coords = "<<C<<", metric = "<<M<<", P = "<<P<<std::endl;
@@ -932,27 +932,27 @@ void ProcessCross2d(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
 }
 
 template <int B, int C>
-void ProcessCross2c(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
-                    bool dots, Metric metric)
+void ProcessCross1(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
+                   bool dots, Metric metric)
 {
     switch(metric) {
       case Euclidean:
-           ProcessCross2d<B,Euclidean>(corr, field1, field2, dots);
+           ProcessCross2<B,Euclidean>(corr, field1, field2, dots);
            break;
       case Rperp:
-           ProcessCross2d<B,Rperp>(corr, field1, field2, dots);
+           ProcessCross2<B,Rperp>(corr, field1, field2, dots);
            break;
       case OldRperp:
-           ProcessCross2d<B,OldRperp>(corr, field1, field2, dots);
+           ProcessCross2<B,OldRperp>(corr, field1, field2, dots);
            break;
       case Rlens:
-           ProcessCross2d<B,Rlens>(corr, field1, field2, dots);
+           ProcessCross2<B,Rlens>(corr, field1, field2, dots);
            break;
       case Arc:
-           ProcessCross2d<B,Arc>(corr, field1, field2, dots);
+           ProcessCross2<B,Arc>(corr, field1, field2, dots);
            break;
       case Periodic:
-           ProcessCross2d<B,Periodic>(corr, field1, field2, dots);
+           ProcessCross2<B,Periodic>(corr, field1, field2, dots);
            break;
       default:
            Assert(false);
@@ -966,13 +966,13 @@ void ProcessCross(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
     dbg<<"Start ProcessCross: "<<bin_type<<" "<<metric<<std::endl;
     switch(bin_type) {
       case Log:
-           ProcessCross2c<Log>(corr, field1, field2, dots, metric);
+           ProcessCross1<Log>(corr, field1, field2, dots, metric);
            break;
       case Linear:
-           ProcessCross2c<Linear>(corr, field1, field2, dots, metric);
+           ProcessCross1<Linear>(corr, field1, field2, dots, metric);
            break;
       case TwoD:
-           ProcessCross2c<TwoD>(corr, field1, field2, dots, metric);
+           ProcessCross1<TwoD>(corr, field1, field2, dots, metric);
            break;
       default:
            Assert(false);
@@ -1026,9 +1026,9 @@ long SamplePairs(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
 }
 
 template <int B, int M, int C>
-int TriviallyZero2e(BaseCorr2* corr,
-                    double x1, double y1, double z1, double s1,
-                    double x2, double y2, double z2, double s2)
+int TriviallyZero3(BaseCorr2* corr,
+                   double x1, double y1, double z1, double s1,
+                   double x2, double y2, double z2, double s2)
 {
     Position<C> p1(x1,y1,z1);
     Position<C> p2(x2,y2,z2);
@@ -1036,24 +1036,24 @@ int TriviallyZero2e(BaseCorr2* corr,
 }
 
 template <int B, int M>
-int TriviallyZero2d(BaseCorr2* corr, Coord coords,
-                    double x1, double y1, double z1, double s1,
-                    double x2, double y2, double z2, double s2)
+int TriviallyZero2(BaseCorr2* corr, Coord coords,
+                   double x1, double y1, double z1, double s1,
+                   double x2, double y2, double z2, double s2)
 {
     switch(coords) {
       case Flat:
            Assert((MetricHelper<M,0>::_Flat == int(Flat)));
-           return TriviallyZero2e<B,M,MetricHelper<M,0>::_Flat>(
+           return TriviallyZero3<B,M,MetricHelper<M,0>::_Flat>(
                corr, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case Sphere:
            Assert((MetricHelper<M,0>::_Sphere == int(Sphere)));
-           return TriviallyZero2e<B,M,MetricHelper<M,0>::_Sphere>(
+           return TriviallyZero3<B,M,MetricHelper<M,0>::_Sphere>(
                corr, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case ThreeD:
            Assert((MetricHelper<M,0>::_ThreeD == int(ThreeD)));
-           return TriviallyZero2e<B,M,MetricHelper<M,0>::_ThreeD>(
+           return TriviallyZero3<B,M,MetricHelper<M,0>::_ThreeD>(
                corr, x1, y1, z1, s1, x2, y2, z2, s2);
       default:
            Assert(false);
@@ -1062,28 +1062,28 @@ int TriviallyZero2d(BaseCorr2* corr, Coord coords,
 }
 
 template <int B>
-int TriviallyZero2c(BaseCorr2* corr, Metric metric, Coord coords,
-                    double x1, double y1, double z1, double s1,
-                    double x2, double y2, double z2, double s2)
+int TriviallyZero1(BaseCorr2* corr, Metric metric, Coord coords,
+                   double x1, double y1, double z1, double s1,
+                   double x2, double y2, double z2, double s2)
 {
     switch(metric) {
       case Euclidean:
-           return TriviallyZero2d<B,Euclidean>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero2<B,Euclidean>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case Rperp:
-           return TriviallyZero2d<B,Rperp>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero2<B,Rperp>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case OldRperp:
-           return TriviallyZero2d<B,OldRperp>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero2<B,OldRperp>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case Rlens:
-           return TriviallyZero2d<B,Rlens>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero2<B,Rlens>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case Arc:
-           return TriviallyZero2d<B,Arc>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero2<B,Arc>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case Periodic:
-           return TriviallyZero2d<B,Periodic>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero2<B,Periodic>(corr, coords, x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       default:
            Assert(false);
@@ -1097,16 +1097,16 @@ int TriviallyZero(BaseCorr2* corr, BinType bin_type, Metric metric, Coord coords
 {
     switch(bin_type) {
       case Log:
-           return TriviallyZero2c<Log>(corr, metric, coords,
-                                       x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero1<Log>(corr, metric, coords,
+                                      x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case Linear:
-           return TriviallyZero2c<Linear>(corr, metric, coords,
-                                          x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero1<Linear>(corr, metric, coords,
+                                         x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       case TwoD:
-           return TriviallyZero2c<TwoD>(corr, metric, coords,
-                                        x1, y1, z1, s1, x2, y2, z2, s2);
+           return TriviallyZero1<TwoD>(corr, metric, coords,
+                                       x1, y1, z1, s1, x2, y2, z2, s2);
            break;
       default:
            Assert(false);

--- a/src/Corr2.cpp
+++ b/src/Corr2.cpp
@@ -852,9 +852,9 @@ Corr2<D1,D2>* BuildCorr2(
 }
 
 template <int B, int M, int C>
-void ProcessAuto2(BaseCorr2* corr, BaseField<C>* field, bool dots)
+void ProcessAuto2(BaseCorr2& corr, BaseField<C>& field, bool dots)
 {
-    const bool P = corr->nontrivialRPar();
+    const bool P = corr.nontrivialRPar();
     dbg<<"ProcessAuto: coords = "<<C<<", metric = "<<M<<", P = "<<P<<std::endl;
 
     // Only call the actual function if the M/C combination is valid.
@@ -865,14 +865,14 @@ void ProcessAuto2(BaseCorr2* corr, BaseField<C>* field, bool dots)
     Assert((ValidMC<M,C>::_M == M));
     if (P) {
         Assert(C == ThreeD);
-        corr->template process<B, ValidMC<M,C>::_M, (C==ThreeD)>(*field, dots);
+        corr.template process<B, ValidMC<M,C>::_M, (C==ThreeD)>(field, dots);
     } else {
-        corr->template process<B, ValidMC<M,C>::_M, false>(*field, dots);
+        corr.template process<B, ValidMC<M,C>::_M, false>(field, dots);
     }
 }
 
 template <int B, int C>
-void ProcessAuto1(BaseCorr2* corr, BaseField<C>* field, bool dots, Metric metric)
+void ProcessAuto1(BaseCorr2& corr, BaseField<C>& field, bool dots, Metric metric)
 {
     switch(metric) {
       case Euclidean:
@@ -899,7 +899,7 @@ void ProcessAuto1(BaseCorr2* corr, BaseField<C>* field, bool dots, Metric metric
 }
 
 template <int C>
-void ProcessAuto(BaseCorr2* corr, BaseField<C>* field, bool dots, BinType bin_type, Metric metric)
+void ProcessAuto(BaseCorr2& corr, BaseField<C>& field, bool dots, BinType bin_type, Metric metric)
 {
     switch(bin_type) {
       case Log:
@@ -917,22 +917,22 @@ void ProcessAuto(BaseCorr2* corr, BaseField<C>* field, bool dots, BinType bin_ty
 }
 
 template <int B, int M, int C>
-void ProcessCross2(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2, bool dots)
+void ProcessCross2(BaseCorr2& corr, BaseField<C>& field1, BaseField<C>& field2, bool dots)
 {
-    const bool P = corr->nontrivialRPar();
+    const bool P = corr.nontrivialRPar();
     dbg<<"ProcessCross: coords = "<<C<<", metric = "<<M<<", P = "<<P<<std::endl;
 
     Assert((ValidMC<M,C>::_M == M));
     if (P) {
         Assert(C == ThreeD);
-        corr->template process<B, ValidMC<M,C>::_M, C==ThreeD>(*field1, *field2, dots);
+        corr.template process<B, ValidMC<M,C>::_M, C==ThreeD>(field1, field2, dots);
     } else {
-        corr->template process<B, ValidMC<M,C>::_M, false>(*field1, *field2, dots);
+        corr.template process<B, ValidMC<M,C>::_M, false>(field1, field2, dots);
     }
 }
 
 template <int B, int C>
-void ProcessCross1(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
+void ProcessCross1(BaseCorr2& corr, BaseField<C>& field1, BaseField<C>& field2,
                    bool dots, Metric metric)
 {
     switch(metric) {
@@ -960,7 +960,7 @@ void ProcessCross1(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
 }
 
 template <int C>
-void ProcessCross(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
+void ProcessCross(BaseCorr2& corr, BaseField<C>& field1, BaseField<C>& field2,
                   bool dots, BinType bin_type, Metric metric)
 {
     dbg<<"Start ProcessCross: "<<bin_type<<" "<<metric<<std::endl;
@@ -999,7 +999,7 @@ int GetOMPThreads()
 }
 
 template <int C>
-long SamplePairs(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
+long SamplePairs(BaseCorr2& corr, BaseField<C>& field1, BaseField<C>& field2,
                  double minsep, double maxsep, BinType bin_type, Metric metric, long long seed,
                  py::array_t<long>& i1p, py::array_t<long>& i2p, py::array_t<double>& sepp)
 {
@@ -1015,28 +1015,28 @@ long SamplePairs(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
 
     dbg<<"Start SamplePairs: "<<bin_type<<" "<<metric<<std::endl;
 
-    Sampler sampler(*corr, minsep, maxsep, i1, i2, sep, n);
+    Sampler sampler(corr, minsep, maxsep, i1, i2, sep, n);
 
     // I don't know how to do the sampling safely in parallel, so temporarily set num_threads=1.
     int old_num_threads = SetOMPThreads(1);
-    ProcessCross(&sampler, field1, field2, false, bin_type, metric);
+    ProcessCross(sampler, field1, field2, false, bin_type, metric);
     SetOMPThreads(old_num_threads);
 
     return sampler.getK();
 }
 
 template <int B, int M, int C>
-int TriviallyZero3(BaseCorr2* corr,
+int TriviallyZero3(BaseCorr2& corr,
                    double x1, double y1, double z1, double s1,
                    double x2, double y2, double z2, double s2)
 {
     Position<C> p1(x1,y1,z1);
     Position<C> p2(x2,y2,z2);
-    return corr->template triviallyZero<B,M>(p1, p2, s1, s2);
+    return corr.template triviallyZero<B,M>(p1, p2, s1, s2);
 }
 
 template <int B, int M>
-int TriviallyZero2(BaseCorr2* corr, Coord coords,
+int TriviallyZero2(BaseCorr2& corr, Coord coords,
                    double x1, double y1, double z1, double s1,
                    double x2, double y2, double z2, double s2)
 {
@@ -1062,7 +1062,7 @@ int TriviallyZero2(BaseCorr2* corr, Coord coords,
 }
 
 template <int B>
-int TriviallyZero1(BaseCorr2* corr, Metric metric, Coord coords,
+int TriviallyZero1(BaseCorr2& corr, Metric metric, Coord coords,
                    double x1, double y1, double z1, double s1,
                    double x2, double y2, double z2, double s2)
 {
@@ -1091,7 +1091,7 @@ int TriviallyZero1(BaseCorr2* corr, Metric metric, Coord coords,
     return 0;
 }
 
-int TriviallyZero(BaseCorr2* corr, BinType bin_type, Metric metric, Coord coords,
+int TriviallyZero(BaseCorr2& corr, BinType bin_type, Metric metric, Coord coords,
                   double x1, double y1, double z1, double s1,
                   double x2, double y2, double z2, double s2)
 {
@@ -1134,16 +1134,16 @@ void WrapCorr2(py::module& _treecorr, std::string prefix)
 template <int C, typename W>
 void WrapProcess(py::module& _treecorr, W& base_corr2)
 {
-    typedef void (*auto_type)(BaseCorr2* corr, BaseField<C>* field,
+    typedef void (*auto_type)(BaseCorr2& corr, BaseField<C>& field,
                               bool dots, BinType bin_type, Metric metric);
     base_corr2.def("processAuto", auto_type(&ProcessAuto));
 
-    typedef void (*cross_type)(BaseCorr2* corr, BaseField<C>* field1, BaseField<C>* field2,
+    typedef void (*cross_type)(BaseCorr2& corr, BaseField<C>& field1, BaseField<C>& field2,
                                bool dots, BinType bin_type, Metric metric);
     base_corr2.def("processCross", cross_type(&ProcessCross));
 
-    typedef long (*sample_type)(BaseCorr2* corr,
-                                BaseField<C>* field1, BaseField<C>* field2,
+    typedef long (*sample_type)(BaseCorr2& corr,
+                                BaseField<C>& field1, BaseField<C>& field2,
                                 double minsep, double maxsep,
                                 BinType bin_type, Metric metric, long long seed,
                                 py::array_t<long>& i1p, py::array_t<long>& i2p,

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -153,36 +153,36 @@ void Corr3<D1,D2,D3>::clear()
 template <int D1, int D2, int D3, int B, int M, int C>
 struct ProcessHelper
 {
-    static void process3(Corr3<D1,D2,D3>& , const Cell<D1,C>*, const MetricHelper<M,0>&) {}
-    static void process12(Corr3<D1,D2,D3>& , const Cell<D1,C>*, const Cell<D2,C>*,
+    static void process3(Corr3<D1,D2,D3>& , const BaseCell<C>*, const MetricHelper<M,0>&) {}
+    static void process12(Corr3<D1,D2,D3>& , const BaseCell<C>*, const BaseCell<C>*,
                           const MetricHelper<M,0>&) {}
-    static void process111(Corr3<D1,D2,D3>& , const Cell<D1,C>*, const Cell<D2,C>*,
-                           const Cell<D3,C>*, const MetricHelper<M,0>&) {}
+    static void process111(Corr3<D1,D2,D3>& , const BaseCell<C>*, const BaseCell<C>*,
+                           const BaseCell<C>*, const MetricHelper<M,0>&) {}
     static void process12(Corr3<D1,D2,D2>& , Corr3<D2,D1,D2>& , Corr3<D2,D2,D1>& ,
-                          const Cell<D1,C>* , const Cell<D2,C>* ,
+                          const BaseCell<C>* , const BaseCell<C>* ,
                           const MetricHelper<M,0>& ) {}
     static void process111(Corr3<D1,D2,D2>& , Corr3<D2,D1,D2>& , Corr3<D2,D2,D1>& ,
-                           const Cell<D1,C>* , const Cell<D2,C>* , const Cell<D2,C>*,
+                           const BaseCell<C>* , const BaseCell<C>* , const BaseCell<C>*,
                            const MetricHelper<M,0>& ) {}
 };
 
 template <int D1, int D2, int B, int M, int C>
 struct ProcessHelper<D1,D2,D2,B,M,C>
 {
-    static void process3(Corr3<D1,D2,D2>& b, const Cell<D1,C>*, const MetricHelper<M,0>&) {}
+    static void process3(Corr3<D1,D2,D2>& b, const BaseCell<C>*, const MetricHelper<M,0>&) {}
     static void process12(Corr3<D1,D2,D2>& b,
-                          const Cell<D1,C>* , const Cell<D2,C>*,
+                          const BaseCell<C>* , const BaseCell<C>*,
                           const MetricHelper<M,0>&) {}
     static void process111(Corr3<D1,D2,D2>& b,
-                           const Cell<D1,C>* , const Cell<D2,C>*, const Cell<D2,C>*,
+                           const BaseCell<C>* , const BaseCell<C>*, const BaseCell<C>*,
                            const MetricHelper<M,0>&) {}
     static void process12(Corr3<D1,D2,D2>& b122, Corr3<D2,D1,D2>& b212, Corr3<D2,D2,D1>& b221,
-                          const Cell<D1,C>* c1, const Cell<D2,C>* c2,
+                          const BaseCell<C>* c1, const BaseCell<C>* c2,
                           const MetricHelper<M,0>& metric)
     { b122.template process12<B>(b212,b221,c1,c2, metric); }
     static void process111(Corr3<D1,D2,D2>& b122, Corr3<D2,D1,D2>& b212,
                            Corr3<D2,D2,D1>& b221,
-                           const Cell<D1,C>* c1, const Cell<D2,C>* c2, const Cell<D2,C>* c3,
+                           const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
                            const MetricHelper<M,0>& metric)
     { b122.template process111<B>(b122,b212,b221,b212,b221,c1,c2,c3, metric); }
 };
@@ -190,23 +190,23 @@ struct ProcessHelper<D1,D2,D2,B,M,C>
 template <int D, int B, int M, int C>
 struct ProcessHelper<D,D,D,B,M,C>
 {
-    static void process3(Corr3<D,D,D>& b, const Cell<D,C>* c1,
+    static void process3(Corr3<D,D,D>& b, const BaseCell<C>* c1,
                          const MetricHelper<M,0>& metric)
     { b.template process3<B>(c1, metric); }
     static void process12(Corr3<D,D,D>& b,
-                          const Cell<D,C>* c1, const Cell<D,C>* c2,
+                          const BaseCell<C>* c1, const BaseCell<C>* c2,
                           const MetricHelper<M,0>& metric)
     { b.template process12<B>(b,b,c1,c2, metric); }
     static void process111(Corr3<D,D,D>& b,
-                           const Cell<D,C>* c1, const Cell<D,C>* c2, const Cell<D,C>* c3,
+                           const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
                            const MetricHelper<M,0>& metric)
     { b.template process111<B>(b,b,b,b,b,c1,c2,c3, metric); }
     static void process12(Corr3<D,D,D>& b122, Corr3<D,D,D>& b212, Corr3<D,D,D>& b221,
-                          const Cell<D,C>* c1, const Cell<D,C>* c2,
+                          const BaseCell<C>* c1, const BaseCell<C>* c2,
                           const MetricHelper<M,0>& metric)
     { b122.template process12<B>(b212,b221,c1,c2, metric); }
     static void process111(Corr3<D,D,D>& b122, Corr3<D,D,D>& b212, Corr3<D,D,D>& b221,
-                           const Cell<D,C>* c1, const Cell<D,C>* c2, const Cell<D,C>* c3,
+                           const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
                            const MetricHelper<M,0>& metric)
     { b122.template process111<B>(b122,b212,b221,b212,b221,c1,c2,c3, metric); }
 };
@@ -238,7 +238,7 @@ void Corr3<D1,D2,D3>::process(const Field<D1,C>& field, bool dots)
 #pragma omp for schedule(dynamic)
 #endif
         for (long i=0;i<n1;++i) {
-            const Cell<D1,C>* c1 = field.getCells()[i];
+            const BaseCell<C>* c1 = field.getCells()[i];
 #ifdef _OPENMP
 #pragma omp critical
 #endif
@@ -254,11 +254,11 @@ void Corr3<D1,D2,D3>::process(const Field<D1,C>& field, bool dots)
             }
             ProcessHelper<D1,D2,D3,B,M,C>::process3(bc3,c1, metric);
             for (long j=i+1;j<n1;++j) {
-                const Cell<D1,C>* c2 = field.getCells()[j];
+                const BaseCell<C>* c2 = field.getCells()[j];
                 ProcessHelper<D1,D2,D3,B,M,C>::process12(bc3,c1,c2, metric);
                 ProcessHelper<D1,D2,D3,B,M,C>::process12(bc3,c2,c1, metric);
                 for (long k=j+1;k<n1;++k) {
-                    const Cell<D1,C>* c3 = field.getCells()[k];
+                    const BaseCell<C>* c3 = field.getCells()[k];
                     ProcessHelper<D1,D2,D3,B,M,C>::process111(bc3,c1,c2,c3, metric);
                 }
             }
@@ -297,13 +297,13 @@ void Corr3<D1,D2,D3>::process(Corr3<D2,D1,D2>* corr212, Corr3<D2,D2,D1>* corr221
         xdbg<<"field1: \n";
         for (long i=0;i<n1;++i) {
             xdbg<<"node "<<i<<std::endl;
-            const Cell<D1,C>* c1 = field1.getCells()[i];
+            const BaseCell<C>* c1 = field1.getCells()[i];
             c1->WriteTree(get_dbgout());
         }
         xdbg<<"field2: \n";
         for (long i=0;i<n2;++i) {
             xdbg<<"node "<<i<<std::endl;
-            const Cell<D2,C>* c2 = field2.getCells()[i];
+            const BaseCell<C>* c2 = field2.getCells()[i];
             c2->WriteTree(get_dbgout());
         }
     }
@@ -335,12 +335,12 @@ void Corr3<D1,D2,D3>::process(Corr3<D2,D1,D2>* corr212, Corr3<D2,D2,D1>* corr221
                 dbg<<omp_get_thread_num()<<" "<<i<<std::endl;
 #endif
             }
-            const Cell<D1,C>* c1 = field1.getCells()[i];
+            const BaseCell<C>* c1 = field1.getCells()[i];
             for (long j=0;j<n2;++j) {
-                const Cell<D2,C>* c2 = field2.getCells()[j];
+                const BaseCell<C>* c2 = field2.getCells()[j];
                 ProcessHelper<D1,D2,D3,B,M,C>::process12(bc122,bc212,bc221, c1,c2, metric);
                 for (long k=j+1;k<n2;++k) {
-                    const Cell<D2,C>* c3 = field2.getCells()[k];
+                    const BaseCell<C>* c3 = field2.getCells()[k];
                     ProcessHelper<D1,D2,D3,B,M,C>::process111(bc122,bc212,bc221, c1,c2,c3, metric);
                 }
             }
@@ -386,19 +386,19 @@ void Corr3<D1,D2,D3>::process(Corr3<D1,D3,D2>* corr132,
         xdbg<<"field1: \n";
         for (long i=0;i<n1;++i) {
             xdbg<<"node "<<i<<std::endl;
-            const Cell<D1,C>* c1 = field1.getCells()[i];
+            const BaseCell<C>* c1 = field1.getCells()[i];
             c1->WriteTree(get_dbgout());
         }
         xdbg<<"field2: \n";
         for (long i=0;i<n2;++i) {
             xdbg<<"node "<<i<<std::endl;
-            const Cell<D2,C>* c2 = field2.getCells()[i];
+            const BaseCell<C>* c2 = field2.getCells()[i];
             c2->WriteTree(get_dbgout());
         }
         xdbg<<"field3: \n";
         for (long i=0;i<n3;++i) {
             xdbg<<"node "<<i<<std::endl;
-            const Cell<D3,C>* c3 = field3.getCells()[i];
+            const BaseCell<C>* c3 = field3.getCells()[i];
             c3->WriteTree(get_dbgout());
         }
     }
@@ -436,11 +436,11 @@ void Corr3<D1,D2,D3>::process(Corr3<D1,D3,D2>* corr132,
                 dbg<<omp_get_thread_num()<<" "<<i<<std::endl;
 #endif
             }
-            const Cell<D1,C>* c1 = field1.getCells()[i];
+            const BaseCell<C>* c1 = field1.getCells()[i];
             for (long j=0;j<n2;++j) {
-                const Cell<D2,C>* c2 = field2.getCells()[j];
+                const BaseCell<C>* c2 = field2.getCells()[j];
                 for (long k=0;k<n3;++k) {
-                    const Cell<D3,C>* c3 = field3.getCells()[k];
+                    const BaseCell<C>* c3 = field3.getCells()[k];
                     bc123.template process111<B>(
                         bc132, bc213, bc231, bc312, bc321,
                         c1, c2, c3, metric);
@@ -464,7 +464,7 @@ void Corr3<D1,D2,D3>::process(Corr3<D1,D3,D2>* corr132,
 }
 
 template <int D1, int D2, int D3> template <int B, int M, int C>
-void Corr3<D1,D2,D3>::process3(const Cell<D1,C>* c1, const MetricHelper<M,0>& metric)
+void Corr3<D1,D2,D3>::process3(const BaseCell<C>* c1, const MetricHelper<M,0>& metric)
 {
     // Does all triangles with 3 points in c1
     xdbg<<"Process3: c1 = "<<c1->getData().getPos()<<"  "<<"  "<<c1->getSize()<<"  "<<c1->getData().getN()<<std::endl;
@@ -487,7 +487,7 @@ void Corr3<D1,D2,D3>::process3(const Cell<D1,C>* c1, const MetricHelper<M,0>& me
 
 template <int D1, int D2, int D3> template <int B, int M, int C>
 void Corr3<D1,D2,D3>::process12(Corr3<D2,D1,D2>& bc212, Corr3<D2,D2,D1>& bc221,
-                                const Cell<D1,C>* c1, const Cell<D2,C>* c2,
+                                const BaseCell<C>* c1, const BaseCell<C>* c2,
                                 const MetricHelper<M,0>& metric)
 {
     // Does all triangles with one point in c1 and the other two points in c2
@@ -661,7 +661,7 @@ void Corr3<D1,D2,D3>::process111(
     Corr3<D1,D3,D2>& bc132,
     Corr3<D2,D1,D3>& bc213, Corr3<D2,D3,D1>& bc231,
     Corr3<D3,D1,D2>& bc312, Corr3<D3,D2,D1>& bc321,
-    const Cell<D1,C>* c1, const Cell<D2,C>* c2, const Cell<D3,C>* c3,
+    const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
     const MetricHelper<M,0>& metric, double d1sq, double d2sq, double d3sq)
 {
     // Does all triangles with 1 point each in c1, c2, c3
@@ -734,7 +734,7 @@ void Corr3<D1,D2,D3>::process111Sorted(
     Corr3<D1,D3,D2>& bc132,
     Corr3<D2,D1,D3>& bc213, Corr3<D2,D3,D1>& bc231,
     Corr3<D3,D1,D2>& bc312, Corr3<D3,D2,D1>& bc321,
-    const Cell<D1,C>* c1, const Cell<D2,C>* c2, const Cell<D3,C>* c3,
+    const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
     const MetricHelper<M,0>& metric, double d1sq, double d2sq, double d3sq)
 {
     const double s1 = c1->getSize();
@@ -1153,7 +1153,7 @@ struct DirectHelper<GData,GData,GData>
 
 template <int D1, int D2, int D3> template <int B, int C>
 void Corr3<D1,D2,D3>::directProcess111(
-    const Cell<D1,C>& c1, const Cell<D2,C>& c2, const Cell<D3,C>& c3,
+    const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
     const double d1, const double d2, const double d3,
     const double logr, const double u, const double v, const int index)
 {
@@ -1174,7 +1174,11 @@ void Corr3<D1,D2,D3>::directProcess111(
     _meanv[index] += www * v;
     _weight[index] += www;
 
-    DirectHelper<D1,D2,D3>::template ProcessZeta<C>(c1,c2,c3,d1,d2,d3,_zeta,index);
+    DirectHelper<D1,D2,D3>::template ProcessZeta<C>(
+        static_cast<const Cell<D1,C>&>(c1),
+        static_cast<const Cell<D2,C>&>(c2),
+        static_cast<const Cell<D3,C>&>(c3),
+        d1,d2,d3,_zeta,index);
 }
 
 template <int D1, int D2, int D3>

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -1264,232 +1264,182 @@ Corr3<D1,D2,D3>* BuildCorr3(
             meanu, meanv, weight, ntri);
 }
 
-template <int B, int M, int D>
-void ProcessAuto3e(Corr3<D,D,D>* corr, BaseField<D>* field, bool dots, Coord coords)
+template <int B, int M, int D, int C>
+void ProcessAuto3e(Corr3<D,D,D>* corr, Field<D,C>* field, bool dots)
 {
-    switch(coords) {
-      case Flat:
-           Assert((MetricHelper<M,0>::_Flat == int(Flat)));
-           corr->template process<B,M>(
-               *static_cast<Field<D,MetricHelper<M,0>::_Flat>*>(field), dots);
-           break;
-      case Sphere:
-           Assert((MetricHelper<M,0>::_Sphere == int(Sphere)));
-           corr->template process<B,M>(
-               *static_cast<Field<D,MetricHelper<M,0>::_Sphere>*>(field), dots);
-           break;
-      case ThreeD:
-           Assert((MetricHelper<M,0>::_ThreeD == int(ThreeD)));
-           corr->template process<B,M>(
-               *static_cast<Field<D,MetricHelper<M,0>::_ThreeD>*>(field), dots);
-           break;
-      default:
-           Assert(false);
-    }
+    Assert((ValidMC<M,C>::_M == M));
+    corr->template process<B,ValidMC<M,C>::_M>(*field, dots);
 }
 
-template <int B, int D>
-void ProcessAuto3d(Corr3<D,D,D>* corr, BaseField<D>* field, bool dots, Coord coords, Metric metric)
+template <int B, int D, int C>
+void ProcessAuto3d(Corr3<D,D,D>* corr, Field<D,C>* field, bool dots, Metric metric)
 {
     switch(metric) {
       case Euclidean:
-           ProcessAuto3e<B,Euclidean>(corr, field, dots, coords);
+           ProcessAuto3e<B,Euclidean>(corr, field, dots);
            break;
       case Arc:
-           ProcessAuto3e<B,Arc>(corr, field, dots, coords);
+           ProcessAuto3e<B,Arc>(corr, field, dots);
            break;
       case Periodic:
-           ProcessAuto3e<B,Periodic>(corr, field, dots, coords);
+           ProcessAuto3e<B,Periodic>(corr, field, dots);
            break;
       default:
            Assert(false);
     }
 }
 
-template <int D>
-void ProcessAuto(Corr3<D,D,D>* corr, BaseField<D>* field,
-                 bool dots, Coord coords, BinType bin_type, Metric metric)
+template <int D, int C>
+void ProcessAuto(Corr3<D,D,D>* corr, Field<D,C>* field,
+                 bool dots, BinType bin_type, Metric metric)
 {
-    dbg<<"Start ProcessAuto "<<D<<" "<<coords<<" "<<bin_type<<" "<<metric<<std::endl;
+    dbg<<"Start ProcessAuto "<<D<<" "<<bin_type<<" "<<metric<<std::endl;
     Assert(bin_type == Log);
 
-    ProcessAuto3d<Log>(corr, field, dots, coords, metric);
+    ProcessAuto3d<Log>(corr, field, dots, metric);
 }
 
-template <int B, int M, int D1, int D2>
+template <int B, int M, int D1, int D2, int C>
 void ProcessCross12e(Corr3<D1,D2,D2>* corr122, Corr3<D2,D1,D2>* corr212,
                      Corr3<D2,D2,D1>* corr221,
-                     BaseField<D1>* field1, BaseField<D2>* field2, bool dots, Coord coords)
+                     Field<D1,C>* field1, Field<D2,C>* field2, bool dots)
 {
-    switch(coords) {
-      case Flat:
-           Assert((MetricHelper<M,0>::_Flat == int(Flat)));
-           corr122->template process<B,M>(
-               corr212, corr221,
-               *static_cast<Field<D1,MetricHelper<M,0>::_Flat>*>(field1),
-               *static_cast<Field<D2,MetricHelper<M,0>::_Flat>*>(field2), dots);
-           break;
-      case Sphere:
-           Assert((MetricHelper<M,0>::_Sphere == int(Sphere)));
-           corr122->template process<B,M>(
-               corr212, corr221,
-               *static_cast<Field<D1,MetricHelper<M,0>::_Sphere>*>(field1),
-               *static_cast<Field<D2,MetricHelper<M,0>::_Sphere>*>(field2), dots);
-           break;
-      case ThreeD:
-           Assert((MetricHelper<M,0>::_ThreeD == int(ThreeD)));
-           corr122->template process<B,M>(
-               corr212, corr221,
-               *static_cast<Field<D1,MetricHelper<M,0>::_ThreeD>*>(field1),
-               *static_cast<Field<D2,MetricHelper<M,0>::_ThreeD>*>(field2), dots);
-           break;
-      default:
-           Assert(false);
-    }
+    Assert((ValidMC<M,C>::_M == M));
+    corr122->template process<B,ValidMC<M,C>::_M>(corr212, corr221, *field1, *field2, dots);
 }
 
-template <int D1, int D2>
+template <int D1, int D2, int C>
 void ProcessCross12(Corr3<D1,D2,D2>* corr122, Corr3<D2,D1,D2>* corr212, Corr3<D2,D2,D1>* corr221,
-                    BaseField<D1>* field1, BaseField<D2>* field2,
-                    bool dots, Coord coords, BinType bin_type, Metric metric)
+                    Field<D1,C>* field1, Field<D2,C>* field2,
+                    bool dots, BinType bin_type, Metric metric)
 {
     Assert(bin_type == Log);
     switch(metric) {
       case Euclidean:
            ProcessCross12e<Log,Euclidean>(corr122, corr212, corr221,
-                                          field1, field2, dots, coords);
+                                          field1, field2, dots);
            break;
       case Arc:
            ProcessCross12e<Log,Arc>(corr122, corr212, corr221,
-                                    field1, field2, dots, coords);
+                                    field1, field2, dots);
            break;
       case Periodic:
            ProcessCross12e<Log,Periodic>(corr122, corr212, corr221,
-                                         field1, field2, dots, coords);
+                                         field1, field2, dots);
            break;
       default:
            Assert(false);
     }
 }
 
-template <int B, int M, int D1, int D2, int D3>
+template <int B, int M, int D1, int D2, int D3, int C>
 void ProcessCross3e(Corr3<D1,D2,D3>* corr123, Corr3<D1,D3,D2>* corr132,
                     Corr3<D2,D1,D3>* corr213, Corr3<D2,D3,D1>* corr231,
                     Corr3<D3,D1,D2>* corr312, Corr3<D3,D2,D1>* corr321,
-                    BaseField<D1>* field1, BaseField<D2>* field2, BaseField<D3>* field3,
-                    bool dots, Coord coords)
+                    Field<D1,C>* field1, Field<D2,C>* field2, Field<D3,C>* field3,
+                    bool dots)
 {
-    switch(coords) {
-      case Flat:
-           Assert((MetricHelper<M,0>::_Flat == int(Flat)));
-           corr123->template process<B,M>(
+    Assert((ValidMC<M,C>::_M == M));
+    corr123->template process<B,ValidMC<M,C>::_M>(
                corr132, corr213, corr231, corr312, corr321,
-               *static_cast<Field<D1,MetricHelper<M,0>::_Flat>*>(field1),
-               *static_cast<Field<D2,MetricHelper<M,0>::_Flat>*>(field2),
-               *static_cast<Field<D3,MetricHelper<M,0>::_Flat>*>(field3), dots);
-           break;
-      case Sphere:
-           Assert((MetricHelper<M,0>::_Sphere == int(Sphere)));
-           corr123->template process<B,M>(
-               corr132, corr213, corr231, corr312, corr321,
-               *static_cast<Field<D1,MetricHelper<M,0>::_Sphere>*>(field1),
-               *static_cast<Field<D2,MetricHelper<M,0>::_Sphere>*>(field2),
-               *static_cast<Field<D3,MetricHelper<M,0>::_Sphere>*>(field3), dots);
-           break;
-      case ThreeD:
-           Assert((MetricHelper<M,0>::_ThreeD == int(ThreeD)));
-           corr123->template process<B,M>(
-               corr132, corr213, corr231, corr312, corr321,
-               *static_cast<Field<D1,MetricHelper<M,0>::_ThreeD>*>(field1),
-               *static_cast<Field<D2,MetricHelper<M,0>::_ThreeD>*>(field2),
-               *static_cast<Field<D3,MetricHelper<M,0>::_ThreeD>*>(field3), dots);
-           break;
-      default:
-           Assert(false);
-    }
+               *field1, *field2, *field3, dots);
 }
 
-template <int B, int D1, int D2, int D3>
+template <int B, int D1, int D2, int D3, int C>
 void ProcessCross3d(Corr3<D1,D2,D3>* corr123, Corr3<D1,D3,D2>* corr132,
                     Corr3<D2,D1,D3>* corr213, Corr3<D2,D3,D1>* corr231,
                     Corr3<D3,D1,D2>* corr312, Corr3<D3,D2,D1>* corr321,
-                    BaseField<D1>* field1, BaseField<D2>* field2, BaseField<D3>* field3,
-                    bool dots, Coord coords, Metric metric)
+                    Field<D1,C>* field1, Field<D2,C>* field2, Field<D3,C>* field3,
+                    bool dots, Metric metric)
 {
     switch(metric) {
       case Euclidean:
            ProcessCross3e<B,Euclidean>(corr123, corr132, corr213, corr231, corr312, corr321,
-                                       field1, field2, field3, dots, coords);
+                                       field1, field2, field3, dots);
            break;
       case Arc:
            ProcessCross3e<B,Arc>(corr123, corr132, corr213, corr231, corr312, corr321,
-                                 field1, field2, field3, dots, coords);
+                                 field1, field2, field3, dots);
            break;
       case Periodic:
            ProcessCross3e<B,Periodic>(corr123, corr132, corr213, corr231, corr312, corr321,
-                                      field1, field2, field3, dots, coords);
+                                      field1, field2, field3, dots);
            break;
       default:
            Assert(false);
     }
 }
 
-template <int D1, int D2, int D3>
+template <int D1, int D2, int D3, int C>
 void ProcessCross(Corr3<D1,D2,D3>* corr123, Corr3<D1,D3,D2>* corr132, Corr3<D2,D1,D3>* corr213,
                   Corr3<D2,D3,D1>* corr231, Corr3<D3,D1,D2>* corr312, Corr3<D3,D2,D1>* corr321,
-                  BaseField<D1>* field1, BaseField<D2>* field2, BaseField<D3>* field3,
-                  bool dots, Coord coords, BinType bin_type, Metric metric)
+                  Field<D1,C>* field1, Field<D2,C>* field2, Field<D3,C>* field3,
+                  bool dots, BinType bin_type, Metric metric)
 {
-    dbg<<"Start ProcessCross3 "<<D1<<" "<<D2<<" "<<D3<<" "<<coords<<" "<<bin_type<<" "<<metric<<std::endl;
+    dbg<<"Start ProcessCross3 "<<D1<<" "<<D2<<" "<<D3<<" "<<bin_type<<" "<<metric<<std::endl;
 
     Assert(D2 == D1);
     Assert(D3 == D1);
     Assert(bin_type == Log);
 
     ProcessCross3d<Log>(corr123, corr132, corr213, corr231, corr312, corr321,
-                        field1, field2, field3, dots, coords, metric);
+                        field1, field2, field3, dots, metric);
 }
 
 // Export the above functions using pybind11
 
-template <int D1, int D2, int D3>
+template <int D1, int D2, int D3, int C>
 struct WrapAuto
 {
-    template <typename C>
-    static void run(C& corr3) {}
+    template <typename W>
+    static void run(W& corr3) {}
 };
 
-template <int D1, int D2>
-struct WrapAuto<D1,D2,D2>
+template <int D1, int D2, int C>
+struct WrapAuto<D1,D2,D2,C>
 {
-    template <typename C>
-    static void run(C& corr3)
+    template <typename W>
+    static void run(W& corr3)
     {
         typedef void (*cross12_type)(Corr3<D1,D2,D2>* corr122, Corr3<D2,D1,D2>* corr212,
                                      Corr3<D2,D2,D1>* corr221,
-                                     BaseField<D1>* field1, BaseField<D2>* field2,
-                                     bool dots, Coord coords, BinType bin_type, Metric metric);
+                                     Field<D1,C>* field1, Field<D2,C>* field2,
+                                     bool dots, BinType bin_type, Metric metric);
         corr3.def("processCross12", cross12_type(&ProcessCross12));
     }
 };
 
-template <int D>
-struct WrapAuto<D,D,D>
+template <int D, int C>
+struct WrapAuto<D,D,D,C>
 {
-    template <typename C>
-    static void run(C& corr3)
+    template <typename W>
+    static void run(W& corr3)
     {
-        typedef void (*auto_type)(Corr3<D,D,D>* corr, BaseField<D>* field,
-                                  bool dots, Coord coords, BinType bin_type, Metric metric);
+        typedef void (*auto_type)(Corr3<D,D,D>* corr, Field<D,C>* field,
+                                  bool dots, BinType bin_type, Metric metric);
         typedef void (*cross12_type)(Corr3<D,D,D>* corr122, Corr3<D,D,D>* corr212,
                                      Corr3<D,D,D>* corr221,
-                                     BaseField<D>* field1, BaseField<D>* field2,
-                                     bool dots, Coord coords, BinType bin_type, Metric metric);
+                                     Field<D,C>* field1, Field<D,C>* field2,
+                                     bool dots, BinType bin_type, Metric metric);
 
         corr3.def("processAuto", auto_type(&ProcessAuto));
         corr3.def("processCross12", cross12_type(&ProcessCross12));
     }
 };
+
+template <int D1, int D2, int D3, int C, typename W1, typename W2>
+void WrapCoord(py::module& _treecorr, W1& corr3, W2& base_corr3)
+{
+    typedef void (*cross_type)(Corr3<D1,D2,D3>* corr123, Corr3<D1,D3,D2>* corr132,
+                               Corr3<D2,D1,D3>* corr213, Corr3<D2,D3,D1>* corr231,
+                               Corr3<D3,D1,D2>* corr312, Corr3<D3,D2,D1>* corr321,
+                               Field<D1,C>* field1, Field<D2,C>* field2, Field<D3,C>* field3,
+                               bool dots, BinType bin_type, Metric metric);
+
+    corr3.def("processCross", cross_type(&ProcessCross));
+    WrapAuto<D1,D2,D3,C>::run(corr3);
+}
+
 
 template <int D1, int D2, int D3, typename W>
 void WrapCorr3(py::module& _treecorr, std::string prefix, W& base_corr3)
@@ -1509,17 +1459,12 @@ void WrapCorr3(py::module& _treecorr, std::string prefix, W& base_corr3)
         py::array_t<double>& meanup, py::array_t<double>& meanvp,
         py::array_t<double>& weightp, py::array_t<double>& ntrip);
 
-    typedef void (*cross_type)(Corr3<D1,D2,D3>* corr123, Corr3<D1,D3,D2>* corr132,
-                               Corr3<D2,D1,D3>* corr213, Corr3<D2,D3,D1>* corr231,
-                               Corr3<D3,D1,D2>* corr312, Corr3<D3,D2,D1>* corr321,
-                               BaseField<D1>* field1, BaseField<D2>* field2, BaseField<D3>* field3,
-                               bool dots, Coord coords, BinType bin_type, Metric metric);
-
     py::class_<Corr3<D1,D2,D3>, BaseCorr3> corr3(_treecorr, (prefix + "Corr").c_str());
     corr3.def(py::init(init_type(&BuildCorr3)));
-    corr3.def("processCross", cross_type(&ProcessCross));
 
-    WrapAuto<D1,D2,D3>::run(corr3);
+    WrapCoord<D1,D2,D3,Flat>(_treecorr, corr3, base_corr3);
+    WrapCoord<D1,D2,D3,Sphere>(_treecorr, corr3, base_corr3);
+    WrapCoord<D1,D2,D3,ThreeD>(_treecorr, corr3, base_corr3);
 }
 
 void pyExportCorr3(py::module& _treecorr)

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -1432,7 +1432,7 @@ struct WrapAuto<D,D,D,C>
 };
 
 template <int D1, int D2, int D3, int C, typename W1, typename W2>
-void WrapCoord(py::module& _treecorr, W1& corr3, W2& base_corr3)
+void WrapCross(py::module& _treecorr, W1& corr3, W2& base_corr3)
 {
     typedef void (*cross_type)(Corr3<D1,D2,D3>* corr123, Corr3<D1,D3,D2>* corr132,
                                Corr3<D2,D1,D3>* corr213, Corr3<D2,D3,D1>* corr231,
@@ -1443,7 +1443,6 @@ void WrapCoord(py::module& _treecorr, W1& corr3, W2& base_corr3)
     corr3.def("processCross", cross_type(&ProcessCross));
     WrapAuto<D1,D2,D3,C>::run(corr3);
 }
-
 
 template <int D1, int D2, int D3, typename W>
 void WrapCorr3(py::module& _treecorr, std::string prefix, W& base_corr3)
@@ -1466,9 +1465,9 @@ void WrapCorr3(py::module& _treecorr, std::string prefix, W& base_corr3)
     py::class_<Corr3<D1,D2,D3>, BaseCorr3> corr3(_treecorr, (prefix + "Corr").c_str());
     corr3.def(py::init(init_type(&BuildCorr3)));
 
-    WrapCoord<D1,D2,D3,Flat>(_treecorr, corr3, base_corr3);
-    WrapCoord<D1,D2,D3,Sphere>(_treecorr, corr3, base_corr3);
-    WrapCoord<D1,D2,D3,ThreeD>(_treecorr, corr3, base_corr3);
+    WrapCross<D1,D2,D3,Flat>(_treecorr, corr3, base_corr3);
+    WrapCross<D1,D2,D3,Sphere>(_treecorr, corr3, base_corr3);
+    WrapCross<D1,D2,D3,ThreeD>(_treecorr, corr3, base_corr3);
 }
 
 void pyExportCorr3(py::module& _treecorr)

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -463,8 +463,8 @@ void Corr3<D1,D2,D3>::process(Corr3<D1,D3,D2>* corr132,
     if (dots) std::cout<<std::endl;
 }
 
-template <int D1, int D2, int D3> template <int B, int M, int C>
-void Corr3<D1,D2,D3>::process3(const BaseCell<C>* c1, const MetricHelper<M,0>& metric)
+template <int B, int M, int C>
+void BaseCorr3::process3(const BaseCell<C>* c1, const MetricHelper<M,0>& metric)
 {
     // Does all triangles with 3 points in c1
     xdbg<<"Process3: c1 = "<<c1->getData().getPos()<<"  "<<"  "<<c1->getSize()<<"  "<<c1->getData().getN()<<std::endl;
@@ -485,10 +485,10 @@ void Corr3<D1,D2,D3>::process3(const BaseCell<C>* c1, const MetricHelper<M,0>& m
     process12<B>(*this, *this, c1->getRight(),c1->getLeft(), metric);
 }
 
-template <int D1, int D2, int D3> template <int B, int M, int C>
-void Corr3<D1,D2,D3>::process12(Corr3<D2,D1,D2>& bc212, Corr3<D2,D2,D1>& bc221,
-                                const BaseCell<C>* c1, const BaseCell<C>* c2,
-                                const MetricHelper<M,0>& metric)
+template <int B, int M, int C>
+void BaseCorr3::process12(BaseCorr3& bc212, BaseCorr3& bc221,
+                          const BaseCell<C>* c1, const BaseCell<C>* c2,
+                          const MetricHelper<M,0>& metric)
 {
     // Does all triangles with one point in c1 and the other two points in c2
     xdbg<<"Process12: c1 = "<<c1->getData().getPos()<<"  "<<"  "<<c1->getSize()<<"  "<<c1->getData().getN()<<std::endl;
@@ -656,11 +656,9 @@ static bool stop111(
     return false;
 }
 
-template <int D1, int D2, int D3> template <int B, int M, int C>
-void Corr3<D1,D2,D3>::process111(
-    Corr3<D1,D3,D2>& bc132,
-    Corr3<D2,D1,D3>& bc213, Corr3<D2,D3,D1>& bc231,
-    Corr3<D3,D1,D2>& bc312, Corr3<D3,D2,D1>& bc321,
+template <int B, int M, int C>
+void BaseCorr3::process111(
+    BaseCorr3& bc132, BaseCorr3& bc213, BaseCorr3& bc231, BaseCorr3& bc312, BaseCorr3& bc321,
     const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
     const MetricHelper<M,0>& metric, double d1sq, double d2sq, double d3sq)
 {
@@ -689,7 +687,7 @@ void Corr3<D1,D2,D3>::process111(
 
     xdbg<<"Before sort: d123 = "<<sqrt(d1sq)<<"  "<<sqrt(d2sq)<<"  "<<sqrt(d3sq)<<std::endl;
 
-    Corr3<D1,D2,D3>& bc123 = *this;  // alias for clarity.
+    BaseCorr3& bc123 = *this;  // alias for clarity.
 
     // Need to end up with d1 > d2 > d3
     if (d1sq > d2sq) {
@@ -729,11 +727,9 @@ void Corr3<D1,D2,D3>::process111(
     }
 }
 
-template <int D1, int D2, int D3> template <int B, int M, int C>
-void Corr3<D1,D2,D3>::process111Sorted(
-    Corr3<D1,D3,D2>& bc132,
-    Corr3<D2,D1,D3>& bc213, Corr3<D2,D3,D1>& bc231,
-    Corr3<D3,D1,D2>& bc312, Corr3<D3,D2,D1>& bc321,
+template <int B, int M, int C>
+void BaseCorr3::process111Sorted(
+    BaseCorr3& bc132, BaseCorr3& bc213, BaseCorr3& bc231, BaseCorr3& bc312, BaseCorr3& bc321,
     const BaseCell<C>* c1, const BaseCell<C>* c2, const BaseCell<C>* c3,
     const MetricHelper<M,0>& metric, double d1sq, double d2sq, double d3sq)
 {
@@ -1151,8 +1147,17 @@ struct DirectHelper<GData,GData,GData>
 };
 
 
-template <int D1, int D2, int D3> template <int B, int C>
-void Corr3<D1,D2,D3>::directProcess111(
+template <int B, int C>
+void BaseCorr3::directProcess111(
+    const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
+    const double d1, const double d2, const double d3,
+    const double logr, const double u, const double v, const int index)
+{
+    finishProcess(c1, c2, c3, d1, d2, d3, logr, u, v, index);
+}
+
+template <int D1, int D2, int D3> template <int C>
+void Corr3<D1,D2,D3>::finishProcess(
     const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
     const double d1, const double d2, const double d3,
     const double logr, const double u, const double v, const int index)

--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -422,46 +422,27 @@ void Field<D,C>::getNear(double x, double y, double z, double sep, long* indices
 //
 //
 
-template <int D>
-BaseField<D>* BuildField(const double* x, const double* y, const double* z,
-                         const double* g1, const double* g2, const double* k,
-                         const double* w, const double* wpos, long nobj,
-                         double minsize, double maxsize,
-                         SplitMethod sm, long long seed, bool brute,
-                         int mintop, int maxtop, Coord coords)
+template <int D, int C>
+Field<D,C>* BuildField(const double* x, const double* y, const double* z,
+                       const double* g1, const double* g2, const double* k,
+                       const double* w, const double* wpos, long nobj,
+                       double minsize, double maxsize,
+                       SplitMethod sm, long long seed, bool brute,
+                       int mintop, int maxtop)
 {
-    dbg<<"Start BuildField "<<D<<"  "<<coords<<std::endl;
-    switch(coords) {
-      case Flat:
-           return new Field<D,Flat>(x, y, 0, g1, g2, k,
-                                    w, wpos, nobj,
-                                    minsize, maxsize,
-                                    sm, seed,
-                                    bool(brute), mintop, maxtop);
-      case Sphere:
-           return new Field<D,Sphere>(x, y, z, g1, g2, k,
-                                      w, wpos, nobj,
-                                      minsize, maxsize,
-                                      sm, seed,
-                                      bool(brute), mintop, maxtop);
-      case ThreeD:
-           return new Field<D,ThreeD>(x, y, z, g1, g2, k,
-                                      w, wpos, nobj,
-                                      minsize, maxsize,
-                                      sm, seed,
-                                      bool(brute), mintop, maxtop);
-      default:
-           Assert(false);
-    }
-    return 0;
+    dbg<<"Start BuildField "<<D<<"  "<<C<<std::endl;
+    return new Field<D,C>(x, y, z, g1, g2, k,
+                          w, wpos, nobj, minsize, maxsize,
+                          sm, seed, brute, mintop, maxtop);
 }
 
-BaseField<GData>* BuildGField(
+template <int C>
+Field<GData,C>* BuildGField(
     py::array_t<double>& xp, py::array_t<double>& yp, py::array_t<double>& zp,
     py::array_t<double>& g1p, py::array_t<double>& g2p,
     py::array_t<double>& wp, py::array_t<double>& wposp,
     double minsize, double maxsize,
-    SplitMethod sm, long long seed, bool brute, int mintop, int maxtop, Coord coords)
+    SplitMethod sm, long long seed, bool brute, int mintop, int maxtop)
 {
     long nobj = xp.size();
     Assert(yp.size() == nobj);
@@ -479,16 +460,17 @@ BaseField<GData>* BuildGField(
     const double* w = static_cast<const double*>(wp.data());
     const double* wpos = wposp.size() == 0 ? 0 : static_cast<const double*>(wposp.data());
 
-    return BuildField<GData>(x, y, z, g1, g2, 0, w, wpos,
-                             nobj, minsize, maxsize, sm, seed,
-                             brute, mintop, maxtop, coords);
+    return BuildField<GData,C>(x, y, z, g1, g2, 0, w, wpos,
+                               nobj, minsize, maxsize, sm, seed,
+                               brute, mintop, maxtop);
 }
 
-BaseField<KData>* BuildKField(
+template <int C>
+Field<KData,C>* BuildKField(
     py::array_t<double>& xp, py::array_t<double>& yp, py::array_t<double>& zp,
     py::array_t<double>& kp, py::array_t<double>& wp, py::array_t<double>& wposp,
     double minsize, double maxsize,
-    SplitMethod sm, long long seed, bool brute, int mintop, int maxtop, Coord coords)
+    SplitMethod sm, long long seed, bool brute, int mintop, int maxtop)
 {
     long nobj = xp.size();
     Assert(yp.size() == nobj);
@@ -504,16 +486,17 @@ BaseField<KData>* BuildKField(
     const double* w = static_cast<const double*>(wp.data());
     const double* wpos = wposp.size() == 0 ? 0 : static_cast<const double*>(wposp.data());
 
-    return BuildField<KData>(x, y, z, 0, 0, k, w, wpos,
-                             nobj, minsize, maxsize, sm, seed,
-                             brute, mintop, maxtop, coords);
+    return BuildField<KData,C>(x, y, z, 0, 0, k, w, wpos,
+                               nobj, minsize, maxsize, sm, seed,
+                               brute, mintop, maxtop);
 }
 
-BaseField<NData>* BuildNField(
+template <int C>
+Field<NData,C>* BuildNField(
     py::array_t<double>& xp, py::array_t<double>& yp, py::array_t<double>& zp,
     py::array_t<double>& wp, py::array_t<double>& wposp,
     double minsize, double maxsize,
-    SplitMethod sm, long long seed, bool brute, int mintop, int maxtop, Coord coords)
+    SplitMethod sm, long long seed, bool brute, int mintop, int maxtop)
 {
     long nobj = xp.size();
     Assert(yp.size() == nobj);
@@ -527,13 +510,13 @@ BaseField<NData>* BuildNField(
     const double* w = static_cast<const double*>(wp.data());
     const double* wpos = wposp.size() == 0 ? 0 : static_cast<const double*>(wposp.data());
 
-    return BuildField<NData>(x, y, z, 0, 0, 0, w, wpos,
-                             nobj, minsize, maxsize, sm, seed,
-                             brute, mintop, maxtop, coords);
+    return BuildField<NData,C>(x, y, z, 0, 0, 0, w, wpos,
+                               nobj, minsize, maxsize, sm, seed,
+                               brute, mintop, maxtop);
 }
 
-template <int D>
-void FieldGetNear(BaseField<D>* field, double x, double y, double z, double sep,
+template <int D, int C>
+void FieldGetNear(Field<D,C>* field, double x, double y, double z, double sep,
                   py::array_t<long>& inp)
 {
     long n = inp.size();
@@ -544,21 +527,18 @@ void FieldGetNear(BaseField<D>* field, double x, double y, double z, double sep,
 // Export the above functions using pybind11
 
 // Also wrap some functions that live in KMeans.cpp
-template <int D>
-void KMeansInitTree(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                    Coord coords, long long seed);
-template <int D>
-void KMeansInitRand(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                    Coord coords, long long seed);
-template <int D>
-void KMeansInitKMPP(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                    Coord coords, long long seed);
-template <int D>
-void KMeansRun(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-               int max_iter, double tol, bool alt, Coord coords);
-template <int D>
-void KMeansAssign(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                  py::array_t<long>& pp, Coord coords);
+template <int D, int C>
+void KMeansInitTree(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed);
+template <int D, int C>
+void KMeansInitRand(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed);
+template <int D, int C>
+void KMeansInitKMPP(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed);
+template <int D, int C>
+void KMeansRun(Field<D,C>* field, py::array_t<double>& cenp, int npatch,
+               int max_iter, double tol, bool alt);
+template <int D, int C>
+void KMeansAssign(Field<D,C>* field, py::array_t<double>& cenp, int npatch, py::array_t<long>& pp);
+
 void QuickAssign(py::array_t<double>& cenp, int npatch,
                  py::array_t<double>& xp, py::array_t<double>& yp,
                  py::array_t<double>& zp, py::array_t<long>& pp);
@@ -570,24 +550,24 @@ void GenerateXYZ(
     py::array_t<double>& rap, py::array_t<double>& decp, py::array_t<double>& rp);
 
 
-template <int D, typename F>
+template <int D, int C, typename F>
 void WrapField(F& field)
 {
-    typedef void (*getNear_type)(BaseField<D>* field, double x, double y, double z,
+    typedef void (*getnear_type)(Field<D,C>* field, double x, double y, double z,
                                  double sep, py::array_t<long>& inp);
 
-    typedef void (*init_type)(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                              Coord coords, long long seed);
-    typedef void (*run_type)(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                            int max_iter, double tol, bool alt, Coord coords);
-    typedef void (*assign_type)(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                                py::array_t<long>& pp, Coord coords);
+    typedef void (*init_type)(Field<D,C>* field, py::array_t<double>& cenp, int npatch,
+                              long long seed);
+    typedef void (*run_type)(Field<D,C>* field, py::array_t<double>& cenp, int npatch,
+                            int max_iter, double tol, bool alt);
+    typedef void (*assign_type)(Field<D,C>* field, py::array_t<double>& cenp, int npatch,
+                                py::array_t<long>& pp);
 
-    field.def("getNObj", &BaseField<D>::getNObj);
-    field.def("getSize", &BaseField<D>::getSize);
-    field.def("countNear", &BaseField<D>::countNear);
-    field.def("getNear", getNear_type(&FieldGetNear));
-    field.def("getNTopLevel", &BaseField<D>::getNTopLevel);
+    field.def("getNObj", &Field<D,C>::getNObj);
+    field.def("getSize", &Field<D,C>::getSize);
+    field.def("countNear", &Field<D,C>::countNear);
+    field.def("getNear", getnear_type(&FieldGetNear));
+    field.def("getNTopLevel", &Field<D,C>::getNTopLevel);
 
     field.def("KMeansInitTree", init_type(&KMeansInitTree));
     field.def("KMeansInitRand", init_type(&KMeansInitRand));
@@ -596,21 +576,46 @@ void WrapField(F& field)
     field.def("KMeansAssign", assign_type(&KMeansAssign));
 }
 
-void pyExportField(py::module& _treecorr)
+template <int C>
+void WrapCoord(py::module& _treecorr, std::string Cstr)
 {
-    py::class_<BaseField<NData> > nfield(_treecorr, "NField");
-    py::class_<BaseField<KData> > kfield(_treecorr, "KField");
-    py::class_<BaseField<GData> > gfield(_treecorr, "GField");
+    typedef Field<NData,C>* (*nfield_type)(
+        py::array_t<double>& xp, py::array_t<double>& yp, py::array_t<double>& zp,
+        py::array_t<double>& wp, py::array_t<double>& wposp,
+        double minsize, double maxsize,
+        SplitMethod sm, long long seed, bool brute, int mintop, int maxtop);
+    typedef Field<KData,C>* (*kfield_type)(
+        py::array_t<double>& xp, py::array_t<double>& yp, py::array_t<double>& zp,
+        py::array_t<double>& kp, py::array_t<double>& wp, py::array_t<double>& wposp,
+        double minsize, double maxsize,
+        SplitMethod sm, long long seed, bool brute, int mintop, int maxtop);
+    typedef Field<GData,C>* (*gfield_type)(
+        py::array_t<double>& xp, py::array_t<double>& yp, py::array_t<double>& zp,
+        py::array_t<double>& g1p, py::array_t<double>& g2p,
+        py::array_t<double>& wp, py::array_t<double>& wposp,
+        double minsize, double maxsize,
+        SplitMethod sm, long long seed, bool brute, int mintop, int maxtop);
+
+    py::class_<Field<NData,C> > nfield(_treecorr, ("NField" + Cstr).c_str());
+    py::class_<Field<KData,C> > kfield(_treecorr, ("KField" + Cstr).c_str());
+    py::class_<Field<GData,C> > gfield(_treecorr, ("GField" + Cstr).c_str());
 
     // These aren't included in the WrapField template, since the function signatures
     // aren't the same.
-    nfield.def(py::init(&BuildNField));
-    kfield.def(py::init(&BuildKField));
-    gfield.def(py::init(&BuildGField));
+    nfield.def(py::init(nfield_type(&BuildNField)));
+    kfield.def(py::init(kfield_type(&BuildKField)));
+    gfield.def(py::init(gfield_type(&BuildGField)));
 
-    WrapField<NData>(nfield);
-    WrapField<KData>(kfield);
-    WrapField<GData>(gfield);
+    WrapField<NData, C>(nfield);
+    WrapField<KData, C>(kfield);
+    WrapField<GData, C>(gfield);
+}
+
+void pyExportField(py::module& _treecorr)
+{
+    WrapCoord<Flat>(_treecorr, "Flat");
+    WrapCoord<Sphere>(_treecorr, "Sphere");
+    WrapCoord<ThreeD>(_treecorr, "ThreeD");
 
     _treecorr.def("QuickAssign", &QuickAssign);
     _treecorr.def("SelectPatch", &SelectPatch);

--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -26,7 +26,7 @@
 // to build the actual Cells.
 template <int D, int C, int SM>
 double SetupTopLevelCells(
-    std::vector<std::pair<CellData<D,C>*,WPosLeafInfo> >& celldata,
+    std::vector<std::pair<BaseCellData<C>*,WPosLeafInfo> >& celldata,
     double maxsizesq, size_t start, size_t end, int mintop, int maxtop,
     std::vector<CellData<D,C>*>& top_data,
     std::vector<double>& top_sizesq,
@@ -43,7 +43,7 @@ double SetupTopLevelCells(
     double sizesq;
     if (end-start == 1) {
         xdbg<<"Only 1 CellData entry: size = 0\n";
-        ave = celldata[start].first;
+        ave = static_cast<CellData<D,C>*>(celldata[start].first);
         celldata[start].first = 0; // Make sure the calling function doesn't delete this!
         sizesq = 0.;
     } else {
@@ -70,7 +70,7 @@ double SetupTopLevelCells(
         top_start.push_back(start);
         top_end.push_back(end);
     } else {
-        size_t mid = SplitData<D,C,SM>(celldata,start,end,ave->getPos());
+        size_t mid = SplitData<C,SM>(celldata,start,end,ave->getPos());
         xdbg<<"Too big.  Recurse with mid = "<<mid<<std::endl;
         SetupTopLevelCells<D,C,SM>(celldata, maxsizesq, start, mid, mintop-1, maxtop-1,
                                    top_data, top_sizesq, top_start, top_end);
@@ -293,8 +293,8 @@ Field<D,C>::~Field()
     for (size_t i=0; i<_celldata.size(); ++i) if (_celldata[i].first) delete _celldata[i].first;
 }
 
-template <int D, int C>
-long CountNear(const Cell<D,C>* cell, const Position<C>& pos, double sep, double sepsq)
+template <int C>
+long CountNear(const BaseCell<C>* cell, const Position<C>& pos, double sep, double sepsq)
 {
     double s = cell->getSize();
     const double dsq = (cell->getPos() - pos).normSq();
@@ -352,8 +352,8 @@ long Field<D,C>::countNear(double x, double y, double z, double sep) const
     return ntot;
 }
 
-template <int D, int C>
-void GetNear(const Cell<D,C>* cell, const Position<C>& pos, double sep, double sepsq,
+template <int C>
+void GetNear(const BaseCell<C>* cell, const Position<C>& pos, double sep, double sepsq,
              long* indices, long& k, long n)
 {
     double s = cell->getSize();

--- a/src/Field.cpp
+++ b/src/Field.cpp
@@ -47,30 +47,30 @@ double SetupTopLevelCells(
         celldata[start].first = 0; // Make sure the calling function doesn't delete this!
         sizesq = 0.;
     } else {
-        ave = new CellData<D,C>(celldata,start,end);
+        ave = new CellData<D,C>(celldata, start, end);
         xdbg<<"ave pos = "<<ave->getPos()<<std::endl;
         xdbg<<"n = "<<ave->getN()<<std::endl;
         xdbg<<"w = "<<ave->getW()<<std::endl;
-        sizesq = CalculateSizeSq(ave->getPos(),celldata,start,end);
+        sizesq = CalculateSizeSq(ave->getPos(), celldata, start, end);
         xdbg<<"size = "<<sqrt(sizesq)<<std::endl;
     }
 
     if (sizesq == 0 || (sizesq <= maxsizesq && mintop<=0)) {
         xdbg<<"Small enough.  Make a cell.\n";
-        if (end-start > 1) ave->finishAverages(celldata,start,end);
+        if (end-start > 1) ave->finishAverages(celldata, start, end);
         top_data.push_back(ave);
         top_sizesq.push_back(sizesq);
         top_start.push_back(start);
         top_end.push_back(end);
     } else if (maxtop <= 0) {
         xdbg<<"At specified end of top layer recusion\n";
-        if (end-start > 1) ave->finishAverages(celldata,start,end);
+        if (end-start > 1) ave->finishAverages(celldata, start, end);
         top_data.push_back(ave);
         top_sizesq.push_back(sizesq);
         top_start.push_back(start);
         top_end.push_back(end);
     } else {
-        size_t mid = SplitData<C,SM>(celldata,start,end,ave->getPos());
+        size_t mid = SplitData<C,SM>(celldata, start, end, ave->getPos());
         xdbg<<"Too big.  Recurse with mid = "<<mid<<std::endl;
         SetupTopLevelCells<D,C,SM>(celldata, maxsizesq, start, mid, mintop-1, maxtop-1,
                                    top_data, top_sizesq, top_start, top_end);
@@ -197,7 +197,7 @@ Field<D,C>::Field(const double* x, const double* y, const double* z,
     this->_celldata.reserve(nobj);
     if (z) {
         for(long i=0;i<nobj;++i) {
-            WPosLeafInfo wp = get_wpos(wpos,w,i);
+            WPosLeafInfo wp = get_wpos(wpos, w, i);
             this->_celldata.push_back(std::make_pair(
                     CellDataHelper<D,C>::build(
                         x[i], y[i], z[i], at<D==GData>(g1,i), at<D==GData>(g2,i),
@@ -206,7 +206,7 @@ Field<D,C>::Field(const double* x, const double* y, const double* z,
     } else {
         Assert(C == Flat);
         for(long i=0;i<nobj;++i) {
-            WPosLeafInfo wp = get_wpos(wpos,w,i);
+            WPosLeafInfo wp = get_wpos(wpos, w, i);
             this->_celldata.push_back(std::make_pair(
                     CellDataHelper<D,C>::build(
                         x[i], y[i], 0., at<D==GData>(g1,i), at<D==GData>(g2,i),
@@ -304,18 +304,18 @@ BaseField<C>::~BaseField()
 }
 
 template <int C>
-long CountNear(const BaseCell<C>* cell, const Position<C>& pos, double sep, double sepsq)
+long CountNear(const BaseCell<C>& cell, const Position<C>& pos, double sep, double sepsq)
 {
-    double s = cell->getSize();
-    const double dsq = (cell->getPos() - pos).normSq();
-    xdbg<<"CountNear: "<<cell->getPos()<<"  "<<pos<<"  "<<dsq<<"  "<<s<<"  "<<sepsq<<std::endl;
+    double s = cell.getSize();
+    const double dsq = (cell.getPos() - pos).normSq();
+    xdbg<<"CountNear: "<<cell.getPos()<<"  "<<pos<<"  "<<dsq<<"  "<<s<<"  "<<sepsq<<std::endl;
 
     // If s == 0, then just check dsq
     if (s==0.) {
         if (dsq <= sepsq) {
-            dbg<<"s==0, d < sep   N = "<<cell->getN()<<std::endl;
+            dbg<<"s==0, d < sep   N = "<<cell.getN()<<std::endl;
             Assert(sqrt(dsq) <= sep);
-            return cell->getN();
+            return cell.getN();
         }
         else {
             Assert(sqrt(dsq) > sep);
@@ -333,16 +333,16 @@ long CountNear(const BaseCell<C>* cell, const Position<C>& pos, double sep, doub
         // If d + s < sep, then all points are close enough.
         if (dsq <= sepsq && s < sep && dsq <= SQR(sep-s)) {
             Assert(sqrt(dsq) + s <= sep);
-            dbg<<"d + s <= sep: "<<sqrt(dsq)+s<<" <= "<<sep<<"  N = "<<cell->getN()<<std::endl;
-            return cell->getN();
+            dbg<<"d + s <= sep: "<<sqrt(dsq)+s<<" <= "<<sep<<"  N = "<<cell.getN()<<std::endl;
+            return cell.getN();
         }
 
         // Otherwise check the subcells.
-        Assert(cell->getLeft());
-        Assert(cell->getRight());
+        Assert(cell.getLeft());
+        Assert(cell.getRight());
         xdbg<<"Recurse to subcells\n";
-        return (CountNear(cell->getLeft(), pos, sep, sepsq) +
-                CountNear(cell->getRight(), pos, sep, sepsq));
+        return (CountNear(*cell.getLeft(), pos, sep, sepsq) +
+                CountNear(*cell.getRight(), pos, sep, sepsq));
     }
 }
 
@@ -350,45 +350,45 @@ template <int C>
 long BaseField<C>::countNear(double x, double y, double z, double sep) const
 {
     BuildCells();  // Make sure this is done.
-    Position<C> pos(x,y,z);
+    Position<C> pos(x, y, z);
     double sepsq = sep*sep;
     long ntot = 0;
     dbg<<"Start countNear: "<<_cells.size()<<" top level cells\n";
     for(size_t i=0; i<_cells.size(); ++i) {
         dbg<<"Top level "<<i<<" with N="<<_cells[i]->getN()<<std::endl;
-        ntot += CountNear(_cells[i], pos, sep, sepsq);
+        ntot += CountNear(*_cells[i], pos, sep, sepsq);
         dbg<<"ntot -> "<<ntot<<std::endl;
     }
     return ntot;
 }
 
 template <int C>
-void GetNear(const BaseCell<C>* cell, const Position<C>& pos, double sep, double sepsq,
+void GetNear(const BaseCell<C>& cell, const Position<C>& pos, double sep, double sepsq,
              long* indices, long& k, long n)
 {
-    double s = cell->getSize();
-    const double dsq = (cell->getPos() - pos).normSq();
-    dbg<<"GetNear: "<<cell->getPos()<<"  "<<pos<<"  "<<dsq<<"  "<<s<<"  "<<sepsq<<std::endl;
+    double s = cell.getSize();
+    const double dsq = (cell.getPos() - pos).normSq();
+    dbg<<"GetNear: "<<cell.getPos()<<"  "<<pos<<"  "<<dsq<<"  "<<s<<"  "<<sepsq<<std::endl;
 
     // If s == 0, then just check dsq
     if (s==0.) {
         if (dsq <= sepsq) {
-            dbg<<"s==0, d < sep   N = "<<cell->getN()<<std::endl;
+            dbg<<"s==0, d < sep   N = "<<cell.getN()<<std::endl;
             Assert(sqrt(dsq) <= sep);
             Assert(k < n);
-            long n1 = cell->getN();
+            long n1 = cell.getN();
             Assert(k + n1 <= n);
             // This shouldn't happen, but if it does, we can get a seg fault, so check.
             if (k + n1 > n) return;
             if (n1 == 1) {
                 dbg<<"N == 1 case\n";
-                indices[k++] = cell->getInfo().index;
+                indices[k++] = cell.getInfo().index;
             } else {
                 dbg<<"N > 1 case: "<<n1<<std::endl;
-                std::vector<long>* leaf_indices = cell->getListInfo().indices;
-                Assert(long(leaf_indices->size()) == n1);
+                const std::vector<long>& leaf_indices = *cell.getListInfo().indices;
+                Assert(long(leaf_indices.size()) == n1);
                 for (long m=0; m<n1; ++m)
-                    indices[k++] = (*leaf_indices)[m];
+                    indices[k++] = leaf_indices[m];
             }
             Assert(k <= n);
         } else {
@@ -402,11 +402,11 @@ void GetNear(const BaseCell<C>* cell, const Position<C>& pos, double sep, double
             dbg<<"d - s > sep: "<<sqrt(dsq)-s<<" > "<<sep<<std::endl;
         } else {
             // Otherwise check the subcells.
-            Assert(cell->getLeft());
-            Assert(cell->getRight());
+            Assert(cell.getLeft());
+            Assert(cell.getRight());
             dbg<<"Recurse to subcells\n";
-            GetNear(cell->getLeft(), pos, sep, sepsq, indices, k, n);
-            GetNear(cell->getRight(), pos, sep, sepsq, indices, k, n);
+            GetNear(*cell.getLeft(), pos, sep, sepsq, indices, k, n);
+            GetNear(*cell.getRight(), pos, sep, sepsq, indices, k, n);
         }
     }
 }
@@ -415,13 +415,13 @@ template <int C>
 void BaseField<C>::getNear(double x, double y, double z, double sep, long* indices, long n) const
 {
     BuildCells();  // Make sure this is done.
-    Position<C> pos(x,y,z);
+    Position<C> pos(x, y, z);
     double sepsq = sep*sep;
     dbg<<"Start getNear: "<<_cells.size()<<" top level cells\n";
     long k = 0;
     for(size_t i=0; i<_cells.size(); ++i) {
         dbg<<"Top level "<<i<<" with N="<<_cells[i]->getN()<<std::endl;
-        GetNear(_cells[i], pos, sep, sepsq, indices, k, n);
+        GetNear(*_cells[i], pos, sep, sepsq, indices, k, n);
         dbg<<"k -> "<<k<<std::endl;
     }
 }
@@ -526,28 +526,29 @@ Field<NData,C>* BuildNField(
 }
 
 template <int C>
-void FieldGetNear(BaseField<C>* field, double x, double y, double z, double sep,
+void FieldGetNear(BaseField<C>& field, double x, double y, double z, double sep,
                   py::array_t<long>& inp)
 {
     long n = inp.size();
     long* indices = static_cast<long*>(inp.mutable_data());
-    field->getNear(x,y,z,sep,indices,n);
+    field.getNear(x, y, z, sep, indices, n);
 }
 
 // Export the above functions using pybind11
 
 // Also wrap some functions that live in KMeans.cpp
 template <int C>
-void KMeansInitTree(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed);
+void KMeansInitTree(BaseField<C>& field, py::array_t<double>& cenp, int npatch, long long seed);
 template <int C>
-void KMeansInitRand(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed);
+void KMeansInitRand(BaseField<C>& field, py::array_t<double>& cenp, int npatch, long long seed);
 template <int C>
-void KMeansInitKMPP(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed);
+void KMeansInitKMPP(BaseField<C>& field, py::array_t<double>& cenp, int npatch, long long seed);
 template <int C>
-void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+void KMeansRun(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
                int max_iter, double tol, bool alt);
 template <int C>
-void KMeansAssign(BaseField<C>* field, py::array_t<double>& cenp, int npatch, py::array_t<long>& pp);
+void KMeansAssign(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
+                  py::array_t<long>& pp);
 
 void QuickAssign(py::array_t<double>& cenp, int npatch,
                  py::array_t<double>& xp, py::array_t<double>& yp,
@@ -563,13 +564,13 @@ void GenerateXYZ(
 template <int C>
 void WrapField(py::module& _treecorr, std::string Cstr)
 {
-    typedef void (*getnear_type)(BaseField<C>* field, double x, double y, double z,
+    typedef void (*getnear_type)(BaseField<C>& field, double x, double y, double z,
                                  double sep, py::array_t<long>& inp);
-    typedef void (*init_type)(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+    typedef void (*init_type)(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
                               long long seed);
-    typedef void (*run_type)(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+    typedef void (*run_type)(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
                             int max_iter, double tol, bool alt);
-    typedef void (*assign_type)(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+    typedef void (*assign_type)(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
                                 py::array_t<long>& pp);
 
     py::class_<BaseField<C> > field(_treecorr, ("Field" + Cstr).c_str());

--- a/src/KMeans.cpp
+++ b/src/KMeans.cpp
@@ -495,10 +495,10 @@ struct AssignPatches
             inertia[patch_num] += (cell->getPos() - centers[patch_num]).normSq() * cell->getW();
 #endif
         } else {
-            std::vector<long>* indices = cell->getListInfo().indices;
-            xdbg<<"Leaf with N>1.  "<<indices->size()<<" indices\n";
-            for (size_t j=0; j<indices->size(); ++j) {
-                long index = (*indices)[j];
+            const std::vector<long>& indices = *cell->getListInfo().indices;
+            xdbg<<"Leaf with N>1.  "<<indices.size()<<" indices\n";
+            for (size_t j=0; j<indices.size(); ++j) {
+                long index = indices[j];
                 xdbg<<"    index = "<<index<<std::endl;
                 Assert(index < n);
                 patches[index] = patch_num;
@@ -740,41 +740,41 @@ void ReadCenters(std::vector<Position<Flat> >& centers, const double* pycenters,
 }
 
 template <int C>
-void KMeansInitTree1(BaseField<C>*field, double* pycenters, int npatch, long long seed)
+void KMeansInitTree1(BaseField<C>& field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitTree for "<<npatch<<" patches\n";
-    const std::vector<BaseCell<C>*> cells = field->getCells();
+    const std::vector<BaseCell<C>*> cells = field.getCells();
     std::vector<Position<C> > centers(npatch);
     InitializeCentersTree(centers, cells, seed);
     WriteCenters(centers, pycenters, npatch);
 }
 
 template <int C>
-void KMeansInitRand1(BaseField<C>*field, double* pycenters, int npatch, long long seed)
+void KMeansInitRand1(BaseField<C>& field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitRand for "<<npatch<<" patches\n";
-    const std::vector<BaseCell<C>*> cells = field->getCells();
+    const std::vector<BaseCell<C>*> cells = field.getCells();
     std::vector<Position<C> > centers(npatch);
     InitializeCentersRand(centers, cells, seed);
     WriteCenters(centers, pycenters, npatch);
 }
 
 template <int C>
-void KMeansInitKMPP1(BaseField<C>*field, double* pycenters, int npatch, long long seed)
+void KMeansInitKMPP1(BaseField<C>& field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitKMPP for "<<npatch<<" patches\n";
-    const std::vector<BaseCell<C>*> cells = field->getCells();
+    const std::vector<BaseCell<C>*> cells = field.getCells();
     std::vector<Position<C> > centers(npatch);
     InitializeCentersKMPP(centers, cells, seed);
     WriteCenters(centers, pycenters, npatch);
 }
 
 template <int C>
-void KMeansRun1(BaseField<C>*field, double* pycenters, int npatch, int max_iter, double tol,
+void KMeansRun1(BaseField<C>& field, double* pycenters, int npatch, int max_iter, double tol,
                 bool alt)
 {
     dbg<<"Start KMeansRun for "<<npatch<<" patches\n";
-    const std::vector<BaseCell<C>*> cells = field->getCells();
+    const std::vector<BaseCell<C>*> cells = field.getCells();
 
     // Initialize the centers of the patches smartly according to the tree structure.
     std::vector<Position<C> > centers(npatch);
@@ -784,7 +784,7 @@ void KMeansRun1(BaseField<C>*field, double* pycenters, int npatch, int max_iter,
     // Want rms shift / field.size < tol
     // So sqrt(total_shift^2 / npatch) / field.size < tol
     // total_shift^2 < tol^2 * size^2 * npatch
-    double tolsq = SQR(tol * field->getSize()) * npatch;
+    double tolsq = SQR(tol * field.getSize()) * npatch;
     xdbg<<"tolsq = "<<tolsq<<std::endl;
 
     // The alt version needs to keep track of the inertia of each patch.
@@ -821,7 +821,7 @@ void KMeansRun1(BaseField<C>*field, double* pycenters, int npatch, int max_iter,
         // Stop if (rms shift / size) < tol
         if (shiftsq < tolsq) {
             dbg<<"Stopping RunKMeans because rms shift = "<<sqrt(shiftsq/npatch)<<std::endl;
-            dbg<<"tol * size = "<<tol * field->getSize()<<std::endl;
+            dbg<<"tol * size = "<<tol * field.getSize()<<std::endl;
             break;
         }
         if (iter == max_iter-1) {
@@ -832,10 +832,10 @@ void KMeansRun1(BaseField<C>*field, double* pycenters, int npatch, int max_iter,
 }
 
 template <int C>
-void KMeansAssign1(BaseField<C>*field, const double* pycenters, int npatch, long* patches, long n)
+void KMeansAssign1(BaseField<C>& field, const double* pycenters, int npatch, long* patches, long n)
 {
     dbg<<"Start KMeansAssign for "<<npatch<<" patches\n";
-    const std::vector<BaseCell<C>*> cells = field->getCells();
+    const std::vector<BaseCell<C>*> cells = field.getCells();
 
     std::vector<Position<C> > centers(npatch);
     ReadCenters(centers, pycenters, npatch);
@@ -848,28 +848,28 @@ void KMeansAssign1(BaseField<C>*field, const double* pycenters, int npatch, long
 }
 
 template <int C>
-void KMeansInitTree(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
+void KMeansInitTree(BaseField<C>& field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansInitTree1(field, centers, npatch, seed);
 }
 
 template <int C>
-void KMeansInitRand(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
+void KMeansInitRand(BaseField<C>& field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansInitRand1(field, centers, npatch, seed);
 }
 
 template <int C>
-void KMeansInitKMPP(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
+void KMeansInitKMPP(BaseField<C>& field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansInitKMPP1(field, centers, npatch, seed);
 }
 
 template <int C>
-void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+void KMeansRun(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
                int max_iter, double tol, bool alt)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
@@ -877,7 +877,7 @@ void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
 }
 
 template <int C>
-void KMeansAssign(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+void KMeansAssign(BaseField<C>& field, py::array_t<double>& cenp, int npatch,
                   py::array_t<long>& pp)
 {
     long n = pp.size();
@@ -1055,15 +1055,15 @@ void GenerateXYZ(
 // Instantiate versions that are wrapped in Field.cpp
 
 #define Inst(C)\
-    template void KMeansInitTree(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansInitTree(BaseField<C>& field, py::array_t<double>& cenp, int npatch, \
                                  long long seed); \
-    template void KMeansInitRand(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansInitRand(BaseField<C>& field, py::array_t<double>& cenp, int npatch, \
                                  long long seed); \
-    template void KMeansInitKMPP(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansInitKMPP(BaseField<C>& field, py::array_t<double>& cenp, int npatch, \
                                  long long seed); \
-    template void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansRun(BaseField<C>& field, py::array_t<double>& cenp, int npatch, \
                             int max_iter, double tol, bool alt); \
-    template void KMeansAssign(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansAssign(BaseField<C>& field, py::array_t<double>& cenp, int npatch, \
                                py::array_t<long>& pp); \
 
 Inst(Flat);

--- a/src/KMeans.cpp
+++ b/src/KMeans.cpp
@@ -847,112 +847,42 @@ void KMeansAssign2(Field<D,C>*field, const double* pycenters, int npatch, long* 
     xdbg<<"After AssignPatches\n";
 }
 
-template <int D>
-void KMeansInitTree(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                    Coord coords, long long seed)
+template <int D, int C>
+void KMeansInitTree(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-
-    switch(coords) {
-      case Flat:
-           KMeansInitTree2(static_cast<Field<D,Flat>*>(field), centers, npatch, seed);
-           break;
-      case Sphere:
-           KMeansInitTree2(static_cast<Field<D,Sphere>*>(field), centers, npatch, seed);
-           break;
-      case ThreeD:
-           KMeansInitTree2(static_cast<Field<D,ThreeD>*>(field), centers, npatch, seed);
-           break;
-      default:
-           Assert(false);
-    }
+    KMeansInitTree2(field, centers, npatch, seed);
 }
 
-template <int D>
-void KMeansInitRand(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                    Coord coords, long long seed)
+template <int D, int C>
+void KMeansInitRand(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-
-    switch(coords) {
-      case Flat:
-           KMeansInitRand2(static_cast<Field<D,Flat>*>(field), centers, npatch, seed);
-           break;
-      case Sphere:
-           KMeansInitRand2(static_cast<Field<D,Sphere>*>(field), centers, npatch, seed);
-           break;
-      case ThreeD:
-           KMeansInitRand2(static_cast<Field<D,ThreeD>*>(field), centers, npatch, seed);
-           break;
-      default:
-           Assert(false);
-    }
+    KMeansInitRand2(field, centers, npatch, seed);
 }
 
-template <int D>
-void KMeansInitKMPP(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                    Coord coords, long long seed)
+template <int D, int C>
+void KMeansInitKMPP(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-
-    switch(coords) {
-      case Flat:
-           KMeansInitKMPP2(static_cast<Field<D,Flat>*>(field), centers, npatch, seed);
-           break;
-      case Sphere:
-           KMeansInitKMPP2(static_cast<Field<D,Sphere>*>(field), centers, npatch, seed);
-           break;
-      case ThreeD:
-           KMeansInitKMPP2(static_cast<Field<D,ThreeD>*>(field), centers, npatch, seed);
-           break;
-      default:
-           Assert(false);
-    }
+    KMeansInitKMPP2(field, centers, npatch, seed);
 }
 
-template <int D>
-void KMeansRun(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-               int max_iter, double tol, bool alt, Coord coords)
+template <int D, int C>
+void KMeansRun(Field<D,C>* field, py::array_t<double>& cenp, int npatch,
+               int max_iter, double tol, bool alt)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-
-    switch(coords) {
-      case Flat:
-           KMeansRun2(static_cast<Field<D,Flat>*>(field), centers, npatch, max_iter, tol, alt);
-           break;
-      case Sphere:
-           KMeansRun2(static_cast<Field<D,Sphere>*>(field), centers, npatch, max_iter, tol, alt);
-           break;
-      case ThreeD:
-           KMeansRun2(static_cast<Field<D,ThreeD>*>(field), centers, npatch, max_iter, tol, alt);
-           break;
-      default:
-           Assert(false);
-    }
+    KMeansRun2(field, centers, npatch, max_iter, tol, alt);
 }
 
-template <int D>
-void KMeansAssign(BaseField<D>* field, py::array_t<double>& cenp, int npatch,
-                  py::array_t<long>& pp, Coord coords)
+template <int D, int C>
+void KMeansAssign(Field<D,C>* field, py::array_t<double>& cenp, int npatch, py::array_t<long>& pp)
 {
     long n = pp.size();
-
     const double* centers = static_cast<const double*>(cenp.data());
     long* patches = static_cast<long*>(pp.mutable_data());
-
-    switch(coords) {
-      case Flat:
-           KMeansAssign2(static_cast<Field<D,Flat>*>(field), centers, npatch, patches, n);
-           break;
-      case Sphere:
-           KMeansAssign2(static_cast<Field<D,Sphere>*>(field), centers, npatch, patches, n);
-           break;
-      case ThreeD:
-           KMeansAssign2(static_cast<Field<D,ThreeD>*>(field), centers, npatch, patches, n);
-           break;
-      default:
-           Assert(false);
-    }
+    KMeansAssign2(field, centers, npatch, patches, n);
 }
 
 void QuickAssign(py::array_t<double>& cenp, int npatch,
@@ -1054,7 +984,7 @@ void SelectPatch(int patch, py::array_t<double>& cenp, int npatch,
         }
     } else {
         // 2d version
-        Assert(cenp.size() == npatch * 3);
+        Assert(cenp.size() == npatch * 2);
         double px = centers[2*patch];
         double py = centers[2*patch+1];
 #ifdef _OPENMP
@@ -1123,18 +1053,24 @@ void GenerateXYZ(
 
 // Instantiate versions that are wrapped in Field.cpp
 
-#define Inst(D)\
-    template void KMeansInitTree(BaseField<D>* field, py::array_t<double>& cenp, int npatch, \
-                        Coord coords, long long seed); \
-    template void KMeansInitRand(BaseField<D>* field, py::array_t<double>& cenp, int npatch, \
-                        Coord coords, long long seed); \
-    template void KMeansInitKMPP(BaseField<D>* field, py::array_t<double>& cenp, int npatch, \
-                        Coord coords, long long seed); \
-    template void KMeansRun(BaseField<D>* field, py::array_t<double>& cenp, int npatch, \
-                int max_iter, double tol, bool alt, Coord coords); \
-    template void KMeansAssign(BaseField<D>* field, py::array_t<double>& cenp, int npatch, \
-                    py::array_t<long>& pp, Coord coords); \
+#define Inst(D,C)\
+    template void KMeansInitTree(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+                                 long long seed); \
+    template void KMeansInitRand(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+                                 long long seed); \
+    template void KMeansInitKMPP(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+                                 long long seed); \
+    template void KMeansRun(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+                            int max_iter, double tol, bool alt); \
+    template void KMeansAssign(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+                               py::array_t<long>& pp); \
 
-Inst(NData);
-Inst(KData);
-Inst(GData);
+Inst(NData,Flat);
+Inst(NData,Sphere);
+Inst(NData,ThreeD);
+Inst(KData,Flat);
+Inst(KData,Sphere);
+Inst(KData,ThreeD);
+Inst(GData,Flat);
+Inst(GData,Sphere);
+Inst(GData,ThreeD);

--- a/src/KMeans.cpp
+++ b/src/KMeans.cpp
@@ -739,8 +739,8 @@ void ReadCenters(std::vector<Position<Flat> >& centers, const double* pycenters,
     }
 }
 
-template <int D, int C>
-void KMeansInitTree2(Field<D,C>*field, double* pycenters, int npatch, long long seed)
+template <int C>
+void KMeansInitTree2(BaseField<C>*field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitTree for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -749,8 +749,8 @@ void KMeansInitTree2(Field<D,C>*field, double* pycenters, int npatch, long long 
     WriteCenters(centers, pycenters, npatch);
 }
 
-template <int D, int C>
-void KMeansInitRand2(Field<D,C>*field, double* pycenters, int npatch, long long seed)
+template <int C>
+void KMeansInitRand2(BaseField<C>*field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitRand for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -759,8 +759,8 @@ void KMeansInitRand2(Field<D,C>*field, double* pycenters, int npatch, long long 
     WriteCenters(centers, pycenters, npatch);
 }
 
-template <int D, int C>
-void KMeansInitKMPP2(Field<D,C>*field, double* pycenters, int npatch, long long seed)
+template <int C>
+void KMeansInitKMPP2(BaseField<C>*field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitKMPP for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -769,8 +769,8 @@ void KMeansInitKMPP2(Field<D,C>*field, double* pycenters, int npatch, long long 
     WriteCenters(centers, pycenters, npatch);
 }
 
-template <int D, int C>
-void KMeansRun2(Field<D,C>*field, double* pycenters, int npatch, int max_iter, double tol,
+template <int C>
+void KMeansRun2(BaseField<C>*field, double* pycenters, int npatch, int max_iter, double tol,
                 bool alt)
 {
     dbg<<"Start KMeansRun for "<<npatch<<" patches\n";
@@ -831,8 +831,8 @@ void KMeansRun2(Field<D,C>*field, double* pycenters, int npatch, int max_iter, d
     WriteCenters(centers, pycenters, npatch);
 }
 
-template <int D, int C>
-void KMeansAssign2(Field<D,C>*field, const double* pycenters, int npatch, long* patches, long n)
+template <int C>
+void KMeansAssign2(BaseField<C>*field, const double* pycenters, int npatch, long* patches, long n)
 {
     dbg<<"Start KMeansAssign for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -847,37 +847,38 @@ void KMeansAssign2(Field<D,C>*field, const double* pycenters, int npatch, long* 
     xdbg<<"After AssignPatches\n";
 }
 
-template <int D, int C>
-void KMeansInitTree(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed)
+template <int C>
+void KMeansInitTree(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansInitTree2(field, centers, npatch, seed);
 }
 
-template <int D, int C>
-void KMeansInitRand(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed)
+template <int C>
+void KMeansInitRand(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansInitRand2(field, centers, npatch, seed);
 }
 
-template <int D, int C>
-void KMeansInitKMPP(Field<D,C>* field, py::array_t<double>& cenp, int npatch, long long seed)
+template <int C>
+void KMeansInitKMPP(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansInitKMPP2(field, centers, npatch, seed);
 }
 
-template <int D, int C>
-void KMeansRun(Field<D,C>* field, py::array_t<double>& cenp, int npatch,
+template <int C>
+void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
                int max_iter, double tol, bool alt)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
     KMeansRun2(field, centers, npatch, max_iter, tol, alt);
 }
 
-template <int D, int C>
-void KMeansAssign(Field<D,C>* field, py::array_t<double>& cenp, int npatch, py::array_t<long>& pp)
+template <int C>
+void KMeansAssign(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
+                  py::array_t<long>& pp)
 {
     long n = pp.size();
     const double* centers = static_cast<const double*>(cenp.data());
@@ -1053,24 +1054,18 @@ void GenerateXYZ(
 
 // Instantiate versions that are wrapped in Field.cpp
 
-#define Inst(D,C)\
-    template void KMeansInitTree(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+#define Inst(C)\
+    template void KMeansInitTree(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
                                  long long seed); \
-    template void KMeansInitRand(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansInitRand(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
                                  long long seed); \
-    template void KMeansInitKMPP(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansInitKMPP(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
                                  long long seed); \
-    template void KMeansRun(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
                             int max_iter, double tol, bool alt); \
-    template void KMeansAssign(Field<D,C>* field, py::array_t<double>& cenp, int npatch, \
+    template void KMeansAssign(BaseField<C>* field, py::array_t<double>& cenp, int npatch, \
                                py::array_t<long>& pp); \
 
-Inst(NData,Flat);
-Inst(NData,Sphere);
-Inst(NData,ThreeD);
-Inst(KData,Flat);
-Inst(KData,Sphere);
-Inst(KData,ThreeD);
-Inst(GData,Flat);
-Inst(GData,Sphere);
-Inst(GData,ThreeD);
+Inst(Flat);
+Inst(Sphere);
+Inst(ThreeD);

--- a/src/KMeans.cpp
+++ b/src/KMeans.cpp
@@ -740,7 +740,7 @@ void ReadCenters(std::vector<Position<Flat> >& centers, const double* pycenters,
 }
 
 template <int C>
-void KMeansInitTree2(BaseField<C>*field, double* pycenters, int npatch, long long seed)
+void KMeansInitTree1(BaseField<C>*field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitTree for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -750,7 +750,7 @@ void KMeansInitTree2(BaseField<C>*field, double* pycenters, int npatch, long lon
 }
 
 template <int C>
-void KMeansInitRand2(BaseField<C>*field, double* pycenters, int npatch, long long seed)
+void KMeansInitRand1(BaseField<C>*field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitRand for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -760,7 +760,7 @@ void KMeansInitRand2(BaseField<C>*field, double* pycenters, int npatch, long lon
 }
 
 template <int C>
-void KMeansInitKMPP2(BaseField<C>*field, double* pycenters, int npatch, long long seed)
+void KMeansInitKMPP1(BaseField<C>*field, double* pycenters, int npatch, long long seed)
 {
     dbg<<"Start KMeansInitKMPP for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -770,7 +770,7 @@ void KMeansInitKMPP2(BaseField<C>*field, double* pycenters, int npatch, long lon
 }
 
 template <int C>
-void KMeansRun2(BaseField<C>*field, double* pycenters, int npatch, int max_iter, double tol,
+void KMeansRun1(BaseField<C>*field, double* pycenters, int npatch, int max_iter, double tol,
                 bool alt)
 {
     dbg<<"Start KMeansRun for "<<npatch<<" patches\n";
@@ -832,7 +832,7 @@ void KMeansRun2(BaseField<C>*field, double* pycenters, int npatch, int max_iter,
 }
 
 template <int C>
-void KMeansAssign2(BaseField<C>*field, const double* pycenters, int npatch, long* patches, long n)
+void KMeansAssign1(BaseField<C>*field, const double* pycenters, int npatch, long* patches, long n)
 {
     dbg<<"Start KMeansAssign for "<<npatch<<" patches\n";
     const std::vector<BaseCell<C>*> cells = field->getCells();
@@ -851,21 +851,21 @@ template <int C>
 void KMeansInitTree(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-    KMeansInitTree2(field, centers, npatch, seed);
+    KMeansInitTree1(field, centers, npatch, seed);
 }
 
 template <int C>
 void KMeansInitRand(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-    KMeansInitRand2(field, centers, npatch, seed);
+    KMeansInitRand1(field, centers, npatch, seed);
 }
 
 template <int C>
 void KMeansInitKMPP(BaseField<C>* field, py::array_t<double>& cenp, int npatch, long long seed)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-    KMeansInitKMPP2(field, centers, npatch, seed);
+    KMeansInitKMPP1(field, centers, npatch, seed);
 }
 
 template <int C>
@@ -873,7 +873,7 @@ void KMeansRun(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
                int max_iter, double tol, bool alt)
 {
     double* centers = static_cast<double*>(cenp.mutable_data());
-    KMeansRun2(field, centers, npatch, max_iter, tol, alt);
+    KMeansRun1(field, centers, npatch, max_iter, tol, alt);
 }
 
 template <int C>
@@ -883,7 +883,7 @@ void KMeansAssign(BaseField<C>* field, py::array_t<double>& cenp, int npatch,
     long n = pp.size();
     const double* centers = static_cast<const double*>(cenp.data());
     long* patches = static_cast<long*>(pp.mutable_data());
-    KMeansAssign2(field, centers, npatch, patches, n);
+    KMeansAssign1(field, centers, npatch, patches, n);
 }
 
 void QuickAssign(py::array_t<double>& cenp, int npatch,

--- a/tests/mpi_test.py
+++ b/tests/mpi_test.py
@@ -219,7 +219,7 @@ def do_mpi_cov(comm, method, output=True):
     ran_cat = treecorr.Catalog(x=x, y=y, npatch=npatch)
 
     # Generate the three sets of correlations we will use
-    rng = np.random.RandomState(31415)
+    rng = np.random.default_rng(31415)
     gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
     ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
     nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
@@ -286,7 +286,7 @@ def do_mpi_cov(comm, method, output=True):
     if output:
         print("\nCOV 1 \n", cov1[0:3,0:3], " for rank ", comm.rank, " of ", comm.size)
 
-    rng = np.random.RandomState(31415)
+    rng = np.random.default_rng(31415)
     gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
     ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
     nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
@@ -337,7 +337,7 @@ def do_mpi_cov(comm, method, output=True):
     np.testing.assert_allclose(w1b, w2b, atol=tol)
 
     # Finally, read back in from the save file and redo the covariance.
-    rng = np.random.RandomState(31415)
+    rng = np.random.default_rng(31415)
     gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
     ng = treecorr.NGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)
     nn = treecorr.NNCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng)

--- a/tests/test_gg.py
+++ b/tests/test_gg.py
@@ -604,7 +604,7 @@ def test_mapsq():
 
     mapsq_file = 'output/gg_m2.txt'
     gg.writeMapSq(mapsq_file, precision=16)
-    data = np.genfromtxt(os.path.join('output','gg_m2.txt'), names=True)
+    data = np.genfromtxt(mapsq_file, names=True)
     np.testing.assert_allclose(data['Mapsq'], mapsq)
     np.testing.assert_allclose(data['Mxsq'], mxsq)
 
@@ -623,6 +623,12 @@ def test_mapsq():
     print('mxsq = ',mxsq)
     print('max = ',max(abs(mxsq)))
     np.testing.assert_allclose(mxsq, 0., atol=3.e-8)
+
+    mapsq_file = 'output/gg_m2_R.txt'
+    gg.writeMapSq(mapsq_file, R=R, precision=16)
+    data = np.genfromtxt(mapsq_file, names=True)
+    np.testing.assert_allclose(data['Mapsq'], mapsq)
+    np.testing.assert_allclose(data['Mxsq'], mxsq)
 
     # Also check the Schneider version.  The math isn't quite as nice here, but it is tractable
     # using a different formula than I used above:

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -28,7 +28,7 @@ def test_dessv():
         print('Skip test_dessv, since fitsio not installed')
         return
 
-    rng = np.random.default_rng(1234)
+    rng = np.random.default_rng(12345)
 
     #treecorr.set_omp_threads(1);
     get_from_wiki('des_sv.fits')
@@ -406,7 +406,7 @@ def test_2d():
     print('rms inertia = ',np.std(inertia))
     assert np.sum(inertia) < 5300.
     print(np.std(inertia)/np.mean(inertia))
-    assert np.std(inertia) < 0.18 * np.mean(inertia)
+    assert np.std(inertia) < 0.2 * np.mean(inertia)
     print('mean counts = ',np.mean(counts))
     print('min counts = ',np.min(counts))
     print('max counts = ',np.max(counts))
@@ -429,7 +429,7 @@ def test_2d():
     print('rms inertia = ',np.std(inertia))
     assert np.sum(inertia) < 5300.
     print(np.std(inertia)/np.mean(inertia))
-    assert np.std(inertia) < 0.09 * np.mean(inertia)
+    assert np.std(inertia) < 0.1 * np.mean(inertia)
     print('mean counts = ',np.mean(counts))
     print('min counts = ',np.min(counts))
     print('max counts = ',np.max(counts))

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -28,7 +28,7 @@ def test_dessv():
         print('Skip test_dessv, since fitsio not installed')
         return
 
-    rng = np.random.default_rng(12345)
+    rng = np.random.default_rng(123)
 
     #treecorr.set_omp_threads(1);
     get_from_wiki('des_sv.fits')

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1764,10 +1764,10 @@ def test_split():
     # If cat has an rng though, they should be identical.
     # (Also need single thread, else the random values come in a different order still.)
     cat.nfields.clear()
-    cat._rng = np.random.RandomState(1234)
+    cat._rng = np.random.default_rng(1234)
     dd_random1.process(cat, num_threads=1)
     cat.nfields.clear()
-    cat._rng = np.random.RandomState(1234)
+    cat._rng = np.random.default_rng(1234)
     dd_random2.process(cat, num_threads=1)
     np.testing.assert_array_equal(dd_random1.npairs, dd_random2.npairs)
 

--- a/tests/test_patch3pt.py
+++ b/tests/test_patch3pt.py
@@ -145,6 +145,7 @@ def test_kkk_jk():
     rng = np.random.RandomState(12345)
     x, y, _, _, k = generate_shear_field(nsource, nhalo, rng)
     cat = treecorr.Catalog(x=x, y=y, k=k)
+    rng = np.random.default_rng(1234)
     kkk = treecorr.KKKCorrelation(nbins=3, min_sep=30., max_sep=100.,
                                   min_u=0.9, max_u=1.0, nubins=1,
                                   min_v=0.0, max_v=0.1, nvbins=1, rng=rng)
@@ -200,7 +201,7 @@ def test_kkk_jk():
     np.testing.assert_allclose(C, cov)
 
     print('marked:')
-    rng_state = kkkp.rng.get_state()
+    rng_state = kkkp.rng.bit_generator.state
     cov = kkkp.estimate_cov('marked_bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_kkk))))
@@ -208,7 +209,7 @@ def test_kkk_jk():
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_kkk), atol=0.7*tol_factor)
 
     # Test design matrix
-    kkkp.rng.set_state(rng_state)
+    kkkp.rng.bit_generator.state = rng_state
     A, w = kkkp.build_cov_design_matrix('marked_bootstrap')
     nboot = A.shape[0]
     A -= np.mean(A, axis=0)
@@ -216,7 +217,7 @@ def test_kkk_jk():
     np.testing.assert_allclose(C, cov)
 
     print('bootstrap:')
-    rng_state = kkkp.rng.get_state()
+    rng_state = kkkp.rng.bit_generator.state
     cov = kkkp.estimate_cov('bootstrap')
     print(np.diagonal(cov))
     print('max log(ratio) = ',np.max(np.abs(np.log(np.diagonal(cov))-np.log(var_kkk))))
@@ -224,7 +225,7 @@ def test_kkk_jk():
     np.testing.assert_allclose(np.log(np.diagonal(cov)), np.log(var_kkk), atol=0.3*tol_factor)
 
     # Test design matrix
-    kkkp.rng.set_state(rng_state)
+    kkkp.rng.bit_generator.state = rng_state
     A, w = kkkp.build_cov_design_matrix('bootstrap')
     nboot = A.shape[0]
     A -= np.mean(A, axis=0)
@@ -632,6 +633,7 @@ def test_ggg_jk():
     rng = np.random.RandomState(12345)
     x, y, g1, g2, _ = generate_shear_field(nsource, nhalo, rng)
     cat = treecorr.Catalog(x=x, y=y, g1=g1, g2=g2)
+    rng = np.random.default_rng(12345)
     ggg = treecorr.GGGCorrelation(nbins=1, min_sep=20., max_sep=40.,
                                   min_u=0.6, max_u=1.0, nubins=1,
                                   min_v=0.0, max_v=0.6, nvbins=1, rng=rng)
@@ -1155,6 +1157,7 @@ def test_nnn_jk():
     # Make the patches with a large random catalog to make sure the patches are uniform area.
     big_rx = rng.uniform(0,1000, 100*nsource)
     big_ry = rng.uniform(0,1000, 100*nsource)
+    rng = np.random.default_rng(1234)
     big_catp = treecorr.Catalog(x=big_rx, y=big_ry, npatch=npatch, rng=rng)
     patch_centers = big_catp.patch_centers
 
@@ -1570,6 +1573,7 @@ def test_brute_jk():
     rx = rng.uniform(0,1000, rand_factor*ngal)
     ry = rng.uniform(0,1000, rand_factor*ngal)
     rand_cat_nopatch = treecorr.Catalog(x=rx, y=ry)
+    rng = np.random.default_rng(8675309)
     rand_cat = treecorr.Catalog(x=rx, y=ry, npatch=npatch, rng=rng)
     patch_centers = rand_cat.patch_centers
 

--- a/treecorr/catalog.py
+++ b/treecorr/catalog.py
@@ -372,8 +372,9 @@ class Catalog(object):
                             should be an integer, which specifies how many digits to write.
                             (default: 16)
 
-        rng (RandomState):  If desired, a numpy.random.RandomState instance to use for any random
-                            number generation (e.g. kmeans patches). (default: None)
+        rng (np.Generator): If desired, a numpy.random.Generator or numpy.random.RandomState
+                            instance to use for any random number generation (e.g. kmeans patches).
+                            (default: None)
 
         num_threads (int):  How many OpenMP threads to use during the catalog load steps.
                             (default: use the number of cpu cores)

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -1096,8 +1096,10 @@ class Corr2(object):
         i1 = np.zeros(n, dtype=int)
         i2 = np.zeros(n, dtype=int)
         sep = np.zeros(n, dtype=float)
+        seed = 0 if self.rng is None else int(self.rng.random() * 2**63)
         ntot = self.corr.samplePairs(f1.data, f2.data, min_sep, max_sep,
-                                     self._bintype, self._metric, i1, i2, sep)
+                                     self._bintype, self._metric, seed,
+                                     i1, i2, sep)
 
         if ntot < n:
             n = ntot

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -475,7 +475,7 @@ class Corr2(object):
     @property
     def rng(self):
         if self._rng is None:
-            self._rng = np.random.RandomState()
+            self._rng = np.random.default_rng()
         return self._rng
 
     # Properties for all the read-only attributes ("ro" stands for "read-only")
@@ -1628,7 +1628,9 @@ def _design_marked(corrs, func, comm=None):
     plist = []
     for k in range(nboot):
         # Select a random set of indices to use.  (Will have repeats.)
-        index = corrs[0].rng.randint(npatch, size=npatch)
+        # Note use choice rather than integers, so it is backwards compatible with the old
+        # np.random.RandomState (which used randint rather than integers for that functionality).
+        index = corrs[0].rng.choice(np.arange(npatch), size=npatch, replace=True)
         vpairs = [c._marked_pairs(index) for c in corrs]
         plist.append(vpairs)
 
@@ -1664,7 +1666,7 @@ def _design_bootstrap(corrs, func, comm=None):
 
     plist = []
     for k in range(nboot):
-        index = corrs[0].rng.randint(npatch, size=npatch)
+        index = corrs[0].rng.choice(np.arange(npatch), size=npatch, replace=True)
         vpairs = [c._bootstrap_pairs(index) for c in corrs]
         plist.append(vpairs)
 

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -1096,7 +1096,7 @@ class Corr2(object):
         i1 = np.zeros(n, dtype=int)
         i2 = np.zeros(n, dtype=int)
         sep = np.zeros(n, dtype=float)
-        ntot = self.corr.samplePairs(f1.data, f2.data, min_sep, max_sep, self._coords,
+        ntot = self.corr.samplePairs(f1.data, f2.data, min_sep, max_sep,
                                      self._bintype, self._metric, i1, i2, sep)
 
         if ntot < n:

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -501,7 +501,7 @@ class Corr3(object):
     @property
     def rng(self):
         if self._rng is None:
-            self._rng = np.random.RandomState()
+            self._rng = np.random.default_rng()
         return self._rng
 
     # Properties for all the read-only attributes ("ro" stands for "read-only")

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -422,11 +422,11 @@ class Field(object):
             centers = np.empty((npatch, 3))
         seed = 0 if rng is None else int(rng.random_sample() * 2**63)
         if init == 'tree':
-            self.data.KMeansInitTree(centers, int(npatch), self._coords, seed)
+            self.data.KMeansInitTree(centers, int(npatch), seed)
         elif init == 'random':
-            self.data.KMeansInitRand(centers, int(npatch), self._coords, seed)
+            self.data.KMeansInitRand(centers, int(npatch), seed)
         elif init == 'kmeans++':
-            self.data.KMeansInitKMPP(centers, int(npatch), self._coords, seed)
+            self.data.KMeansInitKMPP(centers, int(npatch), seed)
         else:
             raise ValueError("Invalid init: %s. "%init +
                              "Must be one of 'tree', 'random', or 'kmeans++.'")
@@ -477,8 +477,7 @@ class Field(object):
                                 (default: False)
         """
         npatch = centers.shape[0]
-        self.data.KMeansRun(centers, npatch, int(max_iter), float(tol),
-                            bool(alt), self._coords)
+        self.data.KMeansRun(centers, npatch, int(max_iter), float(tol), bool(alt))
 
     def kmeans_assign_patches(self, centers):
         """Assign patch numbers to each point according to the given centers.
@@ -498,7 +497,7 @@ class Field(object):
         patches = np.empty(self.ntot, dtype=int)
         npatch = centers.shape[0]
         centers = np.ascontiguousarray(centers)
-        self.data.KMeansAssign(centers, npatch, patches, self._coords)
+        self.data.KMeansAssign(centers, npatch, patches)
         return patches
 
 
@@ -550,9 +549,18 @@ class NField(Field):
 
         zx = cat.z if cat.z is not None else np.array([])
         wpx = cat.wpos if cat.wpos is not None else np.array([])
-        self.data = _treecorr.NField(cat.x, cat.y, zx, cat.w, wpx,
-                                     self.min_size, self.max_size, self._sm, seed,
-                                     self.brute, self.min_top, self.max_top, self._coords)
+        if self._coords == _treecorr.Flat:
+            self.data = _treecorr.NFieldFlat(cat.x, cat.y, zx, cat.w, wpx,
+                                             self.min_size, self.max_size, self._sm, seed,
+                                             self.brute, self.min_top, self.max_top)
+        elif self._coords == _treecorr.Sphere:
+            self.data = _treecorr.NFieldSphere(cat.x, cat.y, zx, cat.w, wpx,
+                                               self.min_size, self.max_size, self._sm, seed,
+                                               self.brute, self.min_top, self.max_top)
+        else:
+            self.data = _treecorr.NFieldThreeD(cat.x, cat.y, zx, cat.w, wpx,
+                                               self.min_size, self.max_size, self._sm, seed,
+                                               self.brute, self.min_top, self.max_top)
         if logger:
             logger.debug('Finished building NField (%s)',self.coords)
 
@@ -605,9 +613,18 @@ class KField(Field):
 
         zx = cat.z if cat.z is not None else np.array([])
         wpx = cat.wpos if cat.wpos is not None else np.array([])
-        self.data = _treecorr.KField(cat.x, cat.y, zx, cat.k, cat.w, wpx,
-                                     self.min_size, self.max_size, self._sm, seed,
-                                     self.brute, self.min_top, self.max_top, self._coords)
+        if self._coords == _treecorr.Flat:
+            self.data = _treecorr.KFieldFlat(cat.x, cat.y, zx, cat.k, cat.w, wpx,
+                                             self.min_size, self.max_size, self._sm, seed,
+                                             self.brute, self.min_top, self.max_top)
+        elif self._coords == _treecorr.Sphere:
+            self.data = _treecorr.KFieldSphere(cat.x, cat.y, zx, cat.k, cat.w, wpx,
+                                               self.min_size, self.max_size, self._sm, seed,
+                                               self.brute, self.min_top, self.max_top)
+        else:
+            self.data = _treecorr.KFieldThreeD(cat.x, cat.y, zx, cat.k, cat.w, wpx,
+                                               self.min_size, self.max_size, self._sm, seed,
+                                               self.brute, self.min_top, self.max_top)
         if logger:
             logger.debug('Finished building KField (%s)',self.coords)
 
@@ -660,8 +677,17 @@ class GField(Field):
 
         zx = cat.z if cat.z is not None else np.array([])
         wpx = cat.wpos if cat.wpos is not None else np.array([])
-        self.data = _treecorr.GField(cat.x, cat.y, zx, cat.g1, cat.g2, cat.w, wpx,
-                                     self.min_size, self.max_size, self._sm, seed,
-                                     self.brute, self.min_top, self.max_top, self._coords)
+        if self._coords == _treecorr.Flat:
+            self.data = _treecorr.GFieldFlat(cat.x, cat.y, zx, cat.g1, cat.g2, cat.w, wpx,
+                                             self.min_size, self.max_size, self._sm, seed,
+                                             self.brute, self.min_top, self.max_top)
+        elif self._coords == _treecorr.Sphere:
+            self.data = _treecorr.GFieldSphere(cat.x, cat.y, zx, cat.g1, cat.g2, cat.w, wpx,
+                                               self.min_size, self.max_size, self._sm, seed,
+                                               self.brute, self.min_top, self.max_top)
+        else:
+            self.data = _treecorr.GFieldThreeD(cat.x, cat.y, zx, cat.g1, cat.g2, cat.w, wpx,
+                                               self.min_size, self.max_size, self._sm, seed,
+                                               self.brute, self.min_top, self.max_top)
         if logger:
             logger.debug('Finished building GField (%s)',self.coords)

--- a/treecorr/field.py
+++ b/treecorr/field.py
@@ -420,7 +420,7 @@ class Field(object):
             centers = np.empty((npatch, 2))
         else:
             centers = np.empty((npatch, 3))
-        seed = 0 if rng is None else int(rng.random_sample() * 2**63)
+        seed = 0 if rng is None else int(rng.random() * 2**63)
         if init == 'tree':
             self.data.KMeansInitTree(centers, int(npatch), seed)
         elif init == 'random':
@@ -545,7 +545,7 @@ class NField(Field):
         self.min_top, self.max_top = self._determine_top(min_top, max_top)
         self.coords = coords if coords is not None else cat.coords
         self._coords = coord_enum(self.coords)  # These are the C++-layer enums
-        seed = 0 if rng is None else int(rng.random_sample() * 2**63)
+        seed = 0 if rng is None else int(rng.random() * 2**63)
 
         zx = cat.z if cat.z is not None else np.array([])
         wpx = cat.wpos if cat.wpos is not None else np.array([])
@@ -609,7 +609,7 @@ class KField(Field):
         self.min_top, self.max_top = self._determine_top(min_top, max_top)
         self.coords = coords if coords is not None else cat.coords
         self._coords = coord_enum(self.coords)  # These are the C++-layer enums
-        seed = 0 if rng is None else int(rng.random_sample() * 2**63)
+        seed = 0 if rng is None else int(rng.random() * 2**63)
 
         zx = cat.z if cat.z is not None else np.array([])
         wpx = cat.wpos if cat.wpos is not None else np.array([])
@@ -673,7 +673,7 @@ class GField(Field):
         self.min_top, self.max_top = self._determine_top(min_top, max_top)
         self.coords = coords if coords is not None else cat.coords
         self._coords = coord_enum(self.coords)  # These are the C++-layer enums
-        seed = 0 if rng is None else int(rng.random_sample() * 2**63)
+        seed = 0 if rng is None else int(rng.random() * 2**63)
 
         zx = cat.z if cat.z is not None else np.array([])
         wpx = cat.wpos if cat.wpos is not None else np.array([])

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -206,7 +206,7 @@ class GGCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         self.corr.processAuto(field.data, self.output_dots,
-                              self._coords, self._bintype, self._metric)
+                              self._bintype, self._metric)
 
 
     def process_cross(self, cat1, cat2, *, metric=None, num_threads=None):
@@ -250,7 +250,7 @@ class GGCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         self.corr.processCross(f1.data, f2.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def getStat(self):
         """The standard statistic for the current correlation object as a 1-d array.

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -297,7 +297,7 @@ class GGGCorrelation(Corr3):
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         self.corr.processAuto(field.data, self.output_dots,
-                              self._coords, self._bintype, self._metric)
+                              self._bintype, self._metric)
 
     def process_cross12(self, cat1, cat2, *, metric=None, num_threads=None):
         """Process two catalogs, accumulating the 3pt cross-correlation, where one of the
@@ -346,7 +346,7 @@ class GGGCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.corr.processCross12(self.corr, self.corr,
                                  f1.data, f2.data, self.output_dots,
-                                 self._coords, self._bintype, self._metric)
+                                 self._bintype, self._metric)
 
     def process_cross(self, cat1, cat2, cat3, *, metric=None, num_threads=None):
         """Process a set of three catalogs, accumulating the 3pt cross-correlation.
@@ -398,7 +398,7 @@ class GGGCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.corr.processCross(self.corr, self.corr, self.corr, self.corr, self.corr,
                                f1.data, f2.data, f3.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def _finalize(self):
         mask1 = self.weight != 0
@@ -1357,7 +1357,7 @@ class GGGCrossCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.g1g2g3.corr.processCross12(self.g2g1g3.corr, self.g2g3g1.corr,
                                         f1.data, f2.data, self.output_dots,
-                                        self._coords, self._bintype, self._metric)
+                                        self._bintype, self._metric)
 
     def process_cross(self, cat1, cat2, cat3, *, metric=None, num_threads=None):
         """Process a set of three catalogs, accumulating the 3pt cross-correlation.
@@ -1410,7 +1410,7 @@ class GGGCrossCorrelation(Corr3):
                                       self.g2g1g3.corr, self.g2g3g1.corr,
                                       self.g3g1g2.corr, self.g3g2g1.corr,
                                       f1.data, f2.data, f3.data, self.output_dots,
-                                      self._coords, self._bintype, self._metric)
+                                      self._bintype, self._metric)
 
     def _finalize(self):
         for ggg in self._all:

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -208,7 +208,7 @@ class KGCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         self.corr.processCross(f1.data, f2.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def _finalize(self):
         mask1 = self.weight != 0

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -198,7 +198,7 @@ class KKCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         self.corr.processAuto(field.data, self.output_dots,
-                              self._coords, self._bintype, self._metric)
+                              self._bintype, self._metric)
 
     def process_cross(self, cat1, cat2, *, metric=None, num_threads=None):
         """Process a single pair of catalogs, accumulating the cross-correlation.
@@ -241,7 +241,7 @@ class KKCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         self.corr.processCross(f1.data, f2.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def _finalize(self):
         mask1 = self.weight != 0

--- a/treecorr/kkkcorrelation.py
+++ b/treecorr/kkkcorrelation.py
@@ -228,7 +228,7 @@ class KKKCorrelation(Corr3):
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         self.corr.processAuto(field.data, self.output_dots,
-                              self._coords, self._bintype, self._metric)
+                              self._bintype, self._metric)
 
     def process_cross12(self, cat1, cat2, *, metric=None, num_threads=None):
         """Process two catalogs, accumulating the 3pt cross-correlation, where one of the
@@ -277,7 +277,7 @@ class KKKCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.corr.processCross12(self.corr, self.corr,
                                  f1.data, f2.data, self.output_dots,
-                                 self._coords, self._bintype, self._metric)
+                                 self._bintype, self._metric)
 
     def process_cross(self, cat1, cat2, cat3, *, metric=None, num_threads=None):
         """Process a set of three catalogs, accumulating the 3pt cross-correlation.
@@ -329,7 +329,7 @@ class KKKCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.corr.processCross(self.corr, self.corr, self.corr, self.corr, self.corr,
                                f1.data, f2.data, f3.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def _finalize(self):
         mask1 = self.weight != 0
@@ -838,7 +838,7 @@ class KKKCrossCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.k1k2k3.corr.processCross12(self.k2k1k3.corr, self.k2k3k1.corr,
                                         f1.data, f2.data, self.output_dots,
-                                        self._coords, self._bintype, self._metric)
+                                        self._bintype, self._metric)
 
     def process_cross(self, cat1, cat2, cat3, *, metric=None, num_threads=None):
         """Process a set of three catalogs, accumulating the 3pt cross-correlation.
@@ -891,7 +891,7 @@ class KKKCrossCorrelation(Corr3):
                                       self.k2k1k3.corr, self.k2k3k1.corr,
                                       self.k3k1k2.corr, self.k3k2k1.corr,
                                       f1.data, f2.data, f3.data, self.output_dots,
-                                      self._coords, self._bintype, self._metric)
+                                      self._bintype, self._metric)
 
     def _finalize(self):
         for kkk in self._all:

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -218,7 +218,7 @@ class NGCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         self.corr.processCross(f1.data, f2.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def _finalize(self):
         mask1 = self.weight != 0

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -217,7 +217,7 @@ class NKCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         self.corr.processCross(f1.data, f2.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
 
     def _finalize(self):
         mask1 = self.weight != 0

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -230,7 +230,7 @@ class NNCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         self.corr.processAuto(field.data, self.output_dots,
-                              self._coords, self._bintype, self._metric)
+                              self._bintype, self._metric)
         self.tot += 0.5 * cat.sumw**2
 
     def process_cross(self, cat1, cat2, *, metric=None, num_threads=None):
@@ -273,7 +273,7 @@ class NNCorrelation(Corr2):
 
         self.logger.info('Starting %d jobs.',f1.nTopLevelNodes)
         self.corr.processCross(f1.data, f2.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
         self.tot += cat1.sumw*cat2.sumw
 
     def _finalize(self):

--- a/treecorr/nnncorrelation.py
+++ b/treecorr/nnncorrelation.py
@@ -267,7 +267,7 @@ class NNNCorrelation(Corr3):
 
         self.logger.info('Starting %d jobs.',field.nTopLevelNodes)
         self.corr.processAuto(field.data, self.output_dots,
-                              self._coords, self._bintype, self._metric)
+                              self._bintype, self._metric)
         self.tot += (1./6.) * cat.sumw**3
 
     def process_cross12(self, cat1, cat2, *, metric=None, num_threads=None):
@@ -317,7 +317,7 @@ class NNNCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.corr.processCross12(self.corr, self.corr,
                                  f1.data, f2.data, self.output_dots,
-                                 self._coords, self._bintype, self._metric)
+                                 self._bintype, self._metric)
         self.tot += cat1.sumw * cat2.sumw**2 / 2.
 
     def process_cross(self, cat1, cat2, cat3, *, metric=None, num_threads=None):
@@ -370,7 +370,7 @@ class NNNCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.corr.processCross(self.corr, self.corr, self.corr, self.corr, self.corr,
                                f1.data, f2.data, f3.data, self.output_dots,
-                               self._coords, self._bintype, self._metric)
+                               self._bintype, self._metric)
         self.tot += cat1.sumw * cat2.sumw * cat3.sumw
 
     def _finalize(self):
@@ -1200,7 +1200,7 @@ class NNNCrossCorrelation(Corr3):
         # into self.corr, whichever way the three catalogs are permuted for each triangle.
         self.n1n2n3.corr.processCross12(self.n2n1n3.corr, self.n2n3n1.corr,
                                         f1.data, f2.data, self.output_dots,
-                                        self._coords, self._bintype, self._metric)
+                                        self._bintype, self._metric)
         tot = cat1.sumw * cat2.sumw**2 / 2.
         self.n1n2n3.tot += tot
         self.n2n1n3.tot += tot
@@ -1258,7 +1258,7 @@ class NNNCrossCorrelation(Corr3):
                                       self.n2n1n3.corr, self.n2n3n1.corr,
                                       self.n3n1n2.corr, self.n3n2n1.corr,
                                       f1.data, f2.data, f3.data, self.output_dots,
-                                      self._coords, self._bintype, self._metric)
+                                      self._bintype, self._metric)
         tot = cat1.sumw * cat2.sumw * cat3.sumw
         for nnn in self._all:
             nnn.tot += tot


### PR DESCRIPTION
Before adding more data type combinations (e.g. NGG, NNG) or new data types (e.g. spin-1 and spin-4 quantities), I wanted to do some refactoring of the internal structure in the C++ code.  

Currently, the code uses template meta-programming to have the compiler generate different functions for the different metrics, bin types, data types, and more.  These make the code faster by avoiding if statements in high-traffic functions by determining the branching at compile time rather than run time.  However, they also make the compiled library fairly large, since the core functions have up to 6 template parameters, each of which takes on from 3 to 6 values.  So that's a lot of combinations, which are about to increase when I add more types of correlations.

I realized that this wasn't really necessary -- that I could refactor the code to remove the data type parameters from the list of template parameters in the core tree processing functions and use virtual functions to get the right function for the final step where the data types actually matter.

This reduced the compiled library size by more than a factor of 2.  And moreover, with the new code structure, when I add additional data types, it won't cause the library size to blow up nearly as much as it would have.