### PR TITLE
Add angle_slop parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,7 +70,7 @@ New features
 - Added ``patch_method`` option to ``process``, and specifically a "local" option.  This is
   not particularly recommended for most use cases, but it is required for the multipole
   three-point method, for which it is the default. (#169)
-- Added ``angle_slop`` option to separately tune the allowed angular slop from cell binning,
+- Added ``angle_slop`` option to separately tune the allowed angular slop from using cells,
   irrespective of the binning. (#170)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ API Changes
 - Switched the default binning for three-point correlations to LogSAS, rather than LogRUV. (#166)
 - Changed estimate_cov with method='shot' to only return the diagonal, rather than gratuitously
   making a full, mostly empty diagonal matrix. (#166)
-- Changed name of Catalog.write kwarg from cat_precision to just precision. (#168)
+- Changed name of Catalog.write kwarg from cat_precision to just precision. (#169)
 
 
 Performance improvements
@@ -56,7 +56,7 @@ New features
 - Allow vark, varg, varv for a Catalog be specifiable on input, rather than calculated directly
   from the corresponding values. (#154)
 - Allow numpy.random.Generator for rng arguments (in addition to legacy RandomState). (#157)
-- Added spin-1 correlations using the letter V (for Velocity), including `NVCorrelation`,
+- Added spin-1 correlations using the letter V (for Vector), including `NVCorrelation`,
   `KVCorrelation` and `VVCorrelation`. (#158)
 - Added spin-3 and spin-4 correlations using the letters T (for Trefoil) and Q (for Quatrefoil)
   respectively, including `NTCorrelation`, `KTCorrelation`, `TTCorrelation`, `NQCorrelation`,
@@ -65,6 +65,13 @@ New features
 - Added ``ordered=True`` option to the 3pt ``process`` methods for keeping the order of the
   catalogs fixed in the triangle orientation. (#165)
 - Added ``bin_type='LogSAS'`` for 3pt correlations. (#165)
+- Added ``bin_type='LogMultipole'`` for 3pt correlations and method `GGGCorrelation.toSAS` to
+  convert from this format to the LogSAS binning if desired. (#167)
+- Added ``patch_method`` option to ``process``, and specifically a "local" option.  This is
+  not particularly recommended for most use cases, but it is required for the multipole
+  three-point method, for which it is the default. (#169)
+- Added ``angle_slop`` option to separately tune the allowed angular slop from cell binning,
+  irrespective of the binning. (#170)
 
 
 Bug fixes

--- a/docs/binning.rst
+++ b/docs/binning.rst
@@ -229,22 +229,22 @@ angle_slop
 
 For some calculations, the angular orientation of the line between two points is relevant
 to the correlation.  For any complex quantity (e.g. shear), the value used in the correlation
-has to be projected on the the line between the two points (for two-point correlations) or
+has to be projected onto the the line between the two points (for two-point correlations) or
 the centroid of the triangle (for three-point correlations).  Even for scalar quantities,
 three-point correlations using the multipole method also use the angular direction of the
 lines between points.
 
 In such cases, another optional parameter, called ``angle_slop`` provides a slightly different
-accuracy/speed trade off than the one provided by ``bin_slop``.  It sets the maximum error
-allowed in the separation direction between two points relative to the direction between
-the corresponding cells when deciding whether to accumulate a pair of cells.  If some object
-pairs would have a direction that is more than ``angle_slop`` radians different from the
-cell pair direction, then the cells will be split further, even if they would pass the
-``bin_slop`` criterion.
+accuracy/speed trade off than the one provided by ``bin_slop``.  It sets the maximum allowed
+angular difference between the line connecting two cells to be accumulated and the lines connecting
+any two of their consituent points.  If the line connecting some pair has a direction that is more
+than ``angle_slop`` radians different from the cell pair direction, then the cells will be split
+further, even if they would pass the ``bin_slop`` criterion.
 
 This parameter allows one to use fairly large bins for shear (or other non-spin-0) correlations
 and tune the accuracy of the projections without worrying that some pairs of cells will have
-large projection errors because a pair of cells happen to fit precisely in a single bin.
+large projection errors because the range of separations for a pair of cells happen to fit
+precisely into a single bin.
 
 
 brute

--- a/docs/binning.rst
+++ b/docs/binning.rst
@@ -224,6 +224,29 @@ down, so the resulting counts come out pretty close to correct.  Furthermore, th
 number of pairs within the specified range is always correct, since each pair is placed
 in some bin.
 
+angle_slop
+^^^^^^^^^^
+
+For some calculations, the angular orientation of the line between two points is relevant
+to the correlation.  For any complex quantity (e.g. shear), the value used in the correlation
+has to be projected on the the line between the two points (for two-point correlations) or
+the centroid of the triangle (for three-point correlations).  Even for scalar quantities,
+three-point correlations using the multipole method also use the angular direction of the
+lines between points.
+
+In such cases, another optional parameter, called ``angle_slop`` provides a slightly different
+accuracy/speed trade off than the one provided by ``bin_slop``.  It sets the maximum error
+allowed in the separation direction between two points relative to the direction between
+the corresponding cells when deciding whether to accumulate a pair of cells.  If some object
+pairs would have a direction that is more than ``angle_slop`` radians different from the
+cell pair direction, then the cells will be split further, even if they would pass the
+``bin_slop`` criterion.
+
+This parameter allows one to use fairly large bins for shear (or other non-spin-0) correlations
+and tune the accuracy of the projections without worrying that some pairs of cells will have
+large projection errors because a pair of cells happen to fit precisely in a single bin.
+
+
 brute
 ^^^^^
 
@@ -250,8 +273,8 @@ Shear correlations require parallel transporting the shear values to the centers
 the cells, and then when accumulating pairs, the shears are projected onto the line joining
 the two points.  Both of these lead to slight differences in the results of a ``bin_slop`` = 0
 calculation compared to the true brute force calculation.
-If the difference is seen to matter for you, this is probably a sign that you should decrease
-your bin size.
+If the difference is seen to matter for you, then the above ``angle_slop`` parameter can be used
+to increase the accuracy of the projections, separate from the ``bin_slop`` considerations.
 
 Additionally, there is one other way to use the ``brute`` parameter.  If you set
 ``brute`` to 1 or 2, rather than True or False, then the forced traversal to the

--- a/docs/correlation2.rst
+++ b/docs/correlation2.rst
@@ -2,20 +2,26 @@
 Two-point Correlation Functions
 ===============================
 
-There are 6 differenct classes for calculating the different possible two-point correlation
-functions:
+There are a number of differenct classes for calculating the different possible two-point
+correlation functions:
 
 .. toctree::
 
     nn
     nk
     kk
-    ng
-    kg
-    gg
     nv
     kv
     vv
+    ng
+    kg
+    gg
+    nt
+    kt
+    gt
+    nq
+    kq
+    gq
 
 Each of the above classes is a sub-class of the base class Corr2, so they have a number of
 features in common about how they are constructed.  The common features are documented here.

--- a/docs/kq.rst
+++ b/docs/kq.rst
@@ -1,0 +1,10 @@
+
+KQCorrelation: Scalar-quatrefoil correlations
+---------------------------------------------
+
+.. autoclass:: treecorr.KQCorrelation
+    :members:
+    :special-members:
+    :show-inheritance:
+
+

--- a/docs/kt.rst
+++ b/docs/kt.rst
@@ -1,0 +1,10 @@
+
+KTCorrelation: Scalar-trefoil correlations
+------------------------------------------
+
+.. autoclass:: treecorr.KTCorrelation
+    :members:
+    :special-members:
+    :show-inheritance:
+
+

--- a/docs/nq.rst
+++ b/docs/nq.rst
@@ -1,0 +1,10 @@
+
+NQCorrelation: Count-quatrefoil correlations
+--------------------------------------------
+
+.. autoclass:: treecorr.NQCorrelation
+    :members:
+    :special-members:
+    :show-inheritance:
+
+

--- a/docs/nt.rst
+++ b/docs/nt.rst
@@ -1,0 +1,10 @@
+
+NTCorrelation: Count-trefoil correlations
+-----------------------------------------
+
+.. autoclass:: treecorr.NTCorrelation
+    :members:
+    :special-members:
+    :show-inheritance:
+
+

--- a/docs/qq.rst
+++ b/docs/qq.rst
@@ -1,0 +1,10 @@
+
+QQCorrelation: Quatrefoil-quatrefoil correlations
+-------------------------------------------------
+
+.. autoclass:: treecorr.QQCorrelation
+    :members:
+    :special-members:
+    :show-inheritance:
+
+

--- a/docs/tt.rst
+++ b/docs/tt.rst
@@ -1,0 +1,10 @@
+
+TTCorrelation: Trefoil-trefoil correlations
+-------------------------------------------
+
+.. autoclass:: treecorr.TTCorrelation
+    :members:
+    :special-members:
+    :show-inheritance:
+
+

--- a/include/BinType.h
+++ b/include/BinType.h
@@ -93,7 +93,7 @@ struct BinTypeHelper<Log>
     template <int C>
     static bool singleBin(double rsq, double s1ps2,
                           const Position<C>& p1, const Position<C>& p2,
-                          double binsize, double b, double bsq,
+                          double binsize, double b, double bsq, double a, double asq,
                           double minsep, double maxsep, double logminsep,
                           int& ik, double& r, double& logr)
     {
@@ -106,6 +106,9 @@ struct BinTypeHelper<Log>
         // s1 + s2 <= b * r
         double s1ps2sq = s1ps2 * s1ps2;
         if (s1ps2sq <= bsq*rsq) return true;
+
+        // Check for angle being too large.
+        if (s1ps2sq > asq*rsq) return false;
 
         // If s1+s2 > 0.5 * (binsize + b) * r, then the total leakage (on both sides perhaps)
         // will be more than b.  I.e. too much slop.
@@ -194,7 +197,7 @@ struct BinTypeHelper<Linear>
     template <int C>
     static bool singleBin(double rsq, double s1ps2,
                           const Position<C>& p1, const Position<C>& p2,
-                          double binsize, double b, double bsq,
+                          double binsize, double b, double bsq, double a, double asq,
                           double minsep, double maxsep, double logminsep,
                           int& ik, double& r, double& logr)
     {
@@ -204,6 +207,9 @@ struct BinTypeHelper<Linear>
         // s1 + s2 <= b
         // Note: this automatically includes the s1ps2 == 0 case, so don't do it separately.
         if (s1ps2 <= b) return true;
+
+        // Check for angle being too large.
+        if (SQR(s1ps2) > asq*rsq) return false;
 
         // If s1+s2 > 0.5 * (binsize + b), then the total leakage (on both sides perhaps)
         // will be more than b.  I.e. too much slop.
@@ -306,7 +312,7 @@ struct BinTypeHelper<TwoD>
     template <int C>
     static bool singleBin(double rsq, double s1ps2,
                           const Position<C>& p1, const Position<C>& p2,
-                          double binsize, double b, double bsq,
+                          double binsize, double b, double bsq, double a, double asq,
                           double minsep, double maxsep, double logminsep,
                           int& k, double& r, double& logr)
     {
@@ -315,6 +321,9 @@ struct BinTypeHelper<TwoD>
         // Standard stop splitting criterion.
         // s1 + s2 <= b
         if (s1ps2 <= b) return true;
+
+        // Check for angle being too large.
+        if (SQR(s1ps2) > asq*rsq) return false;
 
         // If s1+s2 > 0.5 * (binsize + b), then the total leakage (on both sides perhaps)
         // will be more than b.  I.e. too much slop.

--- a/include/Corr2.h
+++ b/include/Corr2.h
@@ -31,7 +31,8 @@ class BaseCorr2
 {
 public:
 
-    BaseCorr2(BinType bin_type, double minsep, double maxsep, int nbins, double binsize, double b,
+    BaseCorr2(BinType bin_type, double minsep, double maxsep, int nbins, double binsize,
+              double b, double a,
               double minrpar, double maxrpar, double xp, double yp, double zp);
     BaseCorr2(const BaseCorr2& rhs);
     virtual ~BaseCorr2() {}
@@ -109,6 +110,7 @@ protected:
     int _nbins;
     double _binsize;
     double _b;
+    double _a;
     double _minrpar, _maxrpar;
     double _xp, _yp, _zp;
     double _logminsep;
@@ -116,6 +118,7 @@ protected:
     double _minsepsq;
     double _maxsepsq;
     double _bsq;
+    double _asq;
     double _fullmaxsep;
     double _fullmaxsepsq;
     int _coords; // Stores the kind of coordinates being used for the analysis.
@@ -128,7 +131,8 @@ class Corr2 : public BaseCorr2
 
 public:
 
-    Corr2(BinType bin_type, double minsep, double maxsep, int nbins, double binsize, double b,
+    Corr2(BinType bin_type, double minsep, double maxsep, int nbins, double binsize,
+          double b, double a,
           double minrpar, double maxrpar, double xp, double yp, double zp,
           double* xi0, double* xi1, double* xi2, double* xi3,
           double* meanr, double* meanlogr, double* weight, double* npairs);

--- a/include/Corr3.h
+++ b/include/Corr3.h
@@ -34,7 +34,8 @@ class BaseCorr3
 {
 public:
 
-    BaseCorr3(BinType bin_type, double minsep, double maxsep, int nbins, double binsize, double b,
+    BaseCorr3(BinType bin_type, double minsep, double maxsep, int nbins, double binsize,
+              double b, double a,
               double minu, double maxu, int nubins, double ubinsize, double bu,
               double minv, double maxv, int nvbins, double vbinsize, double bv,
               double xp, double yp, double zp);
@@ -224,6 +225,7 @@ protected:
     int _nbins;
     double _binsize;
     double _b;
+    double _a;
     double _minu;
     double _maxu;
     int _nubins;
@@ -244,6 +246,7 @@ protected:
     double _minvsq;
     double _maxvsq;
     double _bsq;
+    double _asq;
     double _busq;
     double _bvsq;
     int _ntot; // Total number of bins (e.g. nbins * nubins * nvbins * 2 for LogRUV)
@@ -256,7 +259,8 @@ class Corr3 : public BaseCorr3
 {
 public:
 
-    Corr3(BinType bin_type, double minsep, double maxsep, int nbins, double binsize, double b,
+    Corr3(BinType bin_type, double minsep, double maxsep, int nbins, double binsize,
+          double b, double a,
           double minu, double maxu, int nubins, double ubinsize, double bu,
           double minv, double maxv, int nvbins, double vbinsize, double bv,
           double xp, double yp, double zp,

--- a/src/Corr2.cpp
+++ b/src/Corr2.cpp
@@ -341,7 +341,7 @@ void BaseCorr2::process11(const BaseCell<C>& c1, const BaseCell<C>& c2,
     } else {
         xdbg<<"Need to split.\n";
         bool split1=false, split2=false;
-        double bsq_eff = BinTypeHelper<B>::getEffectiveBSq(rsq,_bsq);
+        double bsq_eff = BinTypeHelper<B>::getEffectiveBSq(rsq,_bsq,_asq);
         xdbg<<"bsq_eff = "<<bsq_eff<<std::endl;
         CalcSplitSq(split1,split2,s1,s2,s1ps2,bsq_eff);
         xdbg<<"rsq = "<<rsq<<", s1ps2 = "<<s1ps2<<"  ";

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -1027,7 +1027,7 @@ void BaseCorr3::splitC2Cells(
         int k=-1;
         double r=0,logr=0;
         // First check if the distance alone requires a split for c2.
-        bool split = !BinTypeHelper<B>::singleBin(rsq, s1ps2, p1, p2, _binsize, _b, _bsq,
+        bool split = !BinTypeHelper<B>::singleBin(rsq, s1ps2, p1, p2, _binsize, _b, _bsq, _b, _bsq,
                                                    _minsep, _maxsep, _logminsep, k, r, logr);
 
         // If not splitting due to side length, might still need to split for angle.
@@ -1171,7 +1171,7 @@ double BaseCorr3::splitC2CellsOrCalculateGn(
         double logr=0;
 
         if (metric.isRParInsideRange(p1, p2, s1ps2, rpar) &&
-            BinTypeHelper<B>::singleBin(rsq, s1ps2, p1, p2, _binsize, _b, _bsq,
+            BinTypeHelper<B>::singleBin(rsq, s1ps2, p1, p2, _binsize, _b, _bsq, _b, _bsq,
                                         _minsep, _maxsep, _logminsep, k, r, logr))
         {
             // Check angle

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1789,7 +1789,7 @@ def test_nan2():
         'max_sep': 100.0,
         'nbins': 10,
         'bin_slop':0.,
-        'angle_slop':1.,
+        'angle_slop': 1.,
         'sep_units':'arcmin',
     }
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1789,6 +1789,7 @@ def test_nan2():
         'max_sep': 100.0,
         'nbins': 10,
         'bin_slop':0.,
+        'angle_slop':1.,
         'sep_units':'arcmin',
     }
 

--- a/tests/test_gg.py
+++ b/tests/test_gg.py
@@ -77,11 +77,11 @@ def test_direct():
     true_xim /= true_weight
 
     np.testing.assert_array_equal(gg.npairs, true_npairs)
-    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(gg.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(gg.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/gg_direct.yaml')
@@ -108,13 +108,24 @@ def test_direct():
                                 max_top=0)
     gg.process(cat1, cat2)
     np.testing.assert_array_equal(gg.npairs, true_npairs)
-    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     # This is the one that is highly affected by the approximation from averaging the shears
     # before projecting, rather than averaging each shear projected to its own connecting line.
-    np.testing.assert_allclose(gg.xim, true_xim.real, rtol=1.e-3, atol=3.e-4)
-    np.testing.assert_allclose(gg.xim_im, true_xim.imag, atol=1.e-3)
+    np.testing.assert_allclose(gg.xim, true_xim.real, atol=3.e-4)
+    np.testing.assert_allclose(gg.xim_im, true_xim.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    gg = treecorr.GGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    gg.process(cat1, cat2)
+    np.testing.assert_array_equal(gg.npairs, true_npairs)
+    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a GGCorrelation object.
     do_pickle(gg)
@@ -354,11 +365,22 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     gg.process(cat1, cat2)
     np.testing.assert_array_equal(gg.npairs, true_npairs)
-    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(gg.xim, true_xim.real, rtol=1.e-3, atol=2.e-4)
-    np.testing.assert_allclose(gg.xim_im, true_xim.imag, rtol=1.e-3, atol=2.e-4)
+    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-6, atol=1.e-6)
+    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-6)
+    np.testing.assert_allclose(gg.xim, true_xim.real, atol=2.e-4)
+    np.testing.assert_allclose(gg.xim_im, true_xim.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    gg = treecorr.GGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    gg.process(cat1, cat2)
+    np.testing.assert_array_equal(gg.npairs, true_npairs)
+    np.testing.assert_allclose(gg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(gg.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Split into patches to test the list-based version of the code.
     cat1p = treecorr.Catalog(ra=ra1, dec=dec1, ra_units='rad', dec_units='rad', w=w1,

--- a/tests/test_ggg.py
+++ b/tests/test_ggg.py
@@ -228,29 +228,44 @@ def test_direct_logruv():
     np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-3, atol=1.e-4)
     np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-3, atol=1.e-4)
 
+    # With angle_slop=0 as well, it becomes basically exact again (to single precision)
+    ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
+                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogRUV')
+    ggg.process(cat)
+    np.testing.assert_array_equal(ggg.ntri, true_ntri)
+    np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam0r, true_gam0.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam0i, true_gam0.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1r, true_gam1.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1i, true_gam1.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2r, true_gam2.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-5, atol=1.e-8)
+
     ggg.process(cat, cat, cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
     np.testing.assert_allclose(ggg.gam0r, true_gam0.real, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(ggg.gam0i, true_gam0.imag, rtol=1.e-5, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam1r, true_gam1.real, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam1i, true_gam1.imag, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam2r, true_gam2.real, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-3, atol=1.e-4)
+    np.testing.assert_allclose(ggg.gam0i, true_gam0.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1r, true_gam1.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1i, true_gam1.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2r, true_gam2.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-5, atol=1.e-8)
 
     ggg.process(cat, cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
     np.testing.assert_allclose(ggg.gam0r, true_gam0.real, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(ggg.gam0i, true_gam0.imag, rtol=1.e-5, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam1r, true_gam1.real, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam1i, true_gam1.imag, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam2r, true_gam2.real, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-3, atol=1.e-4)
-    np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-3, atol=1.e-4)
+    np.testing.assert_allclose(ggg.gam0i, true_gam0.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1r, true_gam1.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1i, true_gam1.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2r, true_gam2.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-5, atol=1.e-8)
 
     # Check a few basic operations with a GGGCorrelation object.
     do_pickle(ggg)
@@ -569,6 +584,20 @@ def test_direct_logruv_spherical():
     np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-3, atol=1.e-4)
     np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-3, atol=1.e-4)
     np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-3, atol=1.e-4)
+
+    ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
+                                  sep_units='deg', bin_slop=0, angle_slop=0, max_top=0, bin_type='LogRUV')
+    ggg.process(cat)
+    np.testing.assert_array_equal(ggg.ntri, true_ntri)
+    np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam0r, true_gam0.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam0i, true_gam0.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1r, true_gam1.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam1i, true_gam1.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2r, true_gam2.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam2i, true_gam2.imag, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3r, true_gam3.real, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-5, atol=1.e-8)
 
 
 @timer
@@ -4200,7 +4229,7 @@ def test_direct_logmultipole_auto():
 
     # Repeat with binslop = 0.
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     ggg.process(cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -4211,7 +4240,7 @@ def test_direct_logmultipole_auto():
 
     # And again with no top-level recursion
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
     ggg.process(cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -4319,7 +4348,8 @@ def test_direct_logmultipole_spherical():
     max_n = 20
 
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, sep_units='deg', nbins=nbins,
-                                  max_n=max_n, bin_slop=0, max_top=2, bin_type='LogMultipole')
+                                  max_n=max_n, bin_slop=0, angle_slop=0, max_top=2,
+                                  bin_type='LogMultipole')
     ggg.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)
@@ -4532,7 +4562,7 @@ def test_direct_logmultipole_cross():
 
     # Repeat with binslop = 0
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=2, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=2, bin_type='LogMultipole')
     ggg.process(cat1, cat2, cat3)
     np.testing.assert_allclose(ggg.ntri, true_ntri_123, rtol=1.e-5)
     np.testing.assert_allclose(ggg.weight, true_weight_123, rtol=1.e-5)
@@ -4620,7 +4650,7 @@ def test_direct_logmultipole_cross12():
     max_n = 20
 
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=2, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=2, bin_type='LogMultipole')
     ggg.process(cat1, cat2)
 
     log_min_sep = np.log(min_sep)

--- a/tests/test_ggg.py
+++ b/tests/test_ggg.py
@@ -586,7 +586,7 @@ def test_direct_logruv_spherical():
     np.testing.assert_allclose(ggg.gam3i, true_gam3.imag, rtol=1.e-3, atol=1.e-4)
 
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, bin_size=bin_size, nbins=nrbins,
-                                  sep_units='deg', bin_slop=0, angle_slop=0, max_top=0, bin_type='LogRUV')
+                                  sep_units='deg', angle_slop=0, max_top=0, bin_type='LogRUV')
     ggg.process(cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -4239,8 +4239,9 @@ def test_direct_logmultipole_auto():
     np.testing.assert_allclose(ggg.gam3, true_gam3, rtol=1.e-4, atol=1.e-8)
 
     # And again with no top-level recursion
+    # Note: angle_slop=0 implies bin_slop=0
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
+                                  angle_slop=0, max_top=0, bin_type='LogMultipole')
     ggg.process(cat)
     np.testing.assert_array_equal(ggg.ntri, true_ntri)
     np.testing.assert_allclose(ggg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -4348,8 +4349,7 @@ def test_direct_logmultipole_spherical():
     max_n = 20
 
     ggg = treecorr.GGGCorrelation(min_sep=min_sep, max_sep=max_sep, sep_units='deg', nbins=nbins,
-                                  max_n=max_n, bin_slop=0, angle_slop=0, max_top=2,
-                                  bin_type='LogMultipole')
+                                  max_n=max_n, angle_slop=0, max_top=2, bin_type='LogMultipole')
     ggg.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)

--- a/tests/test_kg.py
+++ b/tests/test_kg.py
@@ -75,13 +75,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',kg.weight - true_weight)
-    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kg.xi = ',kg.xi)
     print('kg.xi_im = ',kg.xi_im)
-    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kg_direct.yaml')
@@ -111,9 +111,18 @@ def test_direct():
                                 max_top=0)
     kg.process(cat1, cat2)
     np.testing.assert_array_equal(kg.npairs, true_npairs)
-    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-3, atol=1.e-3)
+    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi, true_xi.real, atol=1.e-3)
+    np.testing.assert_allclose(kg.xi_im, true_xi.imag, atol=1.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    kg.process(cat1, cat2)
+    np.testing.assert_array_equal(kg.npairs, true_npairs)
+    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a KGCorrelation object.
     do_pickle(kg)
@@ -258,12 +267,12 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',kg.weight - true_weight)
-    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kg.xi = ',kg.xi)
-    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kg_direct_spherical.yaml')
@@ -288,9 +297,19 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     kg.process(cat1, cat2)
     np.testing.assert_array_equal(kg.npairs, true_npairs)
-    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-3, atol=1.e-3)
+    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi, true_xi.real, atol=1.e-3)
+    np.testing.assert_allclose(kg.xi_im, true_xi.imag, atol=1.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kg = treecorr.KGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    kg.process(cat1, cat2)
+    np.testing.assert_array_equal(kg.npairs, true_npairs)
+    np.testing.assert_allclose(kg.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kg.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
+
 
 
 @timer

--- a/tests/test_kk.py
+++ b/tests/test_kk.py
@@ -73,11 +73,11 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',kk.weight - true_weight)
-    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kk.xi = ',kk.xi)
-    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-5, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kk_direct.yaml')
@@ -101,8 +101,8 @@ def test_direct():
                                 max_top=0)
     kk.process(cat1, cat2)
     np.testing.assert_array_equal(kk.npairs, true_npairs)
-    np.testing.assert_allclose(kk.weight, true_weight)
-    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-5, atol=1.e-8)
 
     # Check a few basic operations with a KKCorrelation object.
     do_pickle(kk)
@@ -265,11 +265,11 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',kk.weight - true_weight)
-    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kk.xi = ',kk.xi)
-    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-5, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kk_direct_spherical.yaml')
@@ -293,8 +293,8 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     kk.process(cat1, cat2)
     np.testing.assert_array_equal(kk.npairs, true_npairs)
-    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-3, atol=1.e-6)
+    np.testing.assert_allclose(kk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kk.xi, true_xi, rtol=1.e-5, atol=1.e-8)
 
     # Split into patches to test the list-based version of the code.
     cat1p = treecorr.Catalog(ra=ra1, dec=dec1, ra_units='rad', dec_units='rad', w=w1, k=k1,
@@ -307,32 +307,32 @@ def test_direct_spherical():
     kk2.process(cat1p, cat2)
     np.testing.assert_array_equal(kk2.npairs, kk.npairs)
     np.testing.assert_allclose(kk2.weight, kk.weight)
-    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-6)
 
     kk2.process(cat1p, cat2, patch_method='local')
     np.testing.assert_array_equal(kk2.npairs, kk.npairs)
     np.testing.assert_allclose(kk2.weight, kk.weight)
-    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-6)
 
     kk2.process(cat1, cat2p)
     np.testing.assert_array_equal(kk2.npairs, kk.npairs)
     np.testing.assert_allclose(kk2.weight, kk.weight)
-    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-6)
 
     kk2.process(cat1, cat2p, patch_method='local')
     np.testing.assert_array_equal(kk2.npairs, kk.npairs)
     np.testing.assert_allclose(kk2.weight, kk.weight)
-    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-6)
 
     kk2.process(cat1p, cat2p)
     np.testing.assert_array_equal(kk2.npairs, kk.npairs)
     np.testing.assert_allclose(kk2.weight, kk.weight)
-    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-6)
 
     kk2.process(cat1p, cat2p, patch_method='local')
     np.testing.assert_array_equal(kk2.npairs, kk.npairs)
     np.testing.assert_allclose(kk2.weight, kk.weight)
-    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-5)
+    np.testing.assert_allclose(kk2.xi, kk.xi, rtol=1.e-6)
 
 
 @timer

--- a/tests/test_kkk.py
+++ b/tests/test_kkk.py
@@ -2288,7 +2288,7 @@ def test_direct_logmultipole_auto():
 
     # And again with no top-level recursion
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
+                                  angle_slop=0, max_top=0, bin_type='LogMultipole')
     kkk.process(cat)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)

--- a/tests/test_kkk.py
+++ b/tests/test_kkk.py
@@ -2280,7 +2280,7 @@ def test_direct_logmultipole_auto():
 
     # Repeat with binslop = 0.
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     kkk.process(cat)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -2288,7 +2288,7 @@ def test_direct_logmultipole_auto():
 
     # And again with no top-level recursion
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
     kkk.process(cat)
     np.testing.assert_array_equal(kkk.ntri, true_ntri)
     np.testing.assert_allclose(kkk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
@@ -2378,7 +2378,8 @@ def test_direct_logmultipole_spherical():
     max_n = 20
 
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, sep_units='deg', nbins=nbins,
-                                  max_n=max_n, bin_slop=0, max_top=2, bin_type='LogMultipole')
+                                  max_n=max_n, bin_slop=0, angle_slop=0, max_top=2,
+                                  bin_type='LogMultipole')
     kkk.process(cat)
 
     r = np.sqrt(x**2 + y**2 + z**2)
@@ -2476,8 +2477,8 @@ def test_direct_logmultipole_spherical():
 
     # Now use Arc metric
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, sep_units='deg', nbins=nbins,
-                                  max_n=max_n, bin_slop=0, max_top=2, bin_type='LogMultipole',
-                                  metric='Arc')
+                                  max_n=max_n, bin_slop=0, angle_slop=0, max_top=2,
+                                  bin_type='LogMultipole', metric='Arc')
     kkk.process(cat)
     np.testing.assert_array_equal(kkk.ntri, true_ntri_arc)
     np.testing.assert_allclose(kkk.weight, true_weight_arc, rtol=1.e-5, atol=1.e-8)
@@ -2600,9 +2601,9 @@ def test_direct_logmultipole_cross():
     np.testing.assert_allclose(kkk.weight, true_weight_123, rtol=1.e-5)
     np.testing.assert_allclose(kkk.zeta, true_zeta_123, rtol=1.e-4)
 
-    # Repeat with binslop = 0
+    # Repeat with binslop = 0, angle_slop=0
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=2, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=2, bin_type='LogMultipole')
     kkk.process(cat1, cat2, cat3)
     np.testing.assert_allclose(kkk.weight, true_weight_123, rtol=1.e-5)
     np.testing.assert_allclose(kkk.zeta, true_zeta_123, rtol=1.e-4)
@@ -2729,7 +2730,7 @@ def test_direct_logmultipole_cross12():
     max_n = 20
 
     kkk = treecorr.KKKCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=2, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=2, bin_type='LogMultipole')
     kkk.process(cat1, cat2)
 
     log_min_sep = np.log(min_sep)

--- a/tests/test_kq.py
+++ b/tests/test_kq.py
@@ -76,13 +76,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',kq.weight - true_weight)
-    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kq.xi = ',kq.xi)
     print('kq.xi_im = ',kq.xi_im)
-    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kq_direct.yaml')
@@ -112,9 +112,18 @@ def test_direct():
                                 max_top=0)
     kq.process(cat1, cat2)
     np.testing.assert_array_equal(kq.npairs, true_npairs)
-    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-3, atol=1.5e-3)
-    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-3, atol=1.5e-3)
+    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi, true_xi.real, atol=2.e-3)
+    np.testing.assert_allclose(kq.xi_im, true_xi.imag, atol=2.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kq = treecorr.KQCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    kq.process(cat1, cat2)
+    np.testing.assert_array_equal(kq.npairs, true_npairs)
+    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a KQCorrelation object.
     do_pickle(kq)
@@ -259,12 +268,12 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',kq.weight - true_weight)
-    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kq.xi = ',kq.xi)
-    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kq_direct_spherical.yaml')
@@ -289,9 +298,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     kq.process(cat1, cat2)
     np.testing.assert_array_equal(kq.npairs, true_npairs)
-    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-3, atol=1.e-3)
+    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi, true_xi.real, atol=2.e-3)
+    np.testing.assert_allclose(kq.xi_im, true_xi.imag, atol=2.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kq = treecorr.KQCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    kq.process(cat1, cat2)
+    np.testing.assert_array_equal(kq.npairs, true_npairs)
+    np.testing.assert_allclose(kq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
 
 @timer

--- a/tests/test_kt.py
+++ b/tests/test_kt.py
@@ -76,13 +76,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',kt.weight - true_weight)
-    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kt.xi = ',kt.xi)
     print('kt.xi_im = ',kt.xi_im)
-    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kt_direct.yaml')
@@ -112,9 +112,18 @@ def test_direct():
                                 max_top=0)
     kt.process(cat1, cat2)
     np.testing.assert_array_equal(kt.npairs, true_npairs)
-    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-3, atol=1.1e-3)
+    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi, true_xi.real, atol=1.e-3)
+    np.testing.assert_allclose(kt.xi_im, true_xi.imag, atol=1.1e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kt = treecorr.KTCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    kt.process(cat1, cat2)
+    np.testing.assert_array_equal(kt.npairs, true_npairs)
+    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a KTCorrelation object.
     do_pickle(kt)
@@ -258,12 +267,12 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',kt.weight - true_weight)
-    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kt.xi = ',kt.xi)
-    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-6, atol=2.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kt_direct_spherical.yaml')
@@ -288,9 +297,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     kt.process(cat1, cat2)
     np.testing.assert_array_equal(kt.npairs, true_npairs)
-    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-3, atol=1.e-3)
+    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi, true_xi.real, atol=1.e-3)
+    np.testing.assert_allclose(kt.xi_im, true_xi.imag, atol=1.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kt = treecorr.KTCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    kt.process(cat1, cat2)
+    np.testing.assert_array_equal(kt.npairs, true_npairs)
+    np.testing.assert_allclose(kt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kt.xi_im, true_xi.imag, rtol=1.e-6, atol=2.e-8)
 
 
 @timer

--- a/tests/test_kv.py
+++ b/tests/test_kv.py
@@ -76,13 +76,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',kv.weight - true_weight)
-    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kv.xi = ',kv.xi)
     print('kv.xi_im = ',kv.xi_im)
-    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kv_direct.yaml')
@@ -112,9 +112,18 @@ def test_direct():
                                 max_top=0)
     kv.process(cat1, cat2)
     np.testing.assert_array_equal(kv.npairs, true_npairs)
-    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-3, atol=1.e-3)
+    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi, true_xi.real, atol=1.e-3)
+    np.testing.assert_allclose(kv.xi_im, true_xi.imag, atol=1.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kv = treecorr.KVCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    kv.process(cat1, cat2)
+    np.testing.assert_array_equal(kv.npairs, true_npairs)
+    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a KVCorrelation object.
     do_pickle(kv)
@@ -258,12 +267,12 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',kv.weight - true_weight)
-    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('kv.xi = ',kv.xi)
-    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/kv_direct_spherical.yaml')
@@ -288,9 +297,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     kv.process(cat1, cat2)
     np.testing.assert_array_equal(kv.npairs, true_npairs)
-    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-3, atol=1.e-3)
-    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-3, atol=1.e-3)
+    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi, true_xi.real, atol=1.e-3)
+    np.testing.assert_allclose(kv.xi_im, true_xi.imag, atol=1.e-3)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    kv = treecorr.KVCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    kv.process(cat1, cat2)
+    np.testing.assert_array_equal(kv.npairs, true_npairs)
+    np.testing.assert_allclose(kv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(kv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
 
 @timer

--- a/tests/test_ng.py
+++ b/tests/test_ng.py
@@ -77,13 +77,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',ng.weight - true_weight)
-    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('ng.xi = ',ng.xi)
     print('ng.xi_im = ',ng.xi_im)
-    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(ng.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/ng_direct.yaml')
@@ -120,9 +120,19 @@ def test_direct():
                                 max_top=0)
     ng.process(cat1, cat2)
     np.testing.assert_array_equal(ng.npairs, true_npairs)
-    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-3, atol=3.e-4)
-    np.testing.assert_allclose(ng.xi_im, true_xi.imag, atol=3.e-4)
+    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    # Note: the angle variation in the projection directions makes this inexact.
+    np.testing.assert_allclose(ng.xi, true_xi.real, atol=2.e-4)
+    np.testing.assert_allclose(ng.xi_im, true_xi.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    ng = treecorr.NGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    ng.process(cat1, cat2)
+    np.testing.assert_array_equal(ng.npairs, true_npairs)
+    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a NGCorrelation object.
     do_pickle(ng)
@@ -266,13 +276,13 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',ng.weight - true_weight)
-    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('ng.xi = ',ng.xi)
     print('ng.xi_im = ',ng.xi_im)
-    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(ng.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/ng_direct_spherical.yaml')
@@ -297,9 +307,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     ng.process(cat1, cat2)
     np.testing.assert_array_equal(ng.npairs, true_npairs)
-    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-3, atol=2.e-4)
+    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi, true_xi.real, atol=2.e-4)
     np.testing.assert_allclose(ng.xi_im, true_xi.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    ng = treecorr.NGCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    ng.process(cat1, cat2)
+    np.testing.assert_array_equal(ng.npairs, true_npairs)
+    np.testing.assert_allclose(ng.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(ng.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
 
 @timer

--- a/tests/test_nk.py
+++ b/tests/test_nk.py
@@ -74,11 +74,11 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',nk.weight - true_weight)
-    np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nk.xi = ',nk.xi)
-    np.testing.assert_allclose(nk.xi, true_xi, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nk.xi, true_xi, rtol=1.e-5, atol=2.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nk_direct.yaml')
@@ -114,8 +114,8 @@ def test_direct():
                                 max_top=0)
     nk.process(cat1, cat2)
     np.testing.assert_array_equal(nk.npairs, true_npairs)
-    np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nk.xi, true_xi, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nk.xi, true_xi, rtol=1.e-5, atol=2.e-8)
 
     # Check a few basic operations with a NKCorrelation object.
     do_pickle(nk)
@@ -271,8 +271,8 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     nk.process(cat1, cat2)
     np.testing.assert_array_equal(nk.npairs, true_npairs)
-    np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nk.xi, true_xi, rtol=1.e-3, atol=1.e-6)
+    np.testing.assert_allclose(nk.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nk.xi, true_xi, rtol=1.e-6, atol=1.e-8)
 
 
 @timer
@@ -507,8 +507,8 @@ def test_varxi():
 
             source = treecorr.Catalog(x=x2, y=y2, w=w, k=k)
             rand = treecorr.Catalog(x=x3, y=y3)
-            nk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15.)
-            rk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15.)
+            nk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15., angle_slop=0.3)
+            rk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15., angle_slop=0.3)
             nk.process(lens, source)
             rk.process(rand, source)
             all_nks.append(nk)
@@ -563,8 +563,8 @@ def test_varxi():
 
     source = treecorr.Catalog(x=x2, y=y2, w=w, k=k)
     rand = treecorr.Catalog(x=x3, y=y3)
-    nk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15.)
-    rk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15.)
+    nk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15., angle_slop=0.3)
+    rk = treecorr.NKCorrelation(bin_size=0.3, min_sep=6., max_sep=15., angle_slop=0.3)
     nk.process(lens, source)
     rk.process(rand, source)
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -368,9 +368,9 @@ def test_linear_binning():
 
     with CaptureLog() as cl:
         nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=1.0,
-                                    bin_type='Linear', logger=cl.logger)
+                                    angle_slop=0.2, bin_type='Linear', logger=cl.logger)
     print(cl.output)
-    assert "It is recommended to use bin_slop <= 0.05" in cl.output
+    assert "It is recommended to use either bin_slop <= 0.05" in cl.output
     print(nn.bin_size,nn.bin_slop,nn.b)
     assert nn.bin_size == 1
     assert nn.bin_slop == 1.0
@@ -378,8 +378,19 @@ def test_linear_binning():
 
     with CaptureLog() as cl:
         nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=0.2,
+                                    angle_slop=0.2, bin_type='Linear', logger=cl.logger)
+    assert "It is recommended to use either bin_slop <= 0.05" in cl.output
+    print(nn.bin_size,nn.bin_slop,nn.b)
+    assert nn.bin_size == 1
+    assert nn.bin_slop == 0.2
+    np.testing.assert_almost_equal(nn.b, 0.2)
+
+    # The default angle_slop = 0.1 is enough to avoid the warning (because angle_slop makes
+    # the calculation sufficiently accurate for typical purposes).
+    with CaptureLog() as cl:
+        nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=0.2,
                                     bin_type='Linear', logger=cl.logger)
-    assert "It is recommended to use bin_slop <= 0.05" in cl.output
+    assert "It is recommended to use either bin_slop <= 0.05" not in cl.output
     print(nn.bin_size,nn.bin_slop,nn.b)
     assert nn.bin_size == 1
     assert nn.bin_slop == 0.2

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -368,7 +368,7 @@ def test_linear_binning():
 
     with CaptureLog() as cl:
         nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=1.0,
-                                    angle_slop=0.2, bin_type='Linear', logger=cl.logger)
+                                    bin_type='Linear', logger=cl.logger)
     print(cl.output)
     assert "It is recommended to use either bin_slop <= 0.05" in cl.output
     print(nn.bin_size,nn.bin_slop,nn.b)
@@ -378,23 +378,23 @@ def test_linear_binning():
 
     with CaptureLog() as cl:
         nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=0.2,
-                                    angle_slop=0.2, bin_type='Linear', logger=cl.logger)
+                                    bin_type='Linear', logger=cl.logger)
     assert "It is recommended to use either bin_slop <= 0.05" in cl.output
     print(nn.bin_size,nn.bin_slop,nn.b)
     assert nn.bin_size == 1
     assert nn.bin_slop == 0.2
     np.testing.assert_almost_equal(nn.b, 0.2)
 
-    # The default angle_slop = 0.1 is enough to avoid the warning (because angle_slop makes
-    # the calculation sufficiently accurate for typical purposes).
+    # For types other than NN, NK, KK, the default angle_slop = 0.1 is enough to avoid the warning
+    # (because angle_slop makes the calculation sufficiently accurate for typical purposes).
     with CaptureLog() as cl:
-        nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=0.2,
+        ng = treecorr.NGCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=0.2,
                                     bin_type='Linear', logger=cl.logger)
     assert "It is recommended to use either bin_slop <= 0.05" not in cl.output
-    print(nn.bin_size,nn.bin_slop,nn.b)
-    assert nn.bin_size == 1
-    assert nn.bin_slop == 0.2
-    np.testing.assert_almost_equal(nn.b, 0.2)
+    print(ng.bin_size,ng.bin_slop,ng.b)
+    assert ng.bin_size == 1
+    assert ng.bin_slop == 0.2
+    np.testing.assert_almost_equal(ng.b, 0.2)
 
     nn = treecorr.NNCorrelation(min_sep=0, max_sep=20, bin_size=1, bin_slop=0.0,
                                 bin_type='Linear')

--- a/tests/test_nnn.py
+++ b/tests/test_nnn.py
@@ -4603,7 +4603,7 @@ def test_direct_logmultipole_cross12():
 
     # And again with no top-level recursion
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
+                                  angle_slop=0, max_top=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2)
     t1 = time.time()
@@ -4639,7 +4639,7 @@ def test_direct_logmultipole_cross12():
     cat1 = treecorr.Catalog(x=x1, y=y1, w=w1, npatch=8, rng=rng)
 
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
+                                  angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2)
     t1 = time.time()
@@ -4679,7 +4679,7 @@ def test_direct_logmultipole_cross12():
 
     # Make sure max_n=0 works correctly.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=0,
-                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
+                                  angle_slop=0, bin_type='LogMultipole')
     ddd.process(cat1, cat2)
     assert ddd.ntri.shape[2] == 1
     np.testing.assert_array_equal(ddd.ntri[:,:,0], true_ntri_122[:,:,max_n])
@@ -4914,7 +4914,7 @@ def test_direct_logmultipole_cross():
 
     # And again with no top-level recursion
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
+                                  angle_slop=0, max_top=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2, cat3)
     t1 = time.time()
@@ -4938,7 +4938,7 @@ def test_direct_logmultipole_cross():
     cat1 = treecorr.Catalog(x=x1, y=y1, w=w1, npatch=8, rng=rng)
 
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
+                                  angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2, cat3)
     t1 = time.time()
@@ -4966,7 +4966,7 @@ def test_direct_logmultipole_cross():
 
     # Make sure max_n=0 works correctly.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=0,
-                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
+                                  angle_slop=0, bin_type='LogMultipole')
     ddd.process(cat1, cat2, cat3)
     assert ddd.ntri.shape[2] == 1
     np.testing.assert_array_equal(ddd.ntri[:,:,0], true_ntri_123[:,:,max_n])

--- a/tests/test_nnn.py
+++ b/tests/test_nnn.py
@@ -4353,9 +4353,9 @@ def test_direct_logmultipole_auto():
     assert np.std(sas.weight/true_ntri_sas) < 0.05
     assert np.std(sas.ntri/true_ntri_sas) < 0.05
 
-    # Repeat with binslop = 0.
+    # Repeat with binslop = 0.  Also use angle_slop here, since angles matter for multipole.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat)
     t1 = time.time()
@@ -4373,7 +4373,7 @@ def test_direct_logmultipole_auto():
 
     # And again with no top-level recursion
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat)
     t1 = time.time()
@@ -4567,7 +4567,7 @@ def test_direct_logmultipole_cross12():
 
     # Repeat with binslop = 0
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2)
     t1 = time.time()
@@ -4603,7 +4603,7 @@ def test_direct_logmultipole_cross12():
 
     # And again with no top-level recursion
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2)
     t1 = time.time()
@@ -4639,7 +4639,7 @@ def test_direct_logmultipole_cross12():
     cat1 = treecorr.Catalog(x=x1, y=y1, w=w1, npatch=8, rng=rng)
 
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2)
     t1 = time.time()
@@ -4679,7 +4679,7 @@ def test_direct_logmultipole_cross12():
 
     # Make sure max_n=0 works correctly.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=0,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     ddd.process(cat1, cat2)
     assert ddd.ntri.shape[2] == 1
     np.testing.assert_array_equal(ddd.ntri[:,:,0], true_ntri_122[:,:,max_n])
@@ -4854,7 +4854,7 @@ def test_direct_logmultipole_cross():
 
     # Repeat with binslop = 0
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2, cat3)
     t1 = time.time()
@@ -4914,7 +4914,7 @@ def test_direct_logmultipole_cross():
 
     # And again with no top-level recursion
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, max_top=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, max_top=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2, cat3)
     t1 = time.time()
@@ -4938,7 +4938,7 @@ def test_direct_logmultipole_cross():
     cat1 = treecorr.Catalog(x=x1, y=y1, w=w1, npatch=8, rng=rng)
 
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=max_n,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     t0 = time.time()
     ddd.process(cat1, cat2, cat3)
     t1 = time.time()
@@ -4966,7 +4966,7 @@ def test_direct_logmultipole_cross():
 
     # Make sure max_n=0 works correctly.
     ddd = treecorr.NNNCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, max_n=0,
-                                  bin_slop=0, bin_type='LogMultipole')
+                                  bin_slop=0, angle_slop=0, bin_type='LogMultipole')
     ddd.process(cat1, cat2, cat3)
     assert ddd.ntri.shape[2] == 1
     np.testing.assert_array_equal(ddd.ntri[:,:,0], true_ntri_123[:,:,max_n])

--- a/tests/test_nq.py
+++ b/tests/test_nq.py
@@ -77,13 +77,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',nq.weight - true_weight)
-    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nq.xi = ',nq.xi)
     print('nq.xi_im = ',nq.xi_im)
-    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(nq.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nq_direct.yaml')
@@ -120,9 +120,18 @@ def test_direct():
                                 max_top=0)
     nq.process(cat1, cat2)
     np.testing.assert_array_equal(nq.npairs, true_npairs)
-    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-3, atol=5.e-4)
+    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi, true_xi.real, atol=5.e-4)
     np.testing.assert_allclose(nq.xi_im, true_xi.imag, atol=3.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    nq = treecorr.NQCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    nq.process(cat1, cat2)
+    np.testing.assert_array_equal(nq.npairs, true_npairs)
+    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a NQCorrelation object.
     do_pickle(nq)
@@ -266,13 +275,13 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',nq.weight - true_weight)
-    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nq.xi = ',nq.xi)
     print('nq.xi_im = ',nq.xi_im)
-    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(nq.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nq_direct_spherical.yaml')
@@ -297,9 +306,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     nq.process(cat1, cat2)
     np.testing.assert_array_equal(nq.npairs, true_npairs)
-    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-3, atol=2.e-4)
+    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi, true_xi.real, atol=2.e-4)
     np.testing.assert_allclose(nq.xi_im, true_xi.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    nq = treecorr.NQCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    nq.process(cat1, cat2)
+    np.testing.assert_array_equal(nq.npairs, true_npairs)
+    np.testing.assert_allclose(nq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nq.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
 
 @timer

--- a/tests/test_nt.py
+++ b/tests/test_nt.py
@@ -77,13 +77,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',nt.weight - true_weight)
-    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nt.xi = ',nt.xi)
     print('nt.xi_im = ',nt.xi_im)
-    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(nt.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nt_direct.yaml')
@@ -120,9 +120,18 @@ def test_direct():
                                 max_top=0)
     nt.process(cat1, cat2)
     np.testing.assert_array_equal(nt.npairs, true_npairs)
-    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-3, atol=4.e-4)
-    np.testing.assert_allclose(nt.xi_im, true_xi.imag, atol=4.e-4)
+    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi, true_xi.real, atol=4.e-4)
+    np.testing.assert_allclose(nt.xi_im, true_xi.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    nt = treecorr.NTCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    nt.process(cat1, cat2)
+    np.testing.assert_array_equal(nt.npairs, true_npairs)
+    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a NTCorrelation object.
     do_pickle(nt)
@@ -267,13 +276,13 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',nt.weight - true_weight)
-    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nt.xi = ',nt.xi)
     print('nt.xi_im = ',nt.xi_im)
-    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(nt.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nt_direct_spherical.yaml')
@@ -298,9 +307,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     nt.process(cat1, cat2)
     np.testing.assert_array_equal(nt.npairs, true_npairs)
-    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-3, atol=2.e-4)
-    np.testing.assert_allclose(nt.xi_im, true_xi.imag, atol=2.e-4)
+    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi, true_xi.real, atol=1.e-4)
+    np.testing.assert_allclose(nt.xi_im, true_xi.imag, atol=1.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    nt = treecorr.NTCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    nt.process(cat1, cat2)
+    np.testing.assert_array_equal(nt.npairs, true_npairs)
+    np.testing.assert_allclose(nt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nt.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
 
 @timer

--- a/tests/test_nv.py
+++ b/tests/test_nv.py
@@ -77,13 +77,13 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',nv.weight - true_weight)
-    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nv.xi = ',nv.xi)
     print('nv.xi_im = ',nv.xi_im)
-    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(nv.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nv_direct.yaml')
@@ -120,9 +120,18 @@ def test_direct():
                                 max_top=0)
     nv.process(cat1, cat2)
     np.testing.assert_array_equal(nv.npairs, true_npairs)
-    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-3, atol=3.e-4)
-    np.testing.assert_allclose(nv.xi_im, true_xi.imag, atol=3.e-4)
+    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi, true_xi.real, atol=1.e-4)
+    np.testing.assert_allclose(nv.xi_im, true_xi.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    nv = treecorr.NVCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    nv.process(cat1, cat2)
+    np.testing.assert_array_equal(nv.npairs, true_npairs)
+    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a NVCorrelation object.
     do_pickle(nv)
@@ -266,13 +275,13 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',nv.weight - true_weight)
-    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xi = ',true_xi)
     print('nv.xi = ',nv.xi)
     print('nv.xi_im = ',nv.xi_im)
-    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(nv.xi_im, true_xi.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/nv_direct_spherical.yaml')
@@ -297,9 +306,18 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     nv.process(cat1, cat2)
     np.testing.assert_array_equal(nv.npairs, true_npairs)
-    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-3, atol=2.e-4)
-    np.testing.assert_allclose(nv.xi_im, true_xi.imag, atol=2.e-4)
+    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi, true_xi.real, atol=1.e-4)
+    np.testing.assert_allclose(nv.xi_im, true_xi.imag, atol=1.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    nv = treecorr.NVCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    nv.process(cat1, cat2)
+    np.testing.assert_array_equal(nv.npairs, true_npairs)
+    np.testing.assert_allclose(nv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi, true_xi.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(nv.xi_im, true_xi.imag, rtol=1.e-6, atol=1.e-8)
 
 
 @timer

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -597,7 +597,7 @@ def test_gg_jk():
             x, y, g1, g2, _ = generate_shear_field(nside)
             print(run,': ',np.mean(g1),np.std(g1),np.min(g1),np.max(g1))
             cat = treecorr.Catalog(x=x, y=y, g1=g1, g2=g2)
-            gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+            gg = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., angle_slop=0.3)
             gg.process(cat)
             all_ggs.append(gg)
 
@@ -635,7 +635,7 @@ def test_gg_jk():
     x, y, g1, g2, _ = generate_shear_field(nside, rng)
 
     cat = treecorr.Catalog(x=x, y=y, g1=g1, g2=g2)
-    gg1 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50.)
+    gg1 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., angle_slop=0.3)
     t0 = time.time()
     gg1.process(cat)
     t1 = time.time()
@@ -671,7 +671,7 @@ def test_gg_jk():
     # Now run with patches, but still with shot variance.  Should be basically the same answer.
     cat = treecorr.Catalog(x=x, y=y, g1=g1, g2=g2, npatch=npatch, rng=rng)
     gg2 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., var_method='shot',
-                                 rng=rng)
+                                 angle_slop=0.3, rng=rng)
     t0 = time.time()
     gg2.process(cat)
     t1 = time.time()
@@ -697,7 +697,7 @@ def test_gg_jk():
 
     # Now run with jackknife variance estimate.  Should be much better.
     gg3 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., var_method='jackknife',
-                                 rng=rng)
+                                 angle_slop=0.3, rng=rng)
     t0 = time.time()
     gg3.process(cat)
     t1 = time.time()
@@ -717,7 +717,7 @@ def test_gg_jk():
 
     # Should also work with local patches
     gg3l = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., var_method='jackknife',
-                                  rng=rng)
+                                  angle_slop=0.3, rng=rng)
     t0 = time.time()
     gg3l.process(cat, patch_method='local')
     t1 = time.time()
@@ -855,7 +855,8 @@ def test_gg_jk():
     # Make sure using rng=default_rng works as well.
     rng4 = np.random.default_rng(123456)
     cat4 = treecorr.Catalog(x=x, y=y, g1=g1, g2=g2, npatch=npatch, rng=rng4)
-    gg4 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng4)
+    gg4 = treecorr.GGCorrelation(bin_size=0.3, min_sep=10., max_sep=50., rng=rng4,
+                                 angle_slop=0.3)
     gg4.process(cat4)
     cov_boot = gg4.estimate_cov('marked_bootstrap')
     np.testing.assert_allclose(cov_boot.diagonal()[:n], var_xip, rtol=0.5*tol_factor)

--- a/tests/test_qq.py
+++ b/tests/test_qq.py
@@ -82,18 +82,18 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',qq.weight - true_weight)
-    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xip = ',true_xip)
     print('qq.xip = ',qq.xip)
     print('qq.xip_im = ',qq.xip_im)
-    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('qq.xim = ',qq.xim)
     print('qq.xim_im = ',qq.xim_im)
-    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/qq_direct.yaml')
@@ -120,9 +120,9 @@ def test_direct():
                                 max_top=0)
     qq.process(cat1, cat2)
     np.testing.assert_array_equal(qq.npairs, true_npairs)
-    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('qq.xim = ',qq.xim)
     print('qq.xim_im = ',qq.xim_im)
@@ -130,8 +130,19 @@ def test_direct():
     print('max diff = ',np.max(np.abs(qq.xim - true_xim.real)))
     print('rel diff = ',(qq.xim - true_xim.real)/true_xim.real)
     print('ratio = ',qq.xim/true_xim.real)
-    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-3, atol=3.e-4)
-    np.testing.assert_allclose(qq.xim_im, true_xim.imag, atol=1.e-3)
+    np.testing.assert_allclose(qq.xim, true_xim.real, atol=3.e-4)
+    np.testing.assert_allclose(qq.xim_im, true_xim.imag, atol=1.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    qq = treecorr.QQCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    qq.process(cat1, cat2)
+    np.testing.assert_array_equal(qq.npairs, true_npairs)
+    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a QQCorrelation object.
     do_pickle(qq)
@@ -292,18 +303,18 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',qq.weight - true_weight)
-    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xip = ',true_xip)
     print('qq.xip = ',qq.xip)
     print('qq.xip_im = ',qq.xip_im)
-    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('qq.xim = ',qq.xim)
     print('qq.xim_im = ',qq.xim_im)
-    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     try:
@@ -330,11 +341,23 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     qq.process(cat1, cat2)
     np.testing.assert_array_equal(qq.npairs, true_npairs)
-    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-3, atol=2.e-4)
-    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-3, atol=2.e-4)
+    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-6, atol=1.e-6)
+    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-6)
+    np.testing.assert_allclose(qq.xim, true_xim.real, atol=2.e-4)
+    np.testing.assert_allclose(qq.xim_im, true_xim.imag, atol=2.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    qq = treecorr.QQCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    qq.process(cat1, cat2)
+    np.testing.assert_array_equal(qq.npairs, true_npairs)
+    np.testing.assert_allclose(qq.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(qq.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
+
 
 @timer
 def test_qq():
@@ -1002,9 +1025,9 @@ def test_twod():
 
 
 if __name__ == '__main__':
-    #test_direct()
-    #test_direct_spherical()
-    #test_qq()
+    test_direct()
+    test_direct_spherical()
+    test_qq()
     test_spherical()
     test_varxi()
     test_jk()

--- a/tests/test_rperp.py
+++ b/tests/test_rperp.py
@@ -793,7 +793,7 @@ def test_ng_rperp():
     # Note: many of the redshifts are equal to other redshifts, so setting max_rpar=0 would
     # be unstable to numerical differences on different machines, as 0 isn't exact, so it would
     # come out to +- 1.e-13 or so.  Use max_rpar=1.e-8 as meaning <= 0.
-    ng = treecorr.NGCorrelation(nbins=10, min_sep=0.5, max_sep=60,
+    ng = treecorr.NGCorrelation(nbins=10, min_sep=0.5, max_sep=60, angle_slop=0.3,
                                 min_rpar=-dmax, max_rpar=1.e-8, bin_slop=0.01)
     ng.process(cat, cat, metric='OldRperp')
 

--- a/tests/test_tt.py
+++ b/tests/test_tt.py
@@ -82,18 +82,18 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',tt.weight - true_weight)
-    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xip = ',true_xip)
     print('tt.xip = ',tt.xip)
     print('tt.xip_im = ',tt.xip_im)
-    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('tt.xim = ',tt.xim)
     print('tt.xim_im = ',tt.xim_im)
-    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/tt_direct.yaml')
@@ -120,17 +120,28 @@ def test_direct():
                                 max_top=0)
     tt.process(cat1, cat2)
     np.testing.assert_array_equal(tt.npairs, true_npairs)
-    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('tt.xim = ',tt.xim)
     print('tt.xim_im = ',tt.xim_im)
     print('diff = ',tt.xim - true_xim.real)
     print('max diff = ',np.max(np.abs(tt.xim - true_xim.real)))
     print('rel diff = ',(tt.xim - true_xim.real)/true_xim.real)
-    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-3, atol=3.e-4)
-    np.testing.assert_allclose(tt.xim_im, true_xim.imag, atol=1.e-3)
+    np.testing.assert_allclose(tt.xim, true_xim.real, atol=3.e-4)
+    np.testing.assert_allclose(tt.xim_im, true_xim.imag, atol=5.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    tt = treecorr.TTCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    tt.process(cat1, cat2)
+    np.testing.assert_array_equal(tt.npairs, true_npairs)
+    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a TTCorrelation object.
     do_pickle(tt)
@@ -291,18 +302,18 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',tt.weight - true_weight)
-    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xip = ',true_xip)
     print('tt.xip = ',tt.xip)
     print('tt.xip_im = ',tt.xip_im)
-    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('tt.xim = ',tt.xim)
     print('tt.xim_im = ',tt.xim_im)
-    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     try:
@@ -329,11 +340,23 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     tt.process(cat1, cat2)
     np.testing.assert_array_equal(tt.npairs, true_npairs)
-    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-3, atol=2.e-4)
-    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-3, atol=2.e-4)
+    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-6, atol=1.e-6)
+    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-6)
+    np.testing.assert_allclose(tt.xim, true_xim.real, atol=1.e-4)
+    np.testing.assert_allclose(tt.xim_im, true_xim.imag, atol=1.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    tt = treecorr.TTCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    tt.process(cat1, cat2)
+    np.testing.assert_array_equal(tt.npairs, true_npairs)
+    np.testing.assert_allclose(tt.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(tt.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
+
 
 @timer
 def test_tt():

--- a/tests/test_vv.py
+++ b/tests/test_vv.py
@@ -82,18 +82,18 @@ def test_direct():
 
     print('true_weight = ',true_weight)
     print('diff = ',vv.weight - true_weight)
-    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xip = ',true_xip)
     print('vv.xip = ',vv.xip)
     print('vv.xip_im = ',vv.xip_im)
-    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('vv.xim = ',vv.xim)
     print('vv.xim_im = ',vv.xim_im)
-    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     config = treecorr.config.read_config('configs/vv_direct.yaml')
@@ -120,17 +120,28 @@ def test_direct():
                                 max_top=0)
     vv.process(cat1, cat2)
     np.testing.assert_array_equal(vv.npairs, true_npairs)
-    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('vv.xim = ',vv.xim)
     print('vv.xim_im = ',vv.xim_im)
     print('diff = ',vv.xim - true_xim.real)
     print('max diff = ',np.max(np.abs(vv.xim - true_xim.real)))
     print('rel diff = ',(vv.xim - true_xim.real)/true_xim.real)
-    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-3, atol=3.e-4)
-    np.testing.assert_allclose(vv.xim_im, true_xim.imag, atol=1.e-3)
+    np.testing.assert_allclose(vv.xim, true_xim.real, atol=3.e-4)
+    np.testing.assert_allclose(vv.xim_im, true_xim.imag, atol=1.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    vv = treecorr.VVCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins, bin_slop=0,
+                                angle_slop=0, max_top=0)
+    vv.process(cat1, cat2)
+    np.testing.assert_array_equal(vv.npairs, true_npairs)
+    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check a few basic operations with a VVCorrelation object.
     do_pickle(vv)
@@ -291,18 +302,18 @@ def test_direct_spherical():
 
     print('true_weight = ',true_weight)
     print('diff = ',vv.weight - true_weight)
-    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
+    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
 
     print('true_xip = ',true_xip)
     print('vv.xip = ',vv.xip)
     print('vv.xip_im = ',vv.xip_im)
-    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
     print('true_xim = ',true_xim)
     print('vv.xim = ',vv.xim)
     print('vv.xim_im = ',vv.xim_im)
-    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-4, atol=1.e-8)
-    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-4, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
 
     # Check that running via the corr2 script works correctly.
     try:
@@ -329,11 +340,23 @@ def test_direct_spherical():
                                 sep_units='deg', bin_slop=0, max_top=0)
     vv.process(cat1, cat2)
     np.testing.assert_array_equal(vv.npairs, true_npairs)
-    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-5, atol=1.e-8)
-    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-3, atol=1.e-6)
-    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-3, atol=2.e-4)
-    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-3, atol=2.e-4)
+    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-6, atol=3.e-7)
+    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-6, atol=2.e-7)
+    np.testing.assert_allclose(vv.xim, true_xim.real, atol=1.e-4)
+    np.testing.assert_allclose(vv.xim_im, true_xim.imag, atol=1.e-4)
+
+    # With angle_slop = 0, it goes back to being basically exact (to single precision).
+    vv = treecorr.VVCorrelation(min_sep=min_sep, max_sep=max_sep, nbins=nbins,
+                                sep_units='deg', bin_slop=0, angle_slop=0, max_top=0)
+    vv.process(cat1, cat2)
+    np.testing.assert_array_equal(vv.npairs, true_npairs)
+    np.testing.assert_allclose(vv.weight, true_weight, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip, true_xip.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xip_im, true_xip.imag, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim, true_xim.real, rtol=1.e-6, atol=1.e-8)
+    np.testing.assert_allclose(vv.xim_im, true_xim.imag, rtol=1.e-6, atol=1.e-8)
+
 
 @timer
 def test_vv():

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -1121,12 +1121,21 @@ class Corr2(object):
             #      d = minsep / (1+1.5 b)
             #      s = 0.5 * b * minsep / (1+1.5 b)
             #        = b * minsep / (2+3b)
-            min_size = self._min_sep * self.b / (2.+3.*self.b)
+            if self.bin_type == 'Log':
+                b1 = min(self.angle_slop, self.b)
+                min_size = self._min_sep * b1 / (2.+3.*b1)
+            else:
+                a = self.angle_slop
+                min_size = min(a * self._min_sep / (2.+3.*a), self.b/2.)
 
             # The maximum size cell that will be useful is one where a cell of size s will
             # be split at the maximum separation even if the other size = 0.
             # i.e. max_size = max_sep * b
-            max_size = self._max_sep * self.b
+            if self.bin_type == 'Log':
+                max_size = self._max_sep * b1
+            else:
+                max_size = min(a * self._max_sep, self.b)
+
             return min_size, max_size
         else:
             # For other metrics, the above calculation doesn't really apply, so just skip

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -225,6 +225,10 @@ class Corr2(object):
                                 This won't work if the system's C compiler cannot use OpenMP
                                 (e.g. clang prior to version 3.7.)
     """
+    # This is appropriate for anything where angles matter, but for pure scalars (NN, NK, KK),
+    # this is unnecessary, so we override it in those classes.
+    _default_angle_slop = 0.1
+
     _valid_params = {
         'nbins' : (int, False, None, None,
                 'The number of output bins to use.'),
@@ -241,7 +245,7 @@ class Corr2(object):
                 'The fraction of a bin width by which it is ok to let the pairs miss the correct '
                 'bin.',
                 'The default is to use 1 if bin_size <= 0.1, or 0.1/bin_size if bin_size > 0.1.'),
-        'angle_slop' : (float, False, 0.1, None,
+        'angle_slop' : (float, False, None, None,
                 'The maximum difference in the projection angle for any pair of objects relative '
                 'to that of the pair of cells being accumulated into bins'),
         'brute' : (bool, False, False, [False, True, 1, 2],
@@ -464,7 +468,7 @@ class Corr2(object):
         self._ro.max_top = get(self.config,'max_top',int,10)
 
         self._ro.bin_slop = get(self.config,'bin_slop',float,-1.0)
-        self._ro.angle_slop = get(self.config,'angle_slop',float,0.1)
+        self._ro.angle_slop = get(self.config,'angle_slop',float,self._default_angle_slop)
         if self.bin_slop < 0.0:
             self._ro.bin_slop = min(max_good_slop, 1.0)
         self._ro.b = self.bin_size * self.bin_slop

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -472,7 +472,7 @@ class Corr2(object):
         if self.bin_slop < 0.0:
             self._ro.bin_slop = min(max_good_slop, 1.0)
         self._ro.b = self.bin_size * self.bin_slop
-        if (self.bin_slop > max_good_slop + 0.0001 and self.angle_slop > 0.1):
+        if self.bin_slop > max_good_slop + 0.0001 and self.angle_slop > 0.1:
             self.logger.warning(
                 "Using bin_slop = %g, angle_slop = %g, bin_size = %g (b = %g).\n"%(
                     self.bin_slop, self.angle_slop, self.bin_size, self.b)+

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -1685,20 +1685,25 @@ class Corr3(object):
             if self.bin_type == 'LogRUV':
                 # The minimum separation we care about is that of the smallest size, which is
                 # min_sep * min_u.  Do the same calculation as for 2pt to get to min_size.
-                b1 = min(self.b, self.bu, self.bv)
+                b1 = min(self.angle_slop, self.b, self.bu, self.bv)
                 min_size = self._min_sep * self.min_u * b1 / (2.+3.*b1)
 
                 # This time, the maximum size is d1 * b.  d1 can be as high as 2*max_sep.
-                b2 = max(self.b, self.bu, self.bv)
+                b2 = min(self.angle_slop, self.b)
                 max_size = 2. * self._max_sep * b2
             elif self.bin_type == 'LogSAS':
                 # LogSAS
-                min_size = 2 * self._min_sep * np.tan(self.min_phi/2) * self.bu / (2+3*self.bu)
-                max_size = 2 * self._max_sep * self.b
+                b1 = min(self.angle_slop, self.b)
+                min_size1 = self._min_sep * b1 / (2.+3.*b1)
+                b2 = min(self.angle_slop, self.bu)
+                min_size2 = 2 * self._min_sep * np.tan(self.min_phi/2) * b2 / (2+3*b2)
+                min_size = min(min_size1, min_size2)
+                max_size = self._max_sep * b1
             else:
                 # LogMultipole
-                min_size = 2 * self._min_sep * self.b / (2*self.max_n+1)
-                max_size = 2 * self._max_sep * self.b
+                b1 = min(self.angle_slop, self.b)
+                min_size = 2 * self._min_sep * b1 / (2.+3*b1)
+                max_size = self._max_sep * b1
             return min_size, max_size
         else:
             return 0., 0.

--- a/treecorr/ggcorrelation.py
+++ b/treecorr/ggcorrelation.py
@@ -120,7 +120,8 @@ class GGCorrelation(Corr2):
     def corr(self):
         if self._corr is None:
             self._corr = _treecorr.GGCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xip, self.xip_im, self.xim, self.xim_im,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -137,6 +138,7 @@ class GGCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/gggcorrelation.py
+++ b/treecorr/gggcorrelation.py
@@ -242,6 +242,7 @@ class GGGCorrelation(Corr3):
             self._corr = _treecorr.GGGCorr(
                     self._bintype,
                     self._min_sep, self._max_sep, self.nbins, self._bin_size, self.b,
+                    self.angle_slop,
                     self._ro.min_u,self._ro.max_u,self._ro.nubins,self._ro.ubin_size,self.bu,
                     self._ro.min_v,self._ro.max_v,self._ro.nvbins,self._ro.vbin_size,self.bv,
                     self.xperiod, self.yperiod, self.zperiod,

--- a/treecorr/kgcorrelation.py
+++ b/treecorr/kgcorrelation.py
@@ -118,7 +118,8 @@ class KGCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.KGCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xi, self.xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -135,6 +136,7 @@ class KGCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -95,6 +95,9 @@ class KKCorrelation(Corr2):
         **kwargs:       See the documentation for `Corr2` for the list of allowed keyword
                         arguments, which may be passed either directly or in the config dict.
     """
+    # The angles are not important for accuracy of KK correlations.
+    _default_angle_slop = 1
+
     def __init__(self, config=None, *, logger=None, **kwargs):
         """Initialize `KKCorrelation`.  See class doc for details.
         """

--- a/treecorr/kkcorrelation.py
+++ b/treecorr/kkcorrelation.py
@@ -117,7 +117,8 @@ class KKCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.KKCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xi, x, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -134,6 +135,7 @@ class KKCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/kkkcorrelation.py
+++ b/treecorr/kkkcorrelation.py
@@ -159,6 +159,8 @@ class KKKCorrelation(Corr3):
         **kwargs:       See the documentation for `Corr3` for the list of allowed keyword
                         arguments, which may be passed either directly or in the config dict.
     """
+    _default_angle_slop = 1
+
     def __init__(self, config=None, *, logger=None, **kwargs):
         """Initialize `KKKCorrelation`.  See class doc for details.
         """
@@ -200,6 +202,7 @@ class KKKCorrelation(Corr3):
             self._corr = _treecorr.KKKCorr(
                     self._bintype,
                     self._min_sep, self._max_sep, self.nbins, self._bin_size, self.b,
+                    self.angle_slop,
                     self._ro.min_u,self._ro.max_u,self._ro.nubins,self._ro.ubin_size,self.bu,
                     self._ro.min_v,self._ro.max_v,self._ro.nvbins,self._ro.vbin_size,self.bv,
                     self.xperiod, self.yperiod, self.zperiod,

--- a/treecorr/kqcorrelation.py
+++ b/treecorr/kqcorrelation.py
@@ -111,7 +111,8 @@ class KQCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.KQCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xi, self.xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -128,6 +129,7 @@ class KQCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/ktcorrelation.py
+++ b/treecorr/ktcorrelation.py
@@ -111,7 +111,8 @@ class KTCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.KTCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xi, self.xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -128,6 +129,7 @@ class KTCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/kvcorrelation.py
+++ b/treecorr/kvcorrelation.py
@@ -111,7 +111,8 @@ class KVCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.KVCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xi, self.xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -128,6 +129,7 @@ class KVCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/ngcorrelation.py
+++ b/treecorr/ngcorrelation.py
@@ -119,7 +119,8 @@ class NGCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.NGCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.raw_xi, self.raw_xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -136,6 +137,7 @@ class NGCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -98,6 +98,9 @@ class NKCorrelation(Corr2):
         **kwargs:       See the documentation for `Corr2` for the list of allowed keyword
                         arguments, which may be passed either directly or in the config dict.
     """
+    # The angles are not important for accuracy of NK correlations.
+    _default_angle_slop = 1
+
     def __init__(self, config=None, *, logger=None, **kwargs):
         """Initialize `NKCorrelation`.  See class doc for details.
         """

--- a/treecorr/nkcorrelation.py
+++ b/treecorr/nkcorrelation.py
@@ -121,7 +121,8 @@ class NKCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.NKCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.raw_xi, x, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -138,6 +139,7 @@ class NKCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -88,6 +88,9 @@ class NNCorrelation(Corr2):
         **kwargs:       See the documentation for `Corr2` for the list of allowed keyword
                         arguments, which may be passed either directly or in the config dict.
     """
+    # The angles are not important for accuracy of NN correlations.
+    _default_angle_slop = 1
+
     def __init__(self, config=None, *, logger=None, **kwargs):
         """Initialize `NNCorrelation`.  See class doc for details.
         """

--- a/treecorr/nncorrelation.py
+++ b/treecorr/nncorrelation.py
@@ -114,7 +114,8 @@ class NNCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.NNCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           x, x, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -131,6 +132,7 @@ class NNCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/nnncorrelation.py
+++ b/treecorr/nnncorrelation.py
@@ -154,6 +154,8 @@ class NNNCorrelation(Corr3):
         **kwargs:       See the documentation for `Corr3` for the list of allowed keyword
                         arguments, which may be passed either directly or in the config dict.
     """
+    _default_angle_slop = 1
+
     def __init__(self, config=None, *, logger=None, **kwargs):
         """Initialize `NNNCorrelation`.  See class doc for details.
         """
@@ -193,6 +195,7 @@ class NNNCorrelation(Corr3):
             self._corr = _treecorr.NNNCorr(
                     self._bintype,
                     self._min_sep,self._max_sep,self.nbins,self._bin_size,self.b,
+                    self.angle_slop,
                     self._ro.min_u,self._ro.max_u,self._ro.nubins,self._ro.ubin_size,self.bu,
                     self._ro.min_v,self._ro.max_v,self._ro.nvbins,self._ro.vbin_size,self.bv,
                     self.xperiod, self.yperiod, self.zperiod,

--- a/treecorr/nqcorrelation.py
+++ b/treecorr/nqcorrelation.py
@@ -118,7 +118,8 @@ class NQCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.NQCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.raw_xi, self.raw_xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -135,6 +136,7 @@ class NQCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/ntcorrelation.py
+++ b/treecorr/ntcorrelation.py
@@ -118,7 +118,8 @@ class NTCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.NTCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.raw_xi, self.raw_xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -135,6 +136,7 @@ class NTCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/nvcorrelation.py
+++ b/treecorr/nvcorrelation.py
@@ -118,7 +118,8 @@ class NVCorrelation(Corr2):
         if self._corr is None:
             x = np.array([])
             self._corr = _treecorr.NVCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.raw_xi, self.raw_xi_im, x, x,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -135,6 +136,7 @@ class NVCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/qqcorrelation.py
+++ b/treecorr/qqcorrelation.py
@@ -120,7 +120,8 @@ class QQCorrelation(Corr2):
     def corr(self):
         if self._corr is None:
             self._corr = _treecorr.QQCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xip, self.xip_im, self.xim, self.xim_im,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -137,6 +138,7 @@ class QQCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/ttcorrelation.py
+++ b/treecorr/ttcorrelation.py
@@ -120,7 +120,8 @@ class TTCorrelation(Corr2):
     def corr(self):
         if self._corr is None:
             self._corr = _treecorr.TTCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xip, self.xip_im, self.xim, self.xim_im,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -137,6 +138,7 @@ class TTCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and

--- a/treecorr/vvcorrelation.py
+++ b/treecorr/vvcorrelation.py
@@ -120,7 +120,8 @@ class VVCorrelation(Corr2):
     def corr(self):
         if self._corr is None:
             self._corr = _treecorr.VVCorr(self._bintype, self._min_sep, self._max_sep, self._nbins,
-                                          self._bin_size, self.b, self.min_rpar, self.max_rpar,
+                                          self._bin_size, self.b, self.angle_slop,
+                                          self.min_rpar, self.max_rpar,
                                           self.xperiod, self.yperiod, self.zperiod,
                                           self.xip, self.xip_im, self.xim, self.xim_im,
                                           self.meanr, self.meanlogr, self.weight, self.npairs)
@@ -137,6 +138,7 @@ class VVCorrelation(Corr2):
                 self.coords == other.coords and
                 self.bin_type == other.bin_type and
                 self.bin_slop == other.bin_slop and
+                self.angle_slop == other.angle_slop and
                 self.min_rpar == other.min_rpar and
                 self.max_rpar == other.max_rpar and
                 self.xperiod == other.xperiod and


### PR DESCRIPTION
One issue that has cropped up from time to time with shear correlations is that there can be some error in the projection directions when the bin size is rather large.  This is because when a pair of cells fully fits into a single bin, or nearly does (according to the given bin_slop), there can still be some errors in the accumulated correlation because the shears are all projected to a slightly different direction than they would with the exact calculation.

Previously, there had been no way to reduce this error other than using smaller bins, which can sometimes be impractical. This PR adds a new option to set a maximum angular error that is allowed for any pair of cells being accumulated.  The parameter `angle_slop` sets a maximum angular difference (in radians) between the direction that a pair of cells being accumulated has compared to any of is constituent object pairs.

For scalar correlations (e.g. NN, KK, NK), there is not really any reason to use this parameter.  But for shear correlations or other non-spin-0 quantities, it can potentially improve the accuracy when the bin size is relatively large.

The default value for all non-spin-0 quantities is angle_slop = 0.1, which is probably reasonable for most use cases.

Additionally, this PR disconnects the angular splitting calculation from the angular one for the three-point multipole algorithm.  With multipole, the bin_slop parameter turns out to be pretty important for accuracy, as the slop between bins seems to move power from the off-diagonal to the diagonal.  So for high-accuracy use cases, one may want to lower the bin_slop to 0 or close to 0.  Now, that doesn't affect the angular splitting decision, which seems to be less impactful to the final multipole accuracy.