### PR TITLE
#162 Fix a bug in linear binning which could cause very bad results for certain use cases.

### DIFF
--- a/include/BinType.h
+++ b/include/BinType.h
@@ -201,7 +201,7 @@ struct BinTypeHelper<Linear>
                           double minsep, double maxsep, double logminsep,
                           int& ik, double& r, double& logr)
     {
-        xdbg<<"singleBin: "<<rsq<<"  "<<s1ps2<<std::endl;
+        xdbg<<"singleBin: "<<rsq<<"  "<<s1ps2<<"  "<<b<<"  "<<a<<std::endl;
 
         // Check for angle being too large.
         if (SQR(s1ps2) > asq*rsq) return false;

--- a/setup.py
+++ b/setup.py
@@ -410,7 +410,11 @@ class my_builder( build_ext ):
         super().finalize_options()
 
         self.include_dirs.append('include')
-        self.library_dirs.append(sysconfig.get_config_var('LIBDIR'))
+
+        # Add the system libdir if it exists.
+        libdir = sysconfig.get_config_var('LIBDIR')
+        if libdir is not None:
+            self.library_dirs.append(libdir)
 
         # Add pybind11's include dir
         # GalSim has a whole long thing for this.

--- a/setup.py
+++ b/setup.py
@@ -405,9 +405,12 @@ def fix_compiler(compiler):
 class my_builder( build_ext ):
 
     def finalize_options(self):
+        from distutils import sysconfig
+
         super().finalize_options()
 
         self.include_dirs.append('include')
+        self.library_dirs.append(sysconfig.get_config_var('LIBDIR'))
 
         # Add pybind11's include dir
         # GalSim has a whole long thing for this.

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -473,7 +473,7 @@ class Corr2(object):
         self._ro.angle_slop = get(self.config,'angle_slop',float,self._default_angle_slop)
         if self.bin_slop < 0.0:
             self._ro.bin_slop = min(max_good_slop, 1.0)
-        self._ro.b = self.bin_size * self.bin_slop
+        self._ro.b = self._bin_size * self.bin_slop
         if self.bin_slop > max_good_slop + 0.0001 and self.angle_slop > 0.1:
             self.logger.warning(
                 "Using bin_slop = %g, angle_slop = %g, bin_size = %g (b = %g).\n"%(


### PR DESCRIPTION
@vduret and @akritiasto reported some very poor accuracy in NN correlations with linear binning, which this PR fixes.

The bug was actually present for any Linear binning if the separations are given in angular units other than radians.  The underlying bug was that the b parameter (used internally to determine when to split pairs of cells being considered for accumulation) did not have the angular units applied to it.  

So if the separations are given in say arcsec, then it was missing a factor of Pi/(180 x 60 x 60) = 5.e-6.  That's a big factor.