### PR TITLE
#177 Enable Rperp and Rlens, along with min/max rpar for 3pt functions

### DIFF
--- a/docs/metric.rst
+++ b/docs/metric.rst
@@ -89,9 +89,15 @@ two points, and
 
 :math:`L \equiv \frac{p1 + p2}{2}`
 
-then
+or, for 3-point correlations
+
+:math:`L \eqiv \frac{p1 + p2 + p3}{3}`.
+
+Then
 
 :math:`r_\parallel = \frac{(p_2 - p_1) \cdot L}{|L|}`
+
+(or similarly for each pair of points in the 3-point case).
 
 That is, it breaks up the full 3-d distance into perpendicular and parallel components:
 :math:`d_{\rm 3d}^2 = r_\bot^2 + r_\parallel^2`,
@@ -145,8 +151,8 @@ In this limit, the formula for :math:`d` reduces to
 -------
 
 This metric is only valid when the first catalog uses 3-dimensional coordinates
-(ra,dec,r) or (x,y,z).  The second catalog may take either 3-d coordinates or spherical
-coordinates (ra,dec).
+(ra,dec,r) or (x,y,z).  The second catalog (and the third in the 3-point case)
+may take either 3-d coordinates or spherical coordinates (ra,dec).
 
 The distance is defined as
 
@@ -200,7 +206,8 @@ Restrictions on the Line of Sight Separation
 There are two additional parameters that are tightly connected to the metric space:
 ``min_rpar`` and ``max_rpar``.
 These set the minimum and maximum values of :math:`r_\parallel` for pairs to be included in the
-correlations.
+correlations.  For 3-point correlations, the minimum and maximum values apply to both
+points 2 and 3 with respect to point 1 in the triangle.
 
 This is most typically relevant for the Rperp or Rlens metrics, but we now (as of version 4.2)
 allow these parameters for any metric.

--- a/include/BinType.h
+++ b/include/BinType.h
@@ -1445,23 +1445,45 @@ struct BinTypeHelper<LogMultipole>
         const MetricHelper<M,0>& metric, int ordered,
         double minsep, double minsepsq, double maxsep, double maxsepsq)
     {
+        xdbg<<"LogMultipole trivial_stop\n";
         // Check if all possible triangles will have either d2 or d3 < minsep
+        int small_count = 0;
         if (d2sq < minsepsq && s1+s3 < minsep && (s1+s3 == 0. || d2sq < SQR(minsep - s1-s3))) {
             xdbg<<"d2 cannot be as large as minsep\n";
-            return true;
+            if (ordered) return true;
+            else small_count += 1;
         }
         if (d3sq < minsepsq && s1+s2 < minsep && (s1+s2 == 0. || d3sq < SQR(minsep - s1-s2))) {
             xdbg<<"d3 cannot be as large as minsep\n";
+            if (ordered) return true;
+            else small_count += 1;
+        }
+        if (!ordered && d1sq < minsepsq && s2+s3 < minsep &&
+            (s2+s3 == 0. || d1sq < SQR(minsep - s2-s3))) {
+            xdbg<<"d1 cannot be as large as minsep\n";
+            small_count += 1;
+        }
+        if (!ordered && small_count >= 2) {
             return true;
         }
 
         // Check if all possible triangles will have d2 or d3 > maxsep.
+        int large_count = 0;
         if (d2sq >= maxsepsq && (s1+s3 == 0. || d2sq >= SQR(maxsep + s1+s3))) {
             xdbg<<"d2 cannot be as small as maxsep\n";
-            return true;
+            if (ordered) return true;
+            else large_count += 1;
         }
         if (d3sq >= maxsepsq && (s1+s2 == 0. || d3sq >= SQR(maxsep + s1+s2))) {
             xdbg<<"d3 cannot be as small as maxsep\n";
+            if (ordered) return true;
+            else large_count += 1;
+        }
+        if (!ordered && d1sq >= maxsepsq && (s2+s3 == 0. || d1sq >= SQR(maxsep + s2+s3))) {
+            xdbg<<"d1 cannot be as small as maxsep\n";
+            large_count += 1;
+        }
+        if (!ordered && large_count >= 2) {
             return true;
         }
 

--- a/include/BinType.h
+++ b/include/BinType.h
@@ -34,7 +34,7 @@
 
 enum BinType { Log, Linear, TwoD, LogRUV, LogSAS, LogMultipole };
 
-template <int M>
+template <int B>
 struct BinTypeHelper;
 
 template <>
@@ -425,12 +425,12 @@ struct BinTypeHelper<LogRUV>
 
     // Once we have all the distances, see if it's possible to stop
     // For this BinType, if return value is false, d2 is set on output.
-    template <int O, int M, int C>
+    template <int O, int M, int P, int C>
     static bool stop111(
         double d1sq, double d2sq, double d3sq,
         double s1, double s2, double s3,
         const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
-        const MetricHelper<M,0>& metric,
+        const MetricHelper<M,P>& metric,
         double& d1, double& d2, double& d3, double& u, double& v,
         double minsep, double minsepsq, double maxsep, double maxsepsq,
         double minu, double minusq, double maxu, double maxusq,
@@ -735,10 +735,10 @@ struct BinTypeHelper<LogRUV>
         }
     }
 
-    template <int O, int M, int C>
+    template <int O, int M, int P, int C>
     static bool isTriangleInRange(const Position<C>& p1, const Position<C>& p2,
                                   const Position<C>& p3,
-                                  const MetricHelper<M,0>& metric,
+                                  const MetricHelper<M,P>& metric,
                                   double d1sq, double d2sq, double d3sq,
                                   double d1, double d2, double d3, double& u, double& v,
                                   double logminsep,
@@ -906,12 +906,12 @@ struct BinTypeHelper<LogSAS>
 
     // Once we have all the distances, see if it's possible to stop
     // For this BinType, if return value is false, d1,d2,d3,cosphi are set on output.
-    template <int O, int M, int C>
+    template <int O, int M, int P, int C>
     static bool stop111(
         double d1sq, double d2sq, double d3sq,
         double s1, double s2, double s3,
         const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
-        const MetricHelper<M,0>& metric,
+        const MetricHelper<M,P>& metric,
         double& d1, double& d2, double& d3, double& phi, double& cosphi,
         double minsep, double minsepsq, double maxsep, double maxsepsq,
         double minphi, double , double maxphi, double ,
@@ -1268,10 +1268,10 @@ struct BinTypeHelper<LogSAS>
     }
 
     // This BinType finally sets phi here.
-    template <int O, int M, int C>
+    template <int O, int M, int P, int C>
     static bool isTriangleInRange(const Position<C>& p1, const Position<C>& p2,
                                   const Position<C>& p3,
-                                  const MetricHelper<M,0>& metric,
+                                  const MetricHelper<M,P>& metric,
                                   double d1sq, double d2sq, double d3sq,
                                   double d1, double d2, double d3, double& phi, double& cosphi,
                                   double logminsep,
@@ -1393,12 +1393,12 @@ struct BinTypeHelper<LogMultipole>
     { return false; }
 
     // Once we have all the distances, see if it's possible to stop
-    template <int O, int M, int C>
+    template <int O, int M, int P, int C>
     static bool stop111(
         double d1sq, double d2sq, double d3sq,
         double s1, double s2, double s3,
         const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
-        const MetricHelper<M,0>& metric,
+        const MetricHelper<M,P>& metric,
         double& , double& , double& , double& , double& ,
         double minsep, double minsepsq, double maxsep, double maxsepsq,
         double , double , double , double ,
@@ -1544,10 +1544,10 @@ struct BinTypeHelper<LogMultipole>
         return true;
     }
 
-    template <int O, int M, int C>
+    template <int O, int M, int P, int C>
     static bool isTriangleInRange(const Position<C>& p1, const Position<C>& p2,
                                   const Position<C>& p3,
-                                  const MetricHelper<M,0>& metric,
+                                  const MetricHelper<M,P>& metric,
                                   double d1sq, double d2sq, double d3sq,
                                   double d1, double d2, double d3,
                                   double& sinphi, double& cosphi,

--- a/include/BinType.h
+++ b/include/BinType.h
@@ -60,7 +60,7 @@ struct BinTypeHelper<Log>
     // In this case it is simply to check if minsep <= r < maxsep.
     template <int C>
     static bool isRSqInRange(double rsq, const Position<C>& p1, const Position<C>& p2,
-                           double minsep, double minsepsq, double maxsep, double maxsepsq)
+                             double minsep, double minsepsq, double maxsep, double maxsepsq)
     {
         return rsq >= minsepsq && rsq < maxsepsq;
     }
@@ -174,7 +174,7 @@ struct BinTypeHelper<Linear>
     // These next few calculations are the same as Log.
     template <int C>
     static bool isRSqInRange(double rsq, const Position<C>& p1, const Position<C>& p2,
-                           double minsep, double minsepsq, double maxsep, double maxsepsq)
+                             double minsep, double minsepsq, double maxsep, double maxsepsq)
     {
         return rsq >= minsepsq && rsq < maxsepsq;
     }
@@ -269,7 +269,7 @@ struct BinTypeHelper<TwoD>
     // Only C=Flat is valid here.
     template <int C>
     static bool isRSqInRange(double rsq, const Position<C>& p1, const Position<C>& p2,
-                           double minsep, double minsepsq, double maxsep, double maxsepsq)
+                             double minsep, double minsepsq, double maxsep, double maxsepsq)
     {
         // Separately check for r==0, since minsep might be 0, but we still don't want to
         // include "pair"s that are really the same object.
@@ -429,7 +429,7 @@ struct BinTypeHelper<LogRUV>
     static bool stop111(
         double d1sq, double d2sq, double d3sq,
         double s1, double s2, double s3,
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
+        const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
         const MetricHelper<M,0>& metric,
         double& d1, double& d2, double& d3, double& u, double& v,
         double minsep, double minsepsq, double maxsep, double maxsepsq,
@@ -696,8 +696,8 @@ struct BinTypeHelper<LogRUV>
     }
 
     template <int O, int M, int C>
-    static bool isTriangleInRange(const BaseCell<C>& c1, const BaseCell<C>& c2,
-                                  const BaseCell<C>& c3,
+    static bool isTriangleInRange(const Position<C>& p1, const Position<C>& p2,
+                                  const Position<C>& p3,
                                   const MetricHelper<M,0>& metric,
                                   double d1sq, double d2sq, double d3sq,
                                   double d1, double d2, double d3, double& u, double& v,
@@ -769,7 +769,7 @@ struct BinTypeHelper<LogRUV>
         Assert(kv < nvbins);
 
         // Now account for negative v
-        if (!metric.CCW(c1.getPos(), c2.getPos(), c3.getPos())) {
+        if (!metric.CCW(p1, p2, p3)) {
             v = -v;
             kv = nvbins - kv - 1;
         } else {
@@ -870,7 +870,7 @@ struct BinTypeHelper<LogSAS>
     static bool stop111(
         double d1sq, double d2sq, double d3sq,
         double s1, double s2, double s3,
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
+        const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
         const MetricHelper<M,0>& metric,
         double& d1, double& d2, double& d3, double& phi, double& cosphi,
         double minsep, double minsepsq, double maxsep, double maxsepsq,
@@ -919,11 +919,11 @@ struct BinTypeHelper<LogSAS>
             return false;
         }
 
-        cosphi = metric.calculateCosPhi(c1,c2,c3,d1sq,d2sq,d3sq,d1,d2,d3);
+        cosphi = metric.calculateCosPhi(p1,p2,p3,d1sq,d2sq,d3sq,d1,d2,d3);
 
         // If we are not swapping 2,3, stop if orientation cannot be counter-clockwise.
         if (O > 1 &&
-            !metric.CCW(c1.getPos(), c3.getPos(), c2.getPos())) {
+            !metric.CCW(p1, p3, p2)) {
             // For skinny triangles, be careful that the points can't flip to the other side.
             // This is similar to the calculation below.  We effecively check that cosphi can't
             // increase to 1.
@@ -1175,8 +1175,8 @@ struct BinTypeHelper<LogSAS>
 
     // This BinType finally sets phi here.
     template <int O, int M, int C>
-    static bool isTriangleInRange(const BaseCell<C>& c1, const BaseCell<C>& c2,
-                                  const BaseCell<C>& c3,
+    static bool isTriangleInRange(const Position<C>& p1, const Position<C>& p2,
+                                  const Position<C>& p3,
                                   const MetricHelper<M,0>& metric,
                                   double d1sq, double d2sq, double d3sq,
                                   double d1, double d2, double d3, double& phi, double& cosphi,
@@ -1211,12 +1211,12 @@ struct BinTypeHelper<LogSAS>
         }
 
         if (O > 1 &&
-            !metric.CCW(c1.getPos(), c3.getPos(), c2.getPos())) {
+            !metric.CCW(p1, p3, p2)) {
             xdbg<<"Triangle is not CCW.\n";
             return false;
         }
 
-        XAssert(metric.CCW(c1.getPos(), c3.getPos(), c2.getPos()));
+        XAssert(metric.CCW(p1, p3, p2));
 
         if (phi < minphi || phi >= maxphi) {
             xdbg<<"phi not in minphi .. maxphi\n";
@@ -1303,7 +1303,7 @@ struct BinTypeHelper<LogMultipole>
     static bool stop111(
         double d1sq, double d2sq, double d3sq,
         double s1, double s2, double s3,
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
+        const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
         const MetricHelper<M,0>& metric,
         double& , double& , double& , double& , double& ,
         double minsep, double minsepsq, double maxsep, double maxsepsq,
@@ -1420,8 +1420,8 @@ struct BinTypeHelper<LogMultipole>
     }
 
     template <int O, int M, int C>
-    static bool isTriangleInRange(const BaseCell<C>& c1, const BaseCell<C>& c2,
-                                  const BaseCell<C>& c3,
+    static bool isTriangleInRange(const Position<C>& p1, const Position<C>& p2,
+                                  const Position<C>& p3,
                                   const MetricHelper<M,0>& metric,
                                   double d1sq, double d2sq, double d3sq,
                                   double d1, double d2, double d3,
@@ -1468,8 +1468,8 @@ struct BinTypeHelper<LogMultipole>
 
         // Calculate cosphi, sinphi for this triangle.
         // (We use the u variable for sinphi in this class.)
-        std::complex<double> r3 = ProjectHelper<C>::ExpIPhi(c1.getPos(), c2.getPos(), d3);
-        std::complex<double> r2 = ProjectHelper<C>::ExpIPhi(c1.getPos(), c3.getPos(), d2);
+        std::complex<double> r3 = ProjectHelper<C>::ExpIPhi(p1, p2, d3);
+        std::complex<double> r2 = ProjectHelper<C>::ExpIPhi(p1, p3, d2);
         std::complex<double> expiphi = r3 * std::conj(r2);
         cosphi = std::real(expiphi);
         sinphi = std::imag(expiphi);

--- a/include/Corr3.h
+++ b/include/Corr3.h
@@ -56,6 +56,10 @@ public:
     { return _d1 == c1.getD() && _d2 == c2.getD() && _d3 == c3.getD(); }
 
     template <int B, int M, int C>
+    bool triviallyZero(Position<C> p1, Position<C> p2, Position<C> p3,
+                       double s1, double s2, double s3, int ordered, bool p13);
+
+    template <int B, int M, int C>
     void process3(const BaseField<C>& field, bool dots, bool quick);
     template <int B, int O, int M, int C>
     void process12(const BaseField<C>& field1, const BaseField<C>& field2, bool dots, bool quick);

--- a/include/Corr3.h
+++ b/include/Corr3.h
@@ -39,7 +39,7 @@ public:
               double b, double a,
               double minu, double maxu, int nubins, double ubinsize, double bu,
               double minv, double maxv, int nvbins, double vbinsize, double bv,
-              double xp, double yp, double zp);
+              double minrpar, double maxrpar, double xp, double yp, double zp);
     BaseCorr3(const BaseCorr3& rhs);
     virtual ~BaseCorr3() {}
 
@@ -55,47 +55,53 @@ public:
         const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3)
     { return _d1 == c1.getD() && _d2 == c2.getD() && _d3 == c3.getD(); }
 
+    bool nontrivialRPar() const
+    {
+        return (_minrpar != -std::numeric_limits<double>::max() ||
+                _maxrpar != std::numeric_limits<double>::max());
+    }
+
     template <int B, int M, int C>
     bool triviallyZero(Position<C> p1, Position<C> p2, Position<C> p3,
                        double s1, double s2, double s3, int ordered, bool p13);
 
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void process3(const BaseField<C>& field, bool dots, bool quick);
-    template <int B, int O, int M, int C>
+    template <int B, int O, int M, int P, int C>
     void process12(const BaseField<C>& field1, const BaseField<C>& field2, bool dots, bool quick);
-    template <int B, int O, int M, int C>
+    template <int B, int O, int M, int P, int C>
     void process21(const BaseField<C>& field1, const BaseField<C>& field2, bool dots, bool quick);
-    template <int B, int O, int M, int C>
+    template <int B, int O, int M, int P, int C>
     void process111(const BaseField<C>& field1, const BaseField<C>& field2,
                     const BaseField<C>& field3, bool dots, bool quick);
 
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void multipole(const BaseField<C>& field, bool dots, bool quick);
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void multipole(const BaseField<C>& field1,  const BaseField<C>& field2, bool dots, bool quick);
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void multipole(const BaseField<C>& field1,  const BaseField<C>& field2,
                    const BaseField<C>& field3, bool dots, int ordered, bool quick);
 
     // Main worker functions for calculating the result
-    template <int B, int M, int C>
-    void process3(const BaseCell<C>& c1, const MetricHelper<M,0>& metric, bool quick);
+    template <int B, int M, int P, int C>
+    void process3(const BaseCell<C>& c1, const MetricHelper<M,P>& metric, bool quick);
 
-    template <int B, int O, int M, int C>
-    void process12(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,0>& metric,
+    template <int B, int O, int M, int P, int C>
+    void process12(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& metric,
                    bool quick);
-    template <int B, int O, int M, int C>
-    void process21(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,0>& metric,
+    template <int B, int O, int M, int P, int C>
+    void process21(const BaseCell<C>& c1, const BaseCell<C>& c2, const MetricHelper<M,P>& metric,
                    bool quick);
 
-    template <int B, int O, int Q, int M, int C>
+    template <int B, int O, int Q, int M, int P, int C>
     void process111(const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-                    const MetricHelper<M,0>& metric,
+                    const MetricHelper<M,P>& metric,
                     double d1sq=0., double d2sq=0., double d3sq=0.);
 
-    template <int B, int O, int Q, int M, int C>
+    template <int B, int O, int Q, int M, int P, int C>
     void process111Sorted(const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-                          const MetricHelper<M,0>& metric,
+                          const MetricHelper<M,P>& metric,
                           double d1sq=0., double d2sq=0., double d3sq=0.);
 
     template <int B, int Q, int C>
@@ -106,39 +112,39 @@ public:
                           const int index);
 
 
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void splitC2Cells(const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-                      const MetricHelper<M,0>& metric, std::vector<const BaseCell<C>*>& newc2list);
+                      const MetricHelper<M,P>& metric, std::vector<const BaseCell<C>*>& newc2list);
 
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void multipoleSplit1(const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-                         const MetricHelper<M,0>& metric, bool quick,
+                         const MetricHelper<M,P>& metric, bool quick,
                          BaseMultipoleScratch& mp);
 
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     void multipoleSplit1(const BaseCell<C>& c1,
                          const std::vector<const BaseCell<C>*>& c2list,
                          const std::vector<const BaseCell<C>*>& c3list,
-                         const MetricHelper<M,0>& metric, int ordered, bool quick,
+                         const MetricHelper<M,P>& metric, int ordered, bool quick,
                          BaseMultipoleScratch& mp2, BaseMultipoleScratch& mp3);
 
-    template <int B, int M, int C>
+    template <int B, int M, int P, int C>
     double splitC2CellsOrCalculateGn(
         const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-        const MetricHelper<M,0>& metric,
+        const MetricHelper<M,P>& metric,
         std::vector<const BaseCell<C>*>& newc2list, bool& anysplit1,
         BaseMultipoleScratch& mp, double maxr);
 
-    template <int B, int Q, int M, int C>
+    template <int B, int Q, int M, int P, int C>
     void multipoleFinish(const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-                         const MetricHelper<M,0>& metric, BaseMultipoleScratch& mp,
+                         const MetricHelper<M,P>& metric, BaseMultipoleScratch& mp,
                          int mink_zeta, double maxr);
 
-    template <int B, int Q, int M, int C>
+    template <int B, int Q, int M, int P, int C>
     void multipoleFinish(const BaseCell<C>& c1,
                          const std::vector<const BaseCell<C>*>& c2list,
                          const std::vector<const BaseCell<C>*>& c3list,
-                         const MetricHelper<M,0>& metric, int ordered,
+                         const MetricHelper<M,P>& metric, int ordered,
                          BaseMultipoleScratch& mp2, BaseMultipoleScratch& mp3,
                          int mink_zeta, double maxr2, double maxr3);
 
@@ -317,6 +323,7 @@ protected:
     int _nvbins;
     double _vbinsize;
     double _bv;
+    double _minrpar, _maxrpar;
     double _xp, _yp, _zp;
     double _logminsep;
     double _halfminsep;
@@ -344,7 +351,7 @@ public:
           double b, double a,
           double minu, double maxu, int nubins, double ubinsize, double bu,
           double minv, double maxv, int nvbins, double vbinsize, double bv,
-          double xp, double yp, double zp,
+          double minrpar, double maxrpar, double xp, double yp, double zp,
           double* zeta0, double* zeta1, double* zeta2, double* zeta3,
           double* zeta4, double* zeta5, double* zeta6, double* zeta7,
           double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -234,6 +234,19 @@ struct MetricHelper<Euclidean, P>
                       double rsq, double rpar, double s1ps2, double maxsep, double maxsepsq) const
     { return true; }
 
+    template <int C>
+    void TripleDistSq(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                      double& d1sq, double& d2sq, double& d3sq) const
+    {
+        double s=0.;
+        if (d1sq == 0.)
+            d1sq = DistSq(p2, p3, s, s);
+        if (d2sq == 0.)
+            d2sq = DistSq(p1, p3, s, s);
+        if (d3sq == 0.)
+            d3sq = DistSq(p1, p2, s, s);
+    }
+
     // Arc is the only metric with anything different from the normal law of cosines.
     template <int C>
     double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
@@ -369,6 +382,19 @@ struct MetricHelper<OldRperp, P>
     }
 
     template <int C>
+    void TripleDistSq(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                      double& d1sq, double& d2sq, double& d3sq) const
+    {
+        double s=0.;
+        if (d1sq == 0.)
+            d1sq = DistSq(p2, p3, s, s);
+        if (d2sq == 0.)
+            d2sq = DistSq(p1, p3, s, s);
+        if (d3sq == 0.)
+            d3sq = DistSq(p1, p2, s, s);
+    }
+
+    template <int C>
     double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
                            double d1sq, double d2sq, double d3sq,
                            double d1, double d2, double d3) const
@@ -498,6 +524,31 @@ struct MetricHelper<Rperp, P>
     }
 
     template <int C>
+    void TripleDistSq(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                      double& d1sq, double& d2sq, double& d3sq) const
+    {
+        // The generalization for three points is the following:
+        //   L = (p1 + p2 + p3)/3
+        //   rij = (pj - pi)
+        //   r_par = |L . r| / |L|
+        //   r_perp^2 = |r|^2 - |r_par|^2
+
+        Position<ThreeD> L = (p1+p2+p3)/3.;
+        double normLsq = L.normSq();
+        // Save this so we can use it later in tooLargeDist.
+        _normLsq = normLsq;
+
+        double r1parsq = SQR(L.dot(p2-p3)) / normLsq;
+        d1sq = (p2-p3).normSq() - r1parsq;
+
+        double r2parsq = SQR(L.dot(p3-p1)) / normLsq;
+        d2sq = (p3-p1).normSq() - r2parsq;
+
+        double r3parsq = SQR(L.dot(p2-p1)) / normLsq;
+        d3sq = (p2-p1).normSq() - r3parsq;
+    }
+
+    template <int C>
     double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
                            double d1sq, double d2sq, double d3sq,
                            double d1, double d2, double d3) const
@@ -570,6 +621,24 @@ struct MetricHelper<Rlens, P>
     bool tooLargeDist(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                       double rsq, double rpar, double s1ps2, double maxsep, double maxsepsq) const
     { return true; }
+
+    template <int C>
+    void TripleDistSq(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                      double& d1sq, double& d2sq, double& d3sq) const
+    {
+        // In this case, d2, d3 are normal, but d1 needs both points projected to the plane
+        // of p1 do get the right separation.
+        // If we do it the normal way then d1 is too big by a factor r2/r1.
+        // So just do that, then then scale down by that factor.
+        double s;
+        if (d1sq == 0.)
+            d1sq = DistSq(p2, p3, s, s);
+        if (d2sq == 0.)
+            d2sq = DistSq(p1, p3, s, s);
+        if (d3sq == 0.)
+            d3sq = DistSq(p1, p2, s, s);
+        d1sq /= p2.normSq() / p1.normSq();
+    }
 
     template <int C>
     double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
@@ -683,6 +752,19 @@ struct MetricHelper<Arc, P>
     bool tooLargeDist(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                       double rsq, double rpar, double s1ps2, double maxsep, double maxsepsq) const
     { return true; }
+
+    template <int C>
+    void TripleDistSq(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                      double& d1sq, double& d2sq, double& d3sq) const
+    {
+        double s=0.;
+        if (d1sq == 0.)
+            d1sq = DistSq(p2, p3, s, s);
+        if (d2sq == 0.)
+            d2sq = DistSq(p1, p3, s, s);
+        if (d3sq == 0.)
+            d3sq = DistSq(p1, p2, s, s);
+    }
 
     template <int C>
     double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
@@ -842,6 +924,19 @@ struct MetricHelper<Periodic, P>
     bool tooLargeDist(const Position<ThreeD>& p1, const Position<ThreeD>& p2,
                       double rsq, double rpar, double s1ps2, double maxsep, double maxsepsq) const
     { return true; }
+
+    template <int C>
+    void TripleDistSq(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                      double& d1sq, double& d2sq, double& d3sq) const
+    {
+        double s=0.;
+        if (d1sq == 0.)
+            d1sq = DistSq(p2, p3, s, s);
+        if (d2sq == 0.)
+            d2sq = DistSq(p1, p3, s, s);
+        if (d3sq == 0.)
+            d3sq = DistSq(p1, p2, s, s);
+    }
 
     template <int C>
     double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -236,10 +236,9 @@ struct MetricHelper<Euclidean, P>
 
     // Arc is the only metric with anything different from the normal law of cosines.
     template <int C>
-    double calculateCosPhi(
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-        double d1sq, double d2sq, double d3sq,
-        double d1, double d2, double d3) const
+    double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                           double d1sq, double d2sq, double d3sq,
+                           double d1, double d2, double d3) const
     { return (d2sq + d3sq - d1sq) / (2*d2*d3); }
 
 
@@ -370,10 +369,9 @@ struct MetricHelper<OldRperp, P>
     }
 
     template <int C>
-    double calculateCosPhi(
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-        double d1sq, double d2sq, double d3sq,
-        double d1, double d2, double d3) const
+    double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                           double d1sq, double d2sq, double d3sq,
+                           double d1, double d2, double d3) const
     { return (d2sq + d3sq - d1sq) / (2*d2*d3); }
 
 };
@@ -500,10 +498,9 @@ struct MetricHelper<Rperp, P>
     }
 
     template <int C>
-    double calculateCosPhi(
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-        double d1sq, double d2sq, double d3sq,
-        double d1, double d2, double d3) const
+    double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                           double d1sq, double d2sq, double d3sq,
+                           double d1, double d2, double d3) const
     { return (d2sq + d3sq - d1sq) / (2*d2*d3); }
 
 };
@@ -575,10 +572,9 @@ struct MetricHelper<Rlens, P>
     { return true; }
 
     template <int C>
-    double calculateCosPhi(
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-        double d1sq, double d2sq, double d3sq,
-        double d1, double d2, double d3) const
+    double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                           double d1sq, double d2sq, double d3sq,
+                           double d1, double d2, double d3) const
     { return (d2sq + d3sq - d1sq) / (2*d2*d3); }
 
 };
@@ -689,10 +685,9 @@ struct MetricHelper<Arc, P>
     { return true; }
 
     template <int C>
-    double calculateCosPhi(
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-        double theta1sq, double theta2sq, double theta3sq,
-        double theta1, double theta2, double theta3) const
+    double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                           double theta1sq, double theta2sq, double theta3sq,
+                           double theta1, double theta2, double theta3) const
     {
         // The correct spherical geometry formula is
         // cos(c) = cos(a) cos(b) + sin(a) sin(b) cos(phi)
@@ -712,9 +707,9 @@ struct MetricHelper<Arc, P>
         // Rather than do trig though, recompute the chord lengths so we can compute
         // cos(phi) with just regular arithmetic and a sqrt.
         //
-        double d1sq = (c2.getPos() - c3.getPos()).normSq();
-        double d2sq = (c1.getPos() - c3.getPos()).normSq();
-        double d3sq = (c1.getPos() - c2.getPos()).normSq();
+        double d1sq = (p2 - p3).normSq();
+        double d2sq = (p1 - p3).normSq();
+        double d3sq = (p1 - p2).normSq();
 
         double cosphi = (d2sq + d3sq - 0.5*d2sq*d3sq - d1sq);
         cosphi /= 2. * std::sqrt( d2sq * d3sq * (1.-0.25*d2sq) * (1.-0.25*d3sq) );
@@ -849,10 +844,9 @@ struct MetricHelper<Periodic, P>
     { return true; }
 
     template <int C>
-    double calculateCosPhi(
-        const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-        double d1sq, double d2sq, double d3sq,
-        double d1, double d2, double d3) const
+    double calculateCosPhi(const Position<C>& p1, const Position<C>& p2, const Position<C>& p3,
+                           double d1sq, double d2sq, double d3sq,
+                           double d1, double d2, double d3) const
     { return (d2sq + d3sq - d1sq) / (2*d2*d3); }
 
 };

--- a/include/Metric.h
+++ b/include/Metric.h
@@ -637,7 +637,7 @@ struct MetricHelper<Rlens, P>
             d2sq = DistSq(p1, p3, s, s);
         if (d3sq == 0.)
             d3sq = DistSq(p1, p2, s, s);
-        d1sq /= p2.normSq() / p1.normSq();
+        d1sq /= (p2.normSq() / p1.normSq());
     }
 
     template <int C>

--- a/include/MultipoleScratch.h
+++ b/include/MultipoleScratch.h
@@ -223,7 +223,7 @@ struct MultipoleScratch<KData> : public BaseMultipoleScratch
 
     MultipoleScratch(const MultipoleScratch& rhs) :
         BaseMultipoleScratch(rhs), buffer(rhs.buffer),
-        _Gn(rhs._Gn), sumwwkk(rhs.sumwwkk)
+        Gnsize(rhs.Gnsize), _Gn(rhs._Gn), sumwwkk(rhs.sumwwkk)
     {}
 
 

--- a/src/Corr2.cpp
+++ b/src/Corr2.cpp
@@ -596,9 +596,8 @@ bool BaseCorr2::triviallyZero(Position<C> p1, Position<C> p2, double s1, double 
     MetricHelper<M,0> metric(minrpar, maxrpar, _xp, _yp, _zp);
     const double rsq = metric.DistSq(p1, p2, s1, s2);
     double s1ps2 = s1 + s2;
-    double rpar = 0;
     return (BinTypeHelper<B>::tooLargeDist(rsq, s1ps2, _maxsep, _maxsepsq) &&
-            metric.tooLargeDist(p1, p2, rsq, rpar, s1ps2, _fullmaxsep, _fullmaxsepsq));
+            metric.tooLargeDist(p1, p2, rsq, 0, s1ps2, _fullmaxsep, _fullmaxsepsq));
 }
 
 Sampler::Sampler(const BaseCorr2& base_corr2, double minsep, double maxsep,

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -73,12 +73,12 @@ BaseCorr3::BaseCorr3(
     double b, double a,
     double minu, double maxu, int nubins, double ubinsize, double bu,
     double minv, double maxv, int nvbins, double vbinsize, double bv,
-    double xp, double yp, double zp):
+    double minrpar, double maxrpar, double xp, double yp, double zp):
     _bin_type(bin_type), _d1(d1), _d2(d2), _d3(d3),
     _minsep(minsep), _maxsep(maxsep), _nbins(nbins), _binsize(binsize), _b(b), _a(a),
     _minu(minu), _maxu(maxu), _nubins(nubins), _ubinsize(ubinsize), _bu(bu),
     _minv(minv), _maxv(maxv), _nvbins(nvbins), _vbinsize(vbinsize), _bv(bv),
-    _xp(xp), _yp(yp), _zp(zp), _coords(-1)
+    _minrpar(minrpar), _maxrpar(maxrpar), _xp(xp), _yp(yp), _zp(zp), _coords(-1)
 {
     // Do a few things that are specific to different bin_types.
     switch(bin_type) {
@@ -130,7 +130,7 @@ Corr3<D1,D2,D3>::Corr3(
     BinType bin_type, double minsep, double maxsep, int nbins, double binsize, double b, double a,
     double minu, double maxu, int nubins, double ubinsize, double bu,
     double minv, double maxv, int nvbins, double vbinsize, double bv,
-    double xp, double yp, double zp,
+    double minrpar, double maxrpar, double xp, double yp, double zp,
     double* zeta0, double* zeta1, double* zeta2, double* zeta3,
     double* zeta4, double* zeta5, double* zeta6, double* zeta7,
     double* meand1, double* meanlogd1, double* meand2, double* meanlogd2,
@@ -140,7 +140,7 @@ Corr3<D1,D2,D3>::Corr3(
               minsep, maxsep, nbins, binsize, b, a,
               minu, maxu, nubins, ubinsize, bu,
               minv, maxv, nvbins, vbinsize, bv,
-              xp, yp, zp),
+              minrpar, maxrpar, xp, yp, zp),
     _owns_data(false),
     _zeta(zeta0, zeta1, zeta2, zeta3, zeta4, zeta5, zeta6, zeta7),
     _meand1(meand1), _meanlogd1(meanlogd1), _meand2(meand2), _meanlogd2(meanlogd2),
@@ -156,6 +156,8 @@ BaseCorr3::BaseCorr3(const BaseCorr3& rhs):
     _ubinsize(rhs._ubinsize), _bu(rhs._bu),
     _minv(rhs._minv), _maxv(rhs._maxv), _nvbins(rhs._nvbins),
     _vbinsize(rhs._vbinsize), _bv(rhs._bv),
+    _minrpar(rhs._minrpar), _maxrpar(rhs._maxrpar),
+    _xp(rhs._xp), _yp(rhs._yp), _zp(rhs._zp),
     _logminsep(rhs._logminsep), _halfminsep(rhs._halfminsep),
     _minsepsq(rhs._minsepsq), _maxsepsq(rhs._maxsepsq),
     _minusq(rhs._minusq), _maxusq(rhs._maxusq),
@@ -295,7 +297,7 @@ bool BaseCorr3::triviallyZero(Position<C> p1, Position<C> p2, Position<C> p3,
     }
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::process3(const BaseField<C>& field, bool dots, bool quick)
 {
     dbg<<"Start process auto\n";
@@ -318,7 +320,7 @@ void BaseCorr3::process3(const BaseField<C>& field, bool dots, bool quick)
         BaseCorr3& corr = *this;
 #endif
 
-        MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+        MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
 
 #ifdef _OPENMP
 #pragma omp for schedule(dynamic)
@@ -360,7 +362,7 @@ void BaseCorr3::process3(const BaseField<C>& field, bool dots, bool quick)
     if (dots) std::cout<<std::endl;
 }
 
-template <int B, int O, int M, int C>
+template <int B, int O, int M, int P, int C>
 void BaseCorr3::process12(const BaseField<C>& field1, const BaseField<C>& field2,
                           bool dots, bool quick)
 {
@@ -377,7 +379,7 @@ void BaseCorr3::process12(const BaseField<C>& field1, const BaseField<C>& field2
     Assert(n1 > 0);
     Assert(n2 > 0);
 
-    MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+    MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
 
     const std::vector<const BaseCell<C>*>& c1list = field1.getCells();
     const std::vector<const BaseCell<C>*>& c2list = field2.getCells();
@@ -430,7 +432,7 @@ void BaseCorr3::process12(const BaseField<C>& field1, const BaseField<C>& field2
     if (dots) std::cout<<std::endl;
 }
 
-template <int B, int O, int M, int C>
+template <int B, int O, int M, int P, int C>
 void BaseCorr3::process21(const BaseField<C>& field1, const BaseField<C>& field2,
                            bool dots, bool quick)
 {
@@ -447,7 +449,7 @@ void BaseCorr3::process21(const BaseField<C>& field1, const BaseField<C>& field2
     Assert(n1 > 0);
     Assert(n2 > 0);
 
-    MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+    MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
 
     const std::vector<const BaseCell<C>*>& c1list = field1.getCells();
     const std::vector<const BaseCell<C>*>& c2list = field2.getCells();
@@ -500,7 +502,7 @@ void BaseCorr3::process21(const BaseField<C>& field1, const BaseField<C>& field2
     if (dots) std::cout<<std::endl;
 }
 
-template <int B, int O, int M, int C>
+template <int B, int O, int M, int P, int C>
 void BaseCorr3::process111(const BaseField<C>& field1, const BaseField<C>& field2,
                            const BaseField<C>& field3, bool dots, bool quick)
 {
@@ -520,7 +522,7 @@ void BaseCorr3::process111(const BaseField<C>& field1, const BaseField<C>& field
     Assert(n2 > 0);
     Assert(n3 > 0);
 
-    MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+    MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
 
     const std::vector<const BaseCell<C>*>& c1list = field1.getCells();
     const std::vector<const BaseCell<C>*>& c2list = field2.getCells();
@@ -573,8 +575,8 @@ void BaseCorr3::process111(const BaseField<C>& field1, const BaseField<C>& field
     if (dots) std::cout<<std::endl;
 }
 
-template <int B, int M, int C>
-void BaseCorr3::process3(const BaseCell<C>& c1, const MetricHelper<M,0>& metric, bool quick)
+template <int B, int M, int P, int C>
+void BaseCorr3::process3(const BaseCell<C>& c1, const MetricHelper<M,P>& metric, bool quick)
 {
     // Does all triangles with 3 points in c1
     xdbg<<ws()<<"Process3: c1 = "<<c1.getPos()<<"  "<<c1.getSize()<<"  "<<c1.getN()<<std::endl;
@@ -599,9 +601,9 @@ void BaseCorr3::process3(const BaseCell<C>& c1, const MetricHelper<M,0>& metric,
     dec_ws();
 }
 
-template <int B, int O, int M, int C>
+template <int B, int O, int M, int P, int C>
 void BaseCorr3::process12(const BaseCell<C>& c1, const BaseCell<C>& c2,
-                          const MetricHelper<M,0>& metric, bool quick)
+                          const MetricHelper<M,P>& metric, bool quick)
 {
     // Does all triangles with one point in c1 and the other two points in c2
     xdbg<<ws()<<"Process12: c1: "<<c1.getSize()<<"  "<<c1.getW()<<"  c2: "<<c2.getSize()<<"  "<<c2.getW()<<std::endl;
@@ -684,9 +686,9 @@ void BaseCorr3::process12(const BaseCell<C>& c1, const BaseCell<C>& c2,
     dec_ws();
 }
 
-template <int B, int O, int M, int C>
+template <int B, int O, int M, int P, int C>
 void BaseCorr3::process21(const BaseCell<C>& c1, const BaseCell<C>& c2,
-                          const MetricHelper<M,0>& metric, bool quick)
+                          const MetricHelper<M,P>& metric, bool quick)
 {
     // Does all triangles with two points in c1 and the other point in c2
     xdbg<<ws()<<"Process21: c1: "<<c1.getSize()<<"  "<<c1.getW()<<"  c2: "<<c2.getSize()<<"  "<<c2.getW()<<std::endl;
@@ -769,10 +771,10 @@ void BaseCorr3::process21(const BaseCell<C>& c1, const BaseCell<C>& c2,
     dec_ws();
 }
 
-template <int B, int O, int Q, int M, int C>
+template <int B, int O, int Q, int M, int P, int C>
 void BaseCorr3::process111(
     const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-    const MetricHelper<M,0>& metric, double d1sq, double d2sq, double d3sq)
+    const MetricHelper<M,P>& metric, double d1sq, double d2sq, double d3sq)
 {
     xdbg<<ws()<<"Process111: c1: "<<c1.getSize()<<"  "<<c1.getW()<<"  c2: "<<c2.getSize()<<"  "<<c2.getW()<<"  c3: "<<c3.getSize()<<"  "<<c3.getW()<<std::endl;
     xdbg<<ws()<<"Process111: c1 = "<<indices(c1)<<"  c2 = "<<indices(c2)<<"  c3 = "<<indices(c3)<<"  ordered="<<O<<"\n";
@@ -935,26 +937,36 @@ void BaseCorr3::process111(
     dec_ws();
 }
 
-template <int B, int O, int Q, int M, int C>
+template <int B, int O, int Q, int M, int P, int C>
 void BaseCorr3::process111Sorted(
     const BaseCell<C>& c1, const BaseCell<C>& c2, const BaseCell<C>& c3,
-    const MetricHelper<M,0>& metric, double d1sq, double d2sq, double d3sq)
+    const MetricHelper<M,P>& metric, double d1sq, double d2sq, double d3sq)
 {
     const double s1 = c1.getSize();
     const double s2 = c2.getSize();
     const double s3 = c3.getSize();
+    const Position<C>& p1 = c1.getPos();
+    const Position<C>& p2 = c2.getPos();
+    const Position<C>& p3 = c3.getPos();
 
-    xdbg<<"Process111Sorted: c1 = "<<c1.getPos()<<"  "<<c1.getSize()<<"  "<<c1.getN()<<std::endl;
-    xdbg<<"                  c2 = "<<c2.getPos()<<"  "<<c2.getSize()<<"  "<<c2.getN()<<std::endl;
-    xdbg<<"                  c3 = "<<c3.getPos()<<"  "<<c3.getSize()<<"  "<<c3.getN()<<std::endl;
+    xdbg<<"Process111Sorted: c1 = "<<p1<<"  "<<s1<<"  "<<c1.getN()<<std::endl;
+    xdbg<<"                  c2 = "<<p2<<"  "<<s2<<"  "<<c2.getN()<<std::endl;
+    xdbg<<"                  c3 = "<<p3<<"  "<<s3<<"  "<<c3.getN()<<std::endl;
     xdbg<<"                  d123 = "<<sqrt(d1sq)<<"  "<<sqrt(d2sq)<<"  "<<sqrt(d3sq)<<std::endl;
     xdbg<<ws()<<"ProcessSorted111: c1 = "<<indices(c1)<<"  c2 = "<<indices(c2)<<"  c3 = "<<indices(c3)<<"  ordered="<<O<<"\n";
+
+    double rpar2, rpar3;
+    if (metric.isRParOutsideRange(p1, p2, s1+s2, rpar2) ||
+        metric.isRParOutsideRange(p1, p3, s1+s3, rpar3)) {
+        xdbg<<ws()<<"Stopping early -- invalid rpar: "<<rpar2<<"  "<<rpar3<<std::endl;
+        return;
+    }
 
     // Various quanities that we'll set along the way if we need them.
     // At the end, if singleBin is true, then all these will be set correctly.
     double d1=-1., d2=-1., d3=-1., u=-1., v=-1.;
     if (BinTypeHelper<B>::template stop111<O>(d1sq, d2sq, d3sq, s1, s2, s3,
-                                              c1.getPos(), c2.getPos(), c3.getPos(), metric,
+                                              p1, p2, p3, metric,
                                               d1, d2, d3, u, v,
                                               _minsep, _minsepsq, _maxsep, _maxsepsq,
                                               _minu, _minusq, _maxu, _maxusq,
@@ -966,7 +978,9 @@ void BaseCorr3::process111Sorted(
 
     // Now check if these cells are small enough that it is ok to drop into a single bin.
     bool split1=false, split2=false, split3=false;
-    if (BinTypeHelper<B>::singleBin(d1sq, d2sq, d3sq, s1, s2, s3,
+    if (metric.isRParInsideRange(p1, p2, s1+s2, rpar2) &&
+        metric.isRParInsideRange(p1, p3, s1+s3, rpar3) &&
+        BinTypeHelper<B>::singleBin(d1sq, d2sq, d3sq, s1, s2, s3,
                                     _b, _a, _bu, _bv, _bsq, _asq, _busq, _bvsq,
                                     split1, split2, split3,
                                     d1, d2, d3, u, v))
@@ -997,6 +1011,17 @@ void BaseCorr3::process111Sorted(
     } else {
         xdbg<<"Need to split.\n";
 
+        if (P && !(split1 || split2 || split3)) {
+            // This can happen if the only reason to split is for rpar reasons.
+            // Then just split the one with the largest size
+            if (s2 > s3)
+                if (s2 > s1) split2 = true;
+                else split1 = true;
+            else
+                if (s3 > s1) split3 = true;
+                else split1 = true;
+        }
+        XAssert(split1 || split2 || split3);
         XAssert(split1 == false || s1 > 0);
         XAssert(split2 == false || s2 > 0);
         XAssert(split3 == false || s3 > 0);
@@ -1091,7 +1116,7 @@ void BaseCorr3::process111Sorted(
 // finish the calculation, coputing Zeta_n from G_n.
 //
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::multipole(const BaseField<C>& field, bool dots, bool quick)
 {
     dbg<<"Start multipole auto\n";
@@ -1102,7 +1127,7 @@ void BaseCorr3::multipole(const BaseField<C>& field, bool dots, bool quick)
     dbg<<"field has "<<n1<<" top level nodes\n";
     Assert(n1 > 0);
 
-    MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+    MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
     const std::vector<const BaseCell<C>*>& cells = field.getCells();
 
 #ifdef _OPENMP
@@ -1144,7 +1169,7 @@ void BaseCorr3::multipole(const BaseField<C>& field, bool dots, bool quick)
     if (dots) std::cout<<std::endl;
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::multipole(const BaseField<C>& field1, const BaseField<C>& field2, bool dots,
                           bool quick)
 {
@@ -1161,7 +1186,7 @@ void BaseCorr3::multipole(const BaseField<C>& field1, const BaseField<C>& field2
     Assert(n1 > 0);
     Assert(n2 > 0);
 
-    MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+    MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
 
     const std::vector<const BaseCell<C>*>& c1list = field1.getCells();
     const std::vector<const BaseCell<C>*>& c2list = field2.getCells();
@@ -1205,7 +1230,7 @@ void BaseCorr3::multipole(const BaseField<C>& field1, const BaseField<C>& field2
     if (dots) std::cout<<std::endl;
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::multipole(const BaseField<C>& field1, const BaseField<C>& field2,
                           const BaseField<C>& field3, bool dots, int ordered, bool quick)
 {
@@ -1225,7 +1250,7 @@ void BaseCorr3::multipole(const BaseField<C>& field1, const BaseField<C>& field2
     Assert(n2 > 0);
     Assert(n3 > 0);
 
-    MetricHelper<M,0> metric(0, 0, _xp, _yp, _zp);
+    MetricHelper<M,P> metric(_minrpar, _maxrpar, _xp, _yp, _zp);
 
     const std::vector<const BaseCell<C>*>& c1list = field1.getCells();
     const std::vector<const BaseCell<C>*>& c2list = field2.getCells();
@@ -1290,10 +1315,10 @@ std::unique_ptr<BaseMultipoleScratch> Corr3<D1,D2,D3>::getMP3(bool use_ww)
     return make_unique<MultipoleScratch<D3> >(_nbins, _nubins, use_ww, buffer);
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::splitC2Cells(
     const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-    const MetricHelper<M,0>& metric, std::vector<const BaseCell<C>*>& newc2list)
+    const MetricHelper<M,P>& metric, std::vector<const BaseCell<C>*>& newc2list)
 {
     // Given the current c1, make a new c2 list where we throw away any from c2 list
     // that can't contribute to the bins, and split any that need to be split.
@@ -1341,10 +1366,10 @@ void BaseCorr3::splitC2Cells(
     }
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::multipoleSplit1(
     const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-    const MetricHelper<M,0>& metric, bool quick, BaseMultipoleScratch& mp)
+    const MetricHelper<M,P>& metric, bool quick, BaseMultipoleScratch& mp)
 {
     xdbg<<ws()<<"MultipoleSplit1: c1 = "<<c1.getPos()<<"  "<<c1.getSize()<<"  "<<c1.getW()<<"  len c2 = "<<c2list.size()<<std::endl;
 
@@ -1376,12 +1401,12 @@ void BaseCorr3::multipoleSplit1(
     dec_ws();
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 void BaseCorr3::multipoleSplit1(
     const BaseCell<C>& c1,
     const std::vector<const BaseCell<C>*>& c2list,
     const std::vector<const BaseCell<C>*>& c3list,
-    const MetricHelper<M,0>& metric, int ordered, bool quick,
+    const MetricHelper<M,P>& metric, int ordered, bool quick,
     BaseMultipoleScratch& mp2, BaseMultipoleScratch& mp3)
 {
     xdbg<<ws()<<"MultipoleSplit1: c1 = "<<c1.getPos()<<"  "<<c1.getSize()<<"  "<<c1.getW()<<"  len c2 = "<<c2list.size()<<" len c3 = "<<c3list.size()<<std::endl;
@@ -1417,10 +1442,10 @@ void BaseCorr3::multipoleSplit1(
     dec_ws();
 }
 
-template <int B, int M, int C>
+template <int B, int M, int P, int C>
 double BaseCorr3::splitC2CellsOrCalculateGn(
     const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-    const MetricHelper<M,0>& metric, std::vector<const BaseCell<C>*>& newc2list, bool& anysplit1,
+    const MetricHelper<M,P>& metric, std::vector<const BaseCell<C>*>& newc2list, bool& anysplit1,
     BaseMultipoleScratch& mp, double prev_max_remaining_r)
 {
     // Similar to splitC2Cells, but this time, check to see if any cells are small enough that
@@ -1513,10 +1538,10 @@ double BaseCorr3::splitC2CellsOrCalculateGn(
     return max_remaining_r;
 }
 
-template <int B, int Q, int M, int C>
+template <int B, int Q, int M, int P, int C>
 void BaseCorr3::multipoleFinish(
     const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-    const MetricHelper<M,0>& metric, BaseMultipoleScratch& mp, int mink_zeta, double maxr)
+    const MetricHelper<M,P>& metric, BaseMultipoleScratch& mp, int mink_zeta, double maxr)
 {
     // This is structured a lot like the previous function.
     // However, in this one, we will actually be filling the Gn array.
@@ -1579,10 +1604,10 @@ void BaseCorr3::multipoleFinish(
     }
 }
 
-template <int B, int Q, int M, int C>
+template <int B, int Q, int M, int P, int C>
 void BaseCorr3::multipoleFinish(
     const BaseCell<C>& c1, const std::vector<const BaseCell<C>*>& c2list,
-    const std::vector<const BaseCell<C>*>& c3list, const MetricHelper<M,0>& metric, int ordered,
+    const std::vector<const BaseCell<C>*>& c3list, const MetricHelper<M,P>& metric, int ordered,
     BaseMultipoleScratch& mp2, BaseMultipoleScratch& mp3, int mink_zeta,
     double maxr2, double maxr3)
 {
@@ -3562,7 +3587,7 @@ Corr3<D1,D2,D3>* BuildCorr3(
     BinType bin_type, double minsep, double maxsep, int nbins, double binsize, double b, double a,
     double minu, double maxu, int nubins, double ubinsize, double bu,
     double minv, double maxv, int nvbins, double vbinsize, double bv,
-    double xp, double yp, double zp,
+    double minrpar, double maxrpar, double xp, double yp, double zp,
     py::array_t<double>& zeta0p, py::array_t<double>& zeta1p,
     py::array_t<double>& zeta2p, py::array_t<double>& zeta3p,
     py::array_t<double>& zeta4p, py::array_t<double>& zeta5p,
@@ -3598,7 +3623,8 @@ Corr3<D1,D2,D3>* BuildCorr3(
 
     return new Corr3<D1,D2,D3>(
             bin_type, minsep, maxsep, nbins, binsize, b, a,
-            minu, maxu, nubins, ubinsize, bu, minv, maxv, nvbins, vbinsize, bv, xp, yp, zp,
+            minu, maxu, nubins, ubinsize, bu, minv, maxv, nvbins, vbinsize, bv,
+            minrpar, maxrpar, xp, yp, zp,
             zeta0, zeta1, zeta2, zeta3, zeta4, zeta5, zeta6, zeta7,
             meand1, meanlogd1, meand2, meanlogd2, meand3, meanlogd3,
             meanu, meanv, weight, weight_im, ntri);
@@ -3611,19 +3637,33 @@ template <int B>
 struct ValidMPB
 { enum { _B = Log }; };
 
-template <int B, int M, int C>
-void ProcessAutob(BaseCorr3& corr, BaseField<C>& field, bool dots, bool quick)
+template <int B, int M, int P, int C>
+void ProcessAutoc(BaseCorr3& corr, BaseField<C>& field, bool dots, bool quick)
 {
-    Assert((ValidMC<M,C>::_M == M));
+    const int _M = ValidMC<M,C>::_M;
+    Assert(_M == M);
 #ifndef DIRECT_MULTIPOLE
     if (B == LogMultipole) {
-        corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(field, dots, quick);
+        const int _B = ValidMPB<B>::_B;
+        corr.template multipole<_B,_M,P>(field, dots, quick);
     } else {
 #endif
-        corr.template process3<B,ValidMC<M,C>::_M>(field, dots, quick);
+        corr.template process3<B,_M,P>(field, dots, quick);
 #ifndef DIRECT_MULTIPOLE
     }
 #endif
+}
+
+template <int B, int M, int C>
+void ProcessAutob(BaseCorr3& corr, BaseField<C>& field, bool dots, bool quick)
+{
+    const bool P = corr.nontrivialRPar();
+    if (P) {
+        Assert(C == ThreeD);
+        ProcessAutoc<B,M,(C==ThreeD)>(corr, field, dots, quick);
+    } else {
+        ProcessAutoc<B,M,false>(corr, field, dots, quick);
+    }
 }
 
 template <int B, int C>
@@ -3673,21 +3713,23 @@ void ProcessAuto(BaseCorr3& corr, BaseField<C>& field,
     }
 }
 
-template <int B, int M, int C>
-void ProcessCross12b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
+template <int B, int M, int P, int C>
+void ProcessCross12c(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
                      int ordered, bool dots, bool quick)
 {
     Assert(ordered == 0 || ordered == 1);
-    Assert((ValidMC<M,C>::_M == M));
+    const int _M = ValidMC<M,C>::_M;
+    Assert(_M == M);
 #ifndef DIRECT_MULTIPOLE
     if (B == LogMultipole) {
+        const int _B = ValidMPB<B>::_B;
         switch(ordered) {
           case 0:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field2, field1, field2, dots, 1, quick);
                // Drop through.
           case 1:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field2, dots, quick);
                break;
           default:
@@ -3697,10 +3739,10 @@ void ProcessCross12b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2
 #endif
         switch(ordered) {
           case 0:
-               corr.template process12<B,0,ValidMC<M,C>::_M>(field1, field2, dots, quick);
+               corr.template process12<B,0,_M,P>(field1, field2, dots, quick);
                break;
           case 1:
-               corr.template process12<B,1,ValidMC<M,C>::_M>(field1, field2, dots, quick);
+               corr.template process12<B,1,_M,P>(field1, field2, dots, quick);
                break;
           default:
                Assert(false);
@@ -3708,6 +3750,19 @@ void ProcessCross12b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2
 #ifndef DIRECT_MULTIPOLE
     }
 #endif
+}
+
+template <int B, int M, int C>
+void ProcessCross12b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
+                     int ordered, bool dots, bool quick)
+{
+    const bool P = corr.nontrivialRPar();
+    if (P) {
+        Assert(C == ThreeD);
+        ProcessCross12c<B,M,(C==ThreeD)>(corr, field1, field2, ordered, dots, quick);
+    } else {
+        ProcessCross12c<B,M,false>(corr, field1, field2, ordered, dots, quick);
+    }
 }
 
 template <int B, int C>
@@ -3758,25 +3813,27 @@ void ProcessCross12(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
     }
 }
 
-template <int B, int M, int C>
-void ProcessCross21b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
+template <int B, int M, int P, int C>
+void ProcessCross21c(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
                      int ordered, bool dots, bool quick)
 {
     Assert(ordered == 0 || ordered == 3);
-    Assert((ValidMC<M,C>::_M == M));
+    const int _M = ValidMC<M,C>::_M;
+    Assert(_M == M);
 #ifndef DIRECT_MULTIPOLE
     if (B == LogMultipole) {
+        const int _B = ValidMPB<B>::_B;
         switch(ordered) {
           case 0:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field2, field1, field1, dots, 1, quick);
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field2, field1, dots, 1, quick);
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field1, field2, dots, 1, quick);
                break;
           case 3:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field1, field2, dots, 4, quick);
                break;
           default:
@@ -3786,13 +3843,13 @@ void ProcessCross21b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2
 #endif
         switch(ordered) {
           case 0:
-               corr.template process21<B,0,ValidMC<M,C>::_M>(field1, field2, dots, quick);
+               corr.template process21<B,0,_M,P>(field1, field2, dots, quick);
                break;
           case 3:
-               corr.template process21<B,3,ValidMC<M,C>::_M>(field1, field2, dots, quick);
+               corr.template process21<B,3,_M,P>(field1, field2, dots, quick);
                break;
           case 4:
-               corr.template process21<B,4,ValidMC<M,C>::_M>(field1, field2, dots, quick);
+               corr.template process21<B,4,_M,P>(field1, field2, dots, quick);
                break;
           default:
                Assert(false);
@@ -3800,6 +3857,19 @@ void ProcessCross21b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2
 #ifndef DIRECT_MULTIPOLE
     }
 #endif
+}
+
+template <int B, int M, int C>
+void ProcessCross21b(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
+                     int ordered, bool dots, bool quick)
+{
+    const bool P = corr.nontrivialRPar();
+    if (P) {
+        Assert(C == ThreeD);
+        ProcessCross21c<B,M,(C==ThreeD)>(corr, field1, field2, ordered, dots, quick);
+    } else {
+        ProcessCross21c<B,M,false>(corr, field1, field2, ordered, dots, quick);
+    }
 }
 
 template <int B, int C>
@@ -3850,40 +3920,42 @@ void ProcessCross21(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2,
     }
 }
 
-template <int B, int M, int C>
-void ProcessCrossb(BaseCorr3& corr,
+template <int B, int M, int P, int C>
+void ProcessCrossc(BaseCorr3& corr,
                    BaseField<C>& field1, BaseField<C>& field2, BaseField<C>& field3,
                    int ordered, bool dots, bool quick)
 {
     Assert(ordered >= 0 && ordered <= 4);
-    Assert((ValidMC<M,C>::_M == M));
+    const int _M = ValidMC<M,C>::_M;
+    Assert(_M == M);
 #ifndef DIRECT_MULTIPOLE
     if (B == LogMultipole) {
+        const int _B = ValidMPB<B>::_B;
         switch(ordered) {
           case 0:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field2, field1, field3, dots, 1, quick);
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field3, field1, field2, dots, 1, quick);
                // Drop through.
           case 1:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field2, field3, dots, 1, quick);
                break;
           case 2:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field2, field3, dots, 4, quick);
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field3, field2, field1, dots, 4, quick);
                break;
           case 3:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field2, field3, dots, 4, quick);
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field2, field1, field3, dots, 4, quick);
                break;
           case 4:
-               corr.template multipole<ValidMPB<B>::_B,ValidMC<M,C>::_M>(
+               corr.template multipole<_B,_M,P>(
                    field1, field2, field3, dots, 4, quick);
                break;
           default:
@@ -3893,19 +3965,19 @@ void ProcessCrossb(BaseCorr3& corr,
 #endif
         switch(ordered) {
           case 0:
-               corr.template process111<B,0,ValidMC<M,C>::_M>(field1, field2, field3, dots, quick);
+               corr.template process111<B,0,_M,P>(field1, field2, field3, dots, quick);
                break;
           case 1:
-               corr.template process111<B,1,ValidMC<M,C>::_M>(field1, field2, field3, dots, quick);
+               corr.template process111<B,1,_M,P>(field1, field2, field3, dots, quick);
                break;
           case 2:
-               corr.template process111<B,2,ValidMC<M,C>::_M>(field1, field2, field3, dots, quick);
+               corr.template process111<B,2,_M,P>(field1, field2, field3, dots, quick);
                break;
           case 3:
-               corr.template process111<B,3,ValidMC<M,C>::_M>(field1, field2, field3, dots, quick);
+               corr.template process111<B,3,_M,P>(field1, field2, field3, dots, quick);
                break;
           case 4:
-               corr.template process111<B,4,ValidMC<M,C>::_M>(field1, field2, field3, dots, quick);
+               corr.template process111<B,4,_M,P>(field1, field2, field3, dots, quick);
                break;
           default:
                Assert(false);
@@ -3913,6 +3985,20 @@ void ProcessCrossb(BaseCorr3& corr,
 #ifndef DIRECT_MULTIPOLE
     }
 #endif
+}
+
+template <int B, int M, int C>
+void ProcessCrossb(BaseCorr3& corr,
+                   BaseField<C>& field1, BaseField<C>& field2, BaseField<C>& field3,
+                   int ordered, bool dots, bool quick)
+{
+    const bool P = corr.nontrivialRPar();
+    if (P) {
+        Assert(C == ThreeD);
+        ProcessCrossc<B,M,(C==ThreeD)>(corr, field1, field2, field3, ordered, dots, quick);
+    } else {
+        ProcessCrossc<B,M,false>(corr, field1, field2, field3, ordered, dots, quick);
+    }
 }
 
 template <int B, int C>
@@ -4109,7 +4195,7 @@ void WrapCorr3(py::module& _treecorr, std::string prefix)
         double b, double a,
         double minu, double maxu, int nubins, double ubinsize, double bu,
         double minv, double maxv, int nvbins, double vbinsize, double bv,
-        double xp, double yp, double zp,
+        double minrpar, double maxrpar, double xp, double yp, double zp,
         py::array_t<double>& zeta0p, py::array_t<double>& zeta1p,
         py::array_t<double>& zeta2p, py::array_t<double>& zeta3p,
         py::array_t<double>& zeta4p, py::array_t<double>& zeta5p,

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -773,13 +773,7 @@ void BaseCorr3::process111(
     }
 
     // Calculate the distances if they aren't known yet
-    double s=0.;
-    if (d1sq == 0.)
-        d1sq = metric.DistSq(c2.getPos(), c3.getPos(), s, s);
-    if (d2sq == 0.)
-        d2sq = metric.DistSq(c1.getPos(), c3.getPos(), s, s);
-    if (d3sq == 0.)
-        d3sq = metric.DistSq(c1.getPos(), c2.getPos(), s, s);
+    metric.TripleDistSq(c1.getPos(), c2.getPos(), c3.getPos(), d1sq, d2sq, d3sq);
 
     inc_ws();
     if (O == 0) {
@@ -3614,6 +3608,15 @@ void ProcessAutoa(BaseCorr3& corr, BaseField<C>& field, bool dots, bool quick, M
       case Euclidean:
            ProcessAutob<B,Euclidean>(corr, field, dots, quick);
            break;
+      case Rperp:
+           ProcessAutob<B,Rperp>(corr, field, dots, quick);
+           break;
+      case OldRperp:
+           ProcessAutob<B,OldRperp>(corr, field, dots, quick);
+           break;
+      case Rlens:
+           ProcessAutob<B,Rlens>(corr, field, dots, quick);
+           break;
       case Arc:
            ProcessAutob<B,Arc>(corr, field, dots, quick);
            break;
@@ -3689,6 +3692,15 @@ void ProcessCross12a(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2
     switch(metric) {
       case Euclidean:
            ProcessCross12b<B,Euclidean>(corr, field1, field2, ordered, dots, quick);
+           break;
+      case Rperp:
+           ProcessCross12b<B,Rperp>(corr, field1, field2, ordered, dots, quick);
+           break;
+      case OldRperp:
+           ProcessCross12b<B,OldRperp>(corr, field1, field2, ordered, dots, quick);
+           break;
+      case Rlens:
+           ProcessCross12b<B,Rlens>(corr, field1, field2, ordered, dots, quick);
            break;
       case Arc:
            ProcessCross12b<B,Arc>(corr, field1, field2, ordered, dots, quick);
@@ -3772,6 +3784,15 @@ void ProcessCross21a(BaseCorr3& corr, BaseField<C>& field1, BaseField<C>& field2
     switch(metric) {
       case Euclidean:
            ProcessCross21b<B,Euclidean>(corr, field1, field2, ordered, dots, quick);
+           break;
+      case Rperp:
+           ProcessCross21b<B,Rperp>(corr, field1, field2, ordered, dots, quick);
+           break;
+      case OldRperp:
+           ProcessCross21b<B,OldRperp>(corr, field1, field2, ordered, dots, quick);
+           break;
+      case Rlens:
+           ProcessCross21b<B,Rlens>(corr, field1, field2, ordered, dots, quick);
            break;
       case Arc:
            ProcessCross21b<B,Arc>(corr, field1, field2, ordered, dots, quick);
@@ -3877,6 +3898,15 @@ void ProcessCrossa(BaseCorr3& corr,
     switch(metric) {
       case Euclidean:
            ProcessCrossb<B,Euclidean>(corr, field1, field2, field3, ordered, dots, quick);
+           break;
+      case Rperp:
+           ProcessCrossb<B,Rperp>(corr, field1, field2, field3, ordered, dots, quick);
+           break;
+      case OldRperp:
+           ProcessCrossb<B,OldRperp>(corr, field1, field2, field3, ordered, dots, quick);
+           break;
+      case Rlens:
+           ProcessCrossb<B,Rlens>(corr, field1, field2, field3, ordered, dots, quick);
            break;
       case Arc:
            ProcessCrossb<B,Arc>(corr, field1, field2, field3, ordered, dots, quick);

--- a/src/Corr3.cpp
+++ b/src/Corr3.cpp
@@ -935,7 +935,7 @@ void BaseCorr3::process111Sorted(
     // At the end, if singleBin is true, then all these will be set correctly.
     double d1=-1., d2=-1., d3=-1., u=-1., v=-1.;
     if (BinTypeHelper<B>::template stop111<O>(d1sq, d2sq, d3sq, s1, s2, s3,
-                                              c1, c2, c3, metric,
+                                              c1.getPos(), c2.getPos(), c3.getPos(), metric,
                                               d1, d2, d3, u, v,
                                               _minsep, _minsepsq, _maxsep, _maxsepsq,
                                               _minu, _minusq, _maxu, _maxusq,
@@ -963,7 +963,7 @@ void BaseCorr3::process111Sorted(
         double logd1, logd2, logd3;
         int index;
         if (BinTypeHelper<B>::template isTriangleInRange<O>(
-                c1, c2, c3, metric,
+                c1.getPos(), c2.getPos(), c3.getPos(), metric,
                 d1sq, d2sq, d3sq, d1, d2, d3, u, v,
                 _logminsep, _minsep, _maxsep, _binsize, _nbins,
                 _minu, _maxu, _ubinsize, _nubins,

--- a/tests/configs/ggg_rperp.yaml
+++ b/tests/configs/ggg_rperp.yaml
@@ -1,0 +1,22 @@
+
+file_name: data/ggg_rperp_lens.dat
+file_name2: data/ggg_rperp_source.dat
+
+x_col: 1
+y_col: 2
+z_col: 3
+
+g1_col: 4
+g2_col: 5
+
+bin_size: 0.1
+min_sep: 15
+max_sep: 20
+min_phi: 0.5
+max_phi: 1.5
+nphi_bins: 10
+max_n: 30
+
+metric: Rperp
+
+ggg_file_name: output/ggg_rperp.out

--- a/tests/configs/ngg_rlens.yaml
+++ b/tests/configs/ngg_rlens.yaml
@@ -1,0 +1,23 @@
+
+file_name: data/ngg_rlens_lens.dat
+file_name2: data/ngg_rlens_source.dat
+
+x_col: 1
+y_col: 2
+z_col: 3
+
+g1_col: [0,4]
+g2_col: [0,5]
+
+verbose: 1
+
+min_sep: 12.
+max_sep: 16.
+bin_size: 0.2
+min_phi: 0.5
+max_phi: 2.5
+nphi_bins: 20
+
+metric: Rlens
+
+ngg_file_name: output/ngg_rlens.out

--- a/tests/configs/ngg_rlens_bkg.yaml
+++ b/tests/configs/ngg_rlens_bkg.yaml
@@ -1,0 +1,24 @@
+
+file_name: data/ngg_rlens_bkg_lens.dat
+file_name2: data/ngg_rlens_bkg_source.dat
+
+x_col: 1
+y_col: 2
+z_col: 3
+
+g1_col: [0,4]
+g2_col: [0,5]
+
+verbose: 1
+
+min_sep: 12.
+max_sep: 16.
+bin_size: 0.2
+min_phi: 0.5
+max_phi: 2.5
+nphi_bins: 20
+
+metric: Rlens
+min_rpar: 0
+
+ngg_file_name: output/ngg_rlens_bkg.out

--- a/tests/test_ngg.py
+++ b/tests/test_ngg.py
@@ -3969,6 +3969,33 @@ def test_ngg_rlens_bkg():
     assert np.max(np.abs(ngg4.gam0 - true_gam0)) > 2.e-4
     assert np.max(np.abs(ngg4.gam2 - true_gam2)) > 2.e-4
 
+    # Can't have max_rpar < min_rpar
+    with assert_raises(ValueError):
+        treecorr.NGGCorrelation(bin_size=bin_size, min_sep=min_sep, max_sep=max_sep,
+                                min_phi=min_phi, max_phi=max_phi, nphi_bins=nphi_bins,
+                                metric='Rlens', min_rpar=10, max_rpar=0)
+
+    # Can't use min/max rpar with non-3d coords
+    ral, decl = coord.CelestialCoord.xyz_to_radec(xl,yl,zl)
+    ras, decs = coord.CelestialCoord.xyz_to_radec(xs,ys,zs)
+    lens_cat_sph = treecorr.Catalog(ra=ral, dec=decl, ra_units='radians', dec_units='radians', r=rl)
+    source_cat_sph = treecorr.Catalog(ra=ras, dec=decs, ra_units='radians', dec_units='radians',
+                                      g1=g1, g2=g2)
+    with assert_raises(ValueError):
+        ngg.process(lens_cat_sph, source_cat_sph)
+    ngg5 = treecorr.NGGCorrelation(bin_size=bin_size, min_sep=min_sep, max_sep=max_sep,
+                                   min_phi=min_phi, max_phi=max_phi, nphi_bins=nphi_bins,
+                                   metric='Rlens', max_rpar=0)
+    with assert_raises(ValueError):
+        ngg5.process(lens_cat_sph, source_cat_sph)
+
+    # sep units invalid with normal 3d coords (non-Arc metric)
+    ngg6 = treecorr.NGGCorrelation(bin_size=bin_size, min_sep=min_sep, max_sep=max_sep,
+                                   min_phi=min_phi, max_phi=max_phi, nphi_bins=nphi_bins,
+                                   metric='Rlens', min_rpar=0, sep_units='arcmin')
+    with assert_raises(ValueError):
+        ngg6.process(lens_cat, source_cat)
+
 
 if __name__ == '__main__':
     test_direct_logruv_cross()

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -74,7 +74,9 @@ class Corr2(object):
     are appropriate for different use cases.  These are specified by the ``metric`` parameter.
     The possible options are:
 
-        - 'Euclidean' = straight line Euclidean distance between two points.
+        - 'Euclidean' = straight line Euclidean distance between two points.  For spherical
+          coordinates (ra,dec without r), this is the chord distance between points on the
+          unit sphere.
         - 'FisherRperp' = the perpendicular component of the distance, following the
           definitions in Fisher et al, 1994 (MNRAS, 267, 927).
         - 'OldRperp' = the perpendicular component of the distance using the definition

--- a/treecorr/corr2base.py
+++ b/treecorr/corr2base.py
@@ -1531,7 +1531,7 @@ class Corr2(object):
         if metric is None:
             metric = get(self.config,'metric',str,'Euclidean')
         coords, metric = parse_metric(metric, coords1, coords2)
-        if coords != '3d':
+        if coords1 != '3d' or coords2 not in [None,'3d']:
             if self.min_rpar != -sys.float_info.max:
                 raise ValueError("min_rpar is only valid for 3d coordinates")
             if self.max_rpar != sys.float_info.max:

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -113,12 +113,22 @@ class Corr3(object):
     use one or if you want to change some parameters from what are in a config dict,
     then you can use normal kwargs, which take precedence over anything in the config dict.
 
-    There are three implemented definitions for the ``metric``, which defines how to calculate
-    the distance between two points, for three-point corretions:
+    There are a number of possible definitions for the distance between two points, which
+    are appropriate for different use cases.  These are specified by the ``metric`` parameter.
+    The possible options are:
 
         - 'Euclidean' = straight line Euclidean distance between two points.  For spherical
           coordinates (ra,dec without r), this is the chord distance between points on the
           unit sphere.
+        - 'FisherRperp' = the perpendicular component of the distance, following the
+          definitions in Fisher et al, 1994 (MNRAS, 267, 927).
+        - 'OldRperp' = the perpendicular component of the distance using the definition
+          of Rperp from TreeCorr v3.x.
+        - 'Rperp' = an alias for FisherRperp.  You can change it to be an alias for
+          OldRperp if you want by setting ``treecorr.Rperp_alias = 'OldRperp'`` before
+          using it.
+        - 'Rlens' = the distance from the first object (taken to be a lens) to the line
+          connecting Earth and the second object (taken to be a lensed source).
         - 'Arc' = the true great circle distance for spherical coordinates.
         - 'Periodic' = Like Euclidean, but with periodic boundaries.
 
@@ -128,6 +138,8 @@ class Corr3(object):
             side length d > period/2, which means for the SSS triangle definition, max_sep
             (the maximum d2) should be less than period/4, and for SAS, max_sep should be less
             than period/2.  This is not enforced.
+
+    See `Metrics` for more information about these various metric options.
 
     There are three allowed value for the ``bin_type`` for three-point correlations.
 
@@ -463,7 +475,8 @@ class Corr3(object):
                 'The maximum number of top layers to use when setting up the field.'),
         'precision' : (int, False, 4, None,
                 'The number of digits after the decimal in the output.'),
-        'metric': (str, False, 'Euclidean', ['Euclidean', 'Arc', 'Periodic'],
+        'metric': (str, False, 'Euclidean', ['Euclidean', 'Rperp', 'FisherRperp', 'OldRperp',
+                                             'Rlens', 'Arc', 'Periodic'],
                 'Which metric to use for the distance measurements'),
         'bin_type': (str, False, 'LogSAS', ['LogRUV', 'LogSAS', 'LogMultipole'],
                 'Which type of binning should be used'),

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -2827,8 +2827,7 @@ class Corr3(object):
     def _zero_array(self):
         # An array of all zeros with the same shape as the data arrays
         z = np.zeros(self.data_shape)
-        # XXX
-        #z.flags.writeable=False  # Just to make sure we get an error if we try to change it.
+        z.flags.writeable=False  # Just to make sure we get an error if we try to change it.
         return z
 
     def _apply_units(self, mask):

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -2834,7 +2834,7 @@ class Corr3(object):
         if metric is None:
             metric = get(self.config,'metric',str,'Euclidean')
         coords, metric = parse_metric(metric, coords1, coords2, coords3)
-        if coords != '3d':
+        if any(c not in ['3d',None] for c in [coords1, coords2, coords3]):
             if self.min_rpar != -sys.float_info.max:
                 raise ValueError("min_rpar is only valid for 3d coordinates")
             if self.max_rpar != sys.float_info.max:

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -1249,16 +1249,13 @@ class Corr3(object):
         # No op for all but NNCorrelation, which needs to add the tot value
         pass
 
-    def _trivially_zero(self, c1, c2, c3):
-        # For now, ignore the metric.  Just be conservative about how much space we need.
+    def _trivially_zero(self, c1, c2, c3, ordered):
         x1,y1,z1,s1 = c1._get_center_size()
         x2,y2,z2,s2 = c2._get_center_size()
         x3,y3,z3,s3 = c3._get_center_size()
-        d3 = ((x1-x2)**2 + (y1-y2)**2 + (z1-z2)**2)**0.5
-        d1 = ((x2-x3)**2 + (y2-y3)**2 + (z2-z3)**2)**0.5
-        d2 = ((x3-x1)**2 + (y3-y1)**2 + (z3-z1)**2)**0.5
-        d3, d2, d1 = sorted([d1,d2,d3])
-        return (d2 > s1 + s2 + s3 + 2*self._max_sep)  # The 2* is where we are being conservative.
+        return self.corr.triviallyZero(self._metric, self._coords,
+                                       x1, y1, z1, s1, x2, y2, z2, s2, x3, y3, z3, s3,
+                                       ordered, (c2 is c3 or c1 is c2))
 
     _make_expanded_patch = Corr2._make_expanded_patch
 
@@ -1267,7 +1264,7 @@ class Corr3(object):
         # Helper function for _process_all_auto, etc. for doing 12 cross pairs
         temp._clear()
 
-        if c2 is not None and not self._trivially_zero(c1,c2,c2):
+        if c2 is not None and not self._trivially_zero(c1,c2,c2,ordered):
             self.logger.info('Process patches %s cross12',ijj)
             temp.process_cross12(c1, c2, metric=metric, ordered=ordered, num_threads=num_threads,
                                  corr_only=corr_only)
@@ -1289,7 +1286,7 @@ class Corr3(object):
         # Helper function for _process_all_cross21, etc. for doing 21 cross pairs
         temp._clear()
 
-        if c1 is not None and not self._trivially_zero(c1,c1,c2):
+        if c1 is not None and not self._trivially_zero(c1,c1,c2,ordered):
             self.logger.info('Process patches %s cross21',iij)
             temp.process_cross21(c1, c2, metric=metric, ordered=ordered, num_threads=num_threads,
                                  corr_only=corr_only)
@@ -1311,7 +1308,7 @@ class Corr3(object):
         # Helper function for _process_all_auto, etc. for doing 123 cross triples
         temp._clear()
 
-        if c2 is not None and c3 is not None and not self._trivially_zero(c1,c2,c3):
+        if c2 is not None and c3 is not None and not self._trivially_zero(c1,c2,c3,ordered):
             self.logger.info('Process patches %s cross',ijk)
             temp.process_cross(c1, c2, c3, metric=metric, ordered=ordered, num_threads=num_threads,
                                corr_only=corr_only)

--- a/treecorr/corr3base.py
+++ b/treecorr/corr3base.py
@@ -128,7 +128,7 @@ class Corr3(object):
           OldRperp if you want by setting ``treecorr.Rperp_alias = 'OldRperp'`` before
           using it.
         - 'Rlens' = the distance from the first object (taken to be a lens) to the line
-          connecting Earth and the second object (taken to be a lensed source).
+          connecting Earth and each of the other two objects (taken to be lensed sources).
         - 'Arc' = the true great circle distance for spherical coordinates.
         - 'Periodic' = Like Euclidean, but with periodic boundaries.
 

--- a/treecorr/util.py
+++ b/treecorr/util.py
@@ -358,7 +358,7 @@ def metric_enum(metric):
         return metric_enum(Rperp_alias)
     elif metric == 'FisherRperp':
         return _treecorr.Rperp
-    elif metric in ['OldRperp']:
+    elif metric == 'OldRperp':
         return _treecorr.OldRperp
     elif metric == 'Rlens':
         return _treecorr.Rlens


### PR DESCRIPTION
So far 3pt functions have been limited to Euclidean, Periodic and Arc metrics.  Now that we have the option to do NGG, etc., it makes sense to allow Rlens for 3pt functions.  As for the 2pt version, the "lens" is taken to be the first field given in the `process` command.  And the sources are the other two points.

For Rperp, I think the thing that makes the most sense is to have a single perpendicular projected plane for all all three points (rather than have each pair define their own perpendicular direction).  So we define the mean of the three radial vectors as the parallel direction.  Then the projected plane is perpendicular to that.

The min_rpar and max_rpar options, if given, are defined relative to point 1 (the "lens" for Rlens metric).  This was the easiest to implement, and I think it makes sense for most applications.  It's now enabled for all metrics for 3pt functions as we have for 2pt.